### PR TITLE
fix(types): return false instead of panicking on invalid input

### DIFF
--- a/types/slot.go
+++ b/types/slot.go
@@ -11,7 +11,7 @@ import "math"
 //  3. A pronic number n*(n+1) (e.g., 6, 12, 20, 30...)
 func IsJustifiableAfter(slot, finalizedSlot uint64) bool {
 	if slot < finalizedSlot {
-		panic("candidate slot must not be before finalized slot")
+		return false
 	}
 
 	delta := slot - finalizedSlot


### PR DESCRIPTION
## Summary

Fixes a panic in `IsJustifiableAfter` when invalid input is provided.  
The function now safely returns `false` instead of panicking.

## Related Issue

Closes #82 

## Changes

- [ ] Updated logic to return `false` on invalid input

