### PR TITLE
refactor(forkchoice): shrink Store public surface       

### DIFF
--- a/chain/forkchoice/aggregation.go
+++ b/chain/forkchoice/aggregation.go
@@ -108,7 +108,7 @@ func (c *Store) ProcessAggregatedAttestation(agg *types.AggregatedAttestation) {
 		return
 	}
 
-	headState, ok := c.Storage.GetState(c.Head)
+	headState, ok := c.storage.GetState(c.head)
 	if !ok {
 		return
 	}
@@ -119,7 +119,7 @@ func (c *Store) ProcessAggregatedAttestation(agg *types.AggregatedAttestation) {
 		return
 	}
 
-	currentSlot := c.Time / types.IntervalsPerSlot
+	currentSlot := c.time / types.IntervalsPerSlot
 
 	for i, valID := range validatorIDs {
 		if valID >= uint64(len(headState.Validators)) {
@@ -143,9 +143,9 @@ func (c *Store) ProcessAggregatedAttestation(agg *types.AggregatedAttestation) {
 			Message:     agg.Data,
 			Signature:   sigs[i],
 		}
-		existing, ok := c.LatestNewAttestations[valID]
+		existing, ok := c.latestNewAttestations[valID]
 		if !ok || existing.Message.Slot < agg.Data.Slot {
-			c.LatestNewAttestations[valID] = sa
+			c.latestNewAttestations[valID] = sa
 		}
 	}
 }

