### PR TITLE
fix: correct vote timing and block production per devnet0 spec

### DIFF
--- a/forkchoice/lmdghost.go
+++ b/forkchoice/lmdghost.go
@@ -55,18 +55,22 @@ func GetHead(blocks map[types.Root]*types.Block, root types.Root, latestVotes ma
 			return current
 		}
 
-		// Choose best child: most votes, then lexicographically highest hash
+		// Choose best child: most votes, then highest slot, then highest hash
 		best := children[0]
 		bestWeight := voteWeights[best]
+		bestSlot := blocks[best].Slot
 
 		for _, child := range children[1:] {
 			weight := voteWeights[child]
+			childSlot := blocks[child].Slot
 
-			// Tie-break: most votes, then lexicographically highest hash
+			// Tie-break: most votes, then highest slot, then lexicographically highest hash
 			if weight > bestWeight ||
-				(weight == bestWeight && compareRoots(child, best) > 0) {
+				(weight == bestWeight && childSlot > bestSlot) ||
+				(weight == bestWeight && childSlot == bestSlot && compareRoots(child, best) > 0) {
 				best = child
 				bestWeight = weight
+				bestSlot = childSlot
 			}
 		}
 

--- a/p2p/config.go
+++ b/p2p/config.go
@@ -1,8 +1,8 @@
 // Package p2p implements networking for the Lean Ethereum consensus protocol.
 package p2p
 
-// Gossipsub topic names (Devnet 0)
+// Gossipsub topic names (Devnet 0, per networking spec)
 const (
-	TopicBlocks       = "/leanconsensus/devnet0/block/ssz_snappy"
-	TopicAttestations = "/leanconsensus/devnet0/attestation/ssz_snappy"
+	TopicBlocks = "/leanconsensus/devnet0/block/ssz_snappy"
+	TopicVotes  = "/leanconsensus/devnet0/vote/ssz_snappy"
 )

--- a/p2p/pubsub.go
+++ b/p2p/pubsub.go
@@ -17,10 +17,10 @@ const (
 	NetworkName = "devnet0"
 )
 
-// Topic names
+// Topic names (per networking spec: block and vote)
 var (
-	BlockTopic       = "/leanconsensus/" + NetworkName + "/block/ssz_snappy"
-	AttestationTopic = "/leanconsensus/" + NetworkName + "/attestation/ssz_snappy"
+	BlockTopic = "/leanconsensus/" + NetworkName + "/block/ssz_snappy"
+	VoteTopic  = "/leanconsensus/" + NetworkName + "/vote/ssz_snappy"
 )
 
 // NewGossipSub creates a new gossipsub instance with lean consensus parameters.


### PR DESCRIPTION
This PR fixes 4 issues found during leanSpec Devnet 0 compliance verification:                  
                                                                                                       
   1. Vote Production Timing (node/node.go)                                                            
      - Changed from interval 2 to interval 1                                                          
      - Per spec: "at the start of second interval(=1)"                                                
                                                                                                       
   2. Block Production (node/node.go)                                                                  
      - Now uses Store.ProduceBlock() which iteratively collects attestations                          
      - Previously created empty blocks                                                                
                                                                                                       
   3. Topic Name (p2p/*.go)                                                                            
      - Changed from "attestation" to "vote" per networking spec                                       
      - Topic: /leanconsensus/devnet0/vote/ssz_snappy                                                  
      - Renamed AttestationHandler -> VoteHandler, etc.                                                
                                                                                                       
   4. LMD-GHOST Tiebreaker (forkchoice/lmdghost.go)                                                    
      - Added slot to tiebreaker: max(weight, slot, hash)                                              
      - Previously only used max(weight, hash)                                                         
                                                     