### PR TITLE
reqresp: add dual blocks_by_root protocol compatibility (lean + legacy)

### DIFF
--- a/network/reqresp/client.go
+++ b/network/reqresp/client.go
@@ -50,7 +50,7 @@ func RequestBlocksByRoot(ctx context.Context, h host.Host, pid peer.ID, roots []
 	ctx, cancel := context.WithTimeout(ctx, reqRespTimeout)
 	defer cancel()
 
-	s, err := h.NewStream(ctx, pid, protocol.ID(BlocksByRootProtocol))
+	s, err := h.NewStream(ctx, pid, protocol.ID(BlocksByRootProtocol), protocol.ID(BlocksByRootProtocolLegacy))
 	if err != nil {
 		return nil, fmt.Errorf("open stream: %w", err)
 	}

--- a/network/reqresp/messages.go
+++ b/network/reqresp/messages.go
@@ -8,8 +8,9 @@ import (
 
 // Protocol IDs matching cross-client convention (ssz_snappy encoding suffix).
 const (
-	StatusProtocol       = "/leanconsensus/req/status/1/ssz_snappy"
-	BlocksByRootProtocol = "/leanconsensus/req/blocks_by_root/1/ssz_snappy"
+	StatusProtocol             = "/leanconsensus/req/status/1/ssz_snappy"
+	BlocksByRootProtocol       = "/leanconsensus/req/lean_blocks_by_root/1/ssz_snappy"
+	BlocksByRootProtocolLegacy = "/leanconsensus/req/blocks_by_root/1/ssz_snappy"
 )
 
 // Response status codes.

--- a/network/reqresp/protocol_test.go
+++ b/network/reqresp/protocol_test.go
@@ -10,7 +10,10 @@ func TestReqRespProtocolIDsMatchCrossClient(t *testing.T) {
 	if reqresp.StatusProtocol != "/leanconsensus/req/status/1/ssz_snappy" {
 		t.Fatalf("status protocol mismatch: got %q", reqresp.StatusProtocol)
 	}
-	if reqresp.BlocksByRootProtocol != "/leanconsensus/req/blocks_by_root/1/ssz_snappy" {
+	if reqresp.BlocksByRootProtocol != "/leanconsensus/req/lean_blocks_by_root/1/ssz_snappy" {
 		t.Fatalf("blocks_by_root protocol mismatch: got %q", reqresp.BlocksByRootProtocol)
+	}
+	if reqresp.BlocksByRootProtocolLegacy != "/leanconsensus/req/blocks_by_root/1/ssz_snappy" {
+		t.Fatalf("blocks_by_root legacy protocol mismatch: got %q", reqresp.BlocksByRootProtocolLegacy)
 	}
 }

--- a/network/reqresp/server.go
+++ b/network/reqresp/server.go
@@ -12,10 +12,12 @@ func RegisterReqResp(h host.Host, handler *ReqRespHandler) {
 		handleStatus(s, handler)
 	})
 
-	h.SetStreamHandler(BlocksByRootProtocol, func(s network.Stream) {
+	bbr := func(s network.Stream) {
 		defer s.Close()
 		handleBlocksByRoot(s, handler)
-	})
+	}
+	h.SetStreamHandler(BlocksByRootProtocol, bbr)
+	h.SetStreamHandler(BlocksByRootProtocolLegacy, bbr)
 }
 
 func handleStatus(s network.Stream, handler *ReqRespHandler) {


### PR DESCRIPTION
## Summary

  This PR adds dual protocol support for blocks_by_root in Gean so it can interoperate with clients using either:

  - /leanconsensus/req/lean_blocks_by_root/1/ssz_snappy
  - /leanconsensus/req/blocks_by_root/1/ssz_snappy (legacy)

  ## Changes

  1. Added separate constants for primary and legacy blocks_by_root protocol IDs.
  2. Registered server handlers for both protocol IDs.
  3. Updated client NewStream call to negotiate using both protocol IDs.
  4. Added/updated protocol tests to assert both IDs are present and correct.

  ## Why

  Different devnet-1 clients currently use different protocol names for the same request type. Without dual support, block sync can fail across client pairs.

  ## Compatibility

  - Backward compatible with legacy peers.
  - Compatible with peers using the newer lean_blocks_by_root protocol.
  - No change to status protocol behavior.

  ## Testing

  - go test ./network/reqresp -count=1 passed.