--- a/chain/forkchoice/block.go
+++ b/chain/forkchoice/block.go
@@ -46,11 +46,11 @@ func (c *Store) ProcessBlock(envelope *types.SignedBlockWithAttestation) error {
 	block := envelope.Message.Block
 	blockHash, _ := block.HashTreeRoot()
 
-	if _, ok := c.Storage.GetBlock(blockHash); ok {
+	if _, ok := c.storage.GetBlock(blockHash); ok {
 		return nil // already known
 	}
 
-	parentState, ok := c.Storage.GetState(block.ParentRoot)
+	parentState, ok := c.storage.GetState(block.ParentRoot)
 	if !ok {
 		return fmt.Errorf("parent state not found for %x", block.ParentRoot)
 	}
@@ -78,7 +78,7 @@ func (c *Store) ProcessBlock(envelope *types.SignedBlockWithAttestation) error {
 		}
 	}
 
-	c.Storage.PutState(blockHash, state)
+	c.storage.PutState(blockHash, state)
 
 	// Step 1b: Verify signatures (skipped when skip_sig_verify build tag is set).
 	if c.shouldVerifySignatures() {
@@ -99,17 +99,17 @@ func (c *Store) ProcessBlock(envelope *types.SignedBlockWithAttestation) error {
 		}
 	}
 
-	c.Storage.PutBlock(blockHash, block)
-	c.Storage.PutSignedBlock(blockHash, envelope)
-	c.Storage.PutState(blockHash, state)
+	c.storage.PutBlock(blockHash, block)
+	c.storage.PutSignedBlock(blockHash, envelope)
+	c.storage.PutState(blockHash, state)
 
 	// Update justified checkpoint from this block's post-state (monotonic).
-	if state.LatestJustified.Slot > c.LatestJustified.Slot {
-		c.LatestJustified = state.LatestJustified
+	if state.LatestJustified.Slot > c.latestJustified.Slot {
+		c.latestJustified = state.LatestJustified
 	}
 	// Update finalized checkpoint from this block's post-state (monotonic).
-	if state.LatestFinalized.Slot > c.LatestFinalized.Slot {
-		c.LatestFinalized = state.LatestFinalized
+	if state.LatestFinalized.Slot > c.latestFinalized.Slot {
+		c.latestFinalized = state.LatestFinalized
 	}
 
 	// Step 2: Process body attestations as on-chain votes.

--- a/node/handler.go
+++ b/node/handler.go
@@ -26,7 +26,7 @@ func registerHandlers(n *Node, fc *forkchoice.Store) error {
 		OnBlocksByRoot: func(roots [][32]byte) []*types.SignedBlockWithAttestation {
 			var blocks []*types.SignedBlockWithAttestation
 			for _, root := range roots {
-				if sb, ok := fc.Storage.GetSignedBlock(root); ok {
+				if sb, ok := fc.GetSignedBlock(root); ok {
 					blocks = append(blocks, sb)
 				}
 			}

--- a/node/sync.go
+++ b/node/sync.go
@@ -40,7 +40,7 @@ func (n *Node) syncWithPeer(ctx context.Context, pid peer.ID) bool {
 	const maxSyncDepth = 64
 
 	for i := 0; i < maxSyncDepth; i++ {
-		if _, ok := n.FC.Storage.GetBlock(nextRoot); ok {
+		if _, ok := n.FC.GetBlock(nextRoot); ok {
 			break // We have this block, chain is connected.
 		}
 

--- a/node/validator.go
+++ b/node/validator.go
@@ -36,7 +36,7 @@ type ValidatorDuties struct {
 // HasProposal reports whether this node has a proposer for the slot.
 func (v *ValidatorDuties) HasProposal(slot uint64) bool {
 	for _, idx := range v.Indices {
-		if statetransition.IsProposer(idx, slot, v.FC.NumValidators) {
+		if statetransition.IsProposer(idx, slot, v.FC.NumValidators()) {
 			return true
 		}
 	}
@@ -62,7 +62,7 @@ func (v *ValidatorDuties) TryPropose(ctx context.Context, slot uint64) {
 	}
 
 	for _, idx := range v.Indices {
-		if !statetransition.IsProposer(idx, slot, v.FC.NumValidators) {
+		if !statetransition.IsProposer(idx, slot, v.FC.NumValidators()) {
 			continue
 		}
 
@@ -116,7 +116,7 @@ func (v *ValidatorDuties) TryAttest(ctx context.Context, slot uint64) {
 	for _, idx := range v.Indices {
 		// Skip if this validator is the proposer for this slot.
 		// The proposer already attests via ProposerAttestation in its block.
-		if statetransition.IsProposer(idx, slot, v.FC.NumValidators) {
+		if statetransition.IsProposer(idx, slot, v.FC.NumValidators()) {
 			continue
 		}
 

--- a/spectests/fc_spectests_test.go
+++ b/spectests/fc_spectests_test.go
@@ -142,7 +142,7 @@ func validateStoreChecks(t *testing.T, testName string, stepIdx int, store *fork
 	t.Helper()
 
 	status := store.GetStatus()
-	justifiedRoot := store.LatestJustified.Root
+	justifiedRoot := status.JustifiedRoot
 
 	if checks.HeadSlot != nil {
 		if status.HeadSlot != *checks.HeadSlot {
@@ -247,16 +247,17 @@ func validateStoreChecks(t *testing.T, testName string, stepIdx int, store *fork
 	if len(checks.AttestationChecks) > 0 {
 		for _, ac := range checks.AttestationChecks {
 			var sa *types.SignedAttestation
+			var found bool
 			var locationName string
 			if ac.Location == "known" {
-				sa = store.LatestKnownAttestations[ac.Validator]
+				sa, found = store.GetKnownAttestation(ac.Validator)
 				locationName = "latest_known_attestations"
 			} else {
-				sa = store.LatestNewAttestations[ac.Validator]
+				sa, found = store.GetNewAttestation(ac.Validator)
 				locationName = "latest_new_attestations"
 			}
 
-			if sa == nil {
+			if !found {
 				t.Errorf("[%s] step %d: validator %d not found in %s",
 					testName, stepIdx, ac.Validator, locationName)
 				continue


### PR DESCRIPTION
PR description:                                       
  ## Summary                                                                                
  - Unexport all 10 mutable fields on `forkchoice.Store` (`Time`, `Head`, `Storage`,        
  `LatestJustified`, etc.)
  - Add minimal accessor methods: `NumValidators()`, `GetBlock()`, `GetSignedBlock()`,
  `GetKnownAttestation()`, `GetNewAttestation()`
  - Add `JustifiedRoot` to `ChainStatus` so external callers use `GetStatus()` instead of
  reaching into checkpoint fields
  - Update all external callers in `node/`, `spectests/`

  ## Test plan
  - [x] `go build ./...` — clean compile
  - [x] `make spec-test` — all fork choice spectests pass
  - [x] `go test ./config/... ./network/... ./node/... ./storage/... ./chain/...` — all unit
   tests pass
