### PR TITLE
fix(test): share XMSS keypair across leansig tests

### DIFF
--- a/xmss/leansig/leansig_test.go
+++ b/xmss/leansig/leansig_test.go
@@ -2,6 +2,8 @@ package leansig_test
 
 import (
 	"crypto/rand"
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/geanlabs/gean/xmss/leansig"
@@ -13,34 +15,36 @@ import (
 const testLsigActivationEpoch = 0
 const testLsigNumActiveEpochs = 262144 // 2^18, matching devnet-1 spec
 
+// Shared keypair generated once in TestMain to avoid redundant ~80s keygen per test.
+var sharedKP *leansig.Keypair
+
+func TestMain(m *testing.M) {
+	var err error
+	sharedKP, err = leansig.GenerateKeypair(42, testLsigActivationEpoch, testLsigNumActiveEpochs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "TestMain: GenerateKeypair failed: %v\n", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	sharedKP.Free()
+	os.Exit(code)
+}
+
 // TestKeyGeneration verifies that keypair generation succeeds and returns
 // valid activation and prepared intervals.
 func TestKeyGeneration(t *testing.T) {
-	kp, err := leansig.GenerateKeypair(42, testLsigActivationEpoch, testLsigNumActiveEpochs)
-	if err != nil {
-		t.Fatalf("GenerateKeypair failed: %v", err)
-	}
-	defer kp.Free()
-
-	t.Logf("Activation interval: [%d, %d)", kp.ActivationStart(), kp.ActivationEnd())
-	t.Logf("Prepared interval: [%d, %d)", kp.PreparedStart(), kp.PreparedEnd())
-
-	if kp.ActivationEnd() <= kp.ActivationStart() {
+	if sharedKP.ActivationEnd() <= sharedKP.ActivationStart() {
 		t.Errorf("activation interval is empty or invalid")
 	}
-	if kp.PreparedEnd() <= kp.PreparedStart() {
+	if sharedKP.PreparedEnd() <= sharedKP.PreparedStart() {
 		t.Errorf("prepared interval is empty or invalid")
 	}
+	t.Logf("Activation interval: [%d, %d)", sharedKP.ActivationStart(), sharedKP.ActivationEnd())
+	t.Logf("Prepared interval: [%d, %d)", sharedKP.PreparedStart(), sharedKP.PreparedEnd())
 }
 
 func TestKeySerializationRoundtrip(t *testing.T) {
-	kp, err := leansig.GenerateKeypair(42, testLsigActivationEpoch, testLsigNumActiveEpochs)
-	if err != nil {
-		t.Fatalf("GenerateKeypair failed: %v", err)
-	}
-	defer kp.Free()
-
-	pkBytes, err := kp.PublicKeyBytes()
+	pkBytes, err := sharedKP.PublicKeyBytes()
 	if err != nil {
 		t.Fatalf("PublicKeyBytes failed: %v", err)
 	}
@@ -49,7 +53,7 @@ func TestKeySerializationRoundtrip(t *testing.T) {
 	}
 	t.Logf("Public key size: %d bytes", len(pkBytes))
 
-	skBytes, err := kp.SecretKeyBytes()
+	skBytes, err := sharedKP.SecretKeyBytes()
 	if err != nil {
 		t.Fatalf("SecretKeyBytes failed: %v", err)
 	}
@@ -60,39 +64,26 @@ func TestKeySerializationRoundtrip(t *testing.T) {
 }
 
 func TestSignAndVerifyWithKeypair(t *testing.T) {
-	kp, err := leansig.GenerateKeypair(42, testLsigActivationEpoch, testLsigNumActiveEpochs)
-	if err != nil {
-		t.Fatalf("GenerateKeypair failed: %v", err)
-	}
-	defer kp.Free()
-
 	epoch := uint32(0)
 	var msg [leansig.MessageLength]byte
 	if _, err := rand.Read(msg[:]); err != nil {
 		t.Fatalf("rand.Read failed: %v", err)
 	}
 
-	sig, err := kp.Sign(epoch, msg)
+	sig, err := sharedKP.Sign(epoch, msg)
 	if err != nil {
 		t.Fatalf("Sign failed: %v", err)
 	}
 	t.Logf("Signature size: %d bytes", len(sig))
 
-	err = kp.VerifyWithKeypair(epoch, msg, sig)
+	err = sharedKP.VerifyWithKeypair(epoch, msg, sig)
 	if err != nil {
 		t.Fatalf("VerifyWithKeypair failed: %v", err)
 	}
-	t.Log("Signature verified with keypair ✓")
 }
 
 func TestSignAndVerifyWithSerializedPubkey(t *testing.T) {
-	kp, err := leansig.GenerateKeypair(42, testLsigActivationEpoch, testLsigNumActiveEpochs)
-	if err != nil {
-		t.Fatalf("GenerateKeypair failed: %v", err)
-	}
-	defer kp.Free()
-
-	pkBytes, err := kp.PublicKeyBytes()
+	pkBytes, err := sharedKP.PublicKeyBytes()
 	if err != nil {
 		t.Fatalf("PublicKeyBytes failed: %v", err)
 	}
@@ -101,7 +92,7 @@ func TestSignAndVerifyWithSerializedPubkey(t *testing.T) {
 	var msg [leansig.MessageLength]byte
 	copy(msg[:], []byte("test message for devnet-1 xmss"))
 
-	sig, err := kp.Sign(epoch, msg)
+	sig, err := sharedKP.Sign(epoch, msg)
 	if err != nil {
 		t.Fatalf("Sign failed: %v", err)
 	}
@@ -110,58 +101,41 @@ func TestSignAndVerifyWithSerializedPubkey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Verify failed: %v", err)
 	}
-	t.Log("Signature verified with serialized pubkey ✓")
 }
 
 func TestVerifyRejectsWrongMessage(t *testing.T) {
-	kp, err := leansig.GenerateKeypair(42, testLsigActivationEpoch, testLsigNumActiveEpochs)
-	if err != nil {
-		t.Fatalf("GenerateKeypair failed: %v", err)
-	}
-	defer kp.Free()
-
 	epoch := uint32(0)
 	var msg [leansig.MessageLength]byte
 	copy(msg[:], []byte("correct message"))
 
-	sig, err := kp.Sign(epoch, msg)
+	sig, err := sharedKP.Sign(epoch, msg)
 	if err != nil {
 		t.Fatalf("Sign failed: %v", err)
 	}
 
-	// Tamper with the message
 	var wrongMsg [leansig.MessageLength]byte
 	copy(wrongMsg[:], []byte("wrong message!!"))
 
-	err = kp.VerifyWithKeypair(epoch, wrongMsg, sig)
+	err = sharedKP.VerifyWithKeypair(epoch, wrongMsg, sig)
 	if err == nil {
 		t.Fatal("Expected verification to fail with wrong message, but it succeeded")
 	}
-	t.Logf("Correctly rejected wrong message: %v ✓", err)
 }
 
 func TestVerifyRejectsWrongEpoch(t *testing.T) {
-	kp, err := leansig.GenerateKeypair(42, testLsigActivationEpoch, testLsigNumActiveEpochs)
-	if err != nil {
-		t.Fatalf("GenerateKeypair failed: %v", err)
-	}
-	defer kp.Free()
-
 	epoch := uint32(0)
 	var msg [leansig.MessageLength]byte
 	copy(msg[:], []byte("epoch test message"))
 
-	sig, err := kp.Sign(epoch, msg)
+	sig, err := sharedKP.Sign(epoch, msg)
 	if err != nil {
 		t.Fatalf("Sign failed: %v", err)
 	}
 
-	// Verify with wrong epoch
-	err = kp.VerifyWithKeypair(epoch+1, msg, sig)
+	err = sharedKP.VerifyWithKeypair(epoch+1, msg, sig)
 	if err == nil {
 		t.Fatal("Expected verification to fail with wrong epoch, but it succeeded")
 	}
-	t.Logf("Correctly rejected wrong epoch: %v ✓", err)
 }
 
 func TestAdvancePreparation(t *testing.T) {


### PR DESCRIPTION
## Summary                                                                                
                                                                                            
Share a single XMSS keypair via `TestMain` across 6 tests that were each generating the 
  same keypair independently   