### PR TITLE
fix(node): prevent time.Ticker leak in SlotTicker

### DIFF
--- a/node/clock.go
+++ b/node/clock.go
@@ -43,6 +43,6 @@ func (c *Clock) CurrentTime() uint64 {
 }
 
 // SlotTicker returns a channel that fires at the start of each interval.
-func (c *Clock) SlotTicker() <-chan time.Time {
-	return time.NewTicker(time.Second).C // 1 second per interval
+func (c *Clock) SlotTicker() *time.Ticker {
+	return time.NewTicker(time.Second) // 1 second per interval
 }

--- a/node/ticker.go
+++ b/node/ticker.go
@@ -20,6 +20,7 @@ func (n *Node) Run(ctx context.Context) error {
 	n.initialSync(ctx)
 
 	ticker := n.Clock.SlotTicker()
+	defer ticker.Stop()
 	var lastSlot uint64
 
 	for {
@@ -30,7 +31,7 @@ func (n *Node) Run(ctx context.Context) error {
 				n.log.Warn("host close error", "err", err)
 			}
 			return nil
-		case <-ticker:
+		case <-ticker.C:
 			if n.Clock.IsBeforeGenesis() {
 				continue
 			}


### PR DESCRIPTION
### Description
This PR fixes a goroutine and timer resource leak in the node's event loop discovered in  #84 .

## Changes
- Updated `SlotTicker()` to return the `*time.Ticker` instance directly.
- Updated `node/ticker.go`'s main event loop to receive the ticker, read from `ticker.C`, and `defer ticker.Stop()` upon initialization.