### PR TITLE
fix(reqresp): prevent zero-byte injection on empty read

### DIFF
--- a/network/reqresp/codec.go
+++ b/network/reqresp/codec.go
@@ -116,6 +116,6 @@ type byteReader struct {
 
 func (br byteReader) ReadByte() (byte, error) {
 	var buf [1]byte
-	_, err := br.Reader.Read(buf[:])
+	_, err := io.ReadFull(br.Reader, buf[:])
 	return buf[0], err
 }


### PR DESCRIPTION
## Summary

Fix `byteReader.ReadByte` to correctly handle valid `(0, nil)` short reads from `io.Reader`.

The previous implementation could return `0x00` with no error when no byte was read, silently corrupting varint decoding.

## Fix

Replace `Reader.Read` with `io.ReadFull` to guarantee exactly one byte is read or an error is returned.

## Impact

Prevents zero-byte injection into the varint stream and avoids downstream decode corruption.


Fixes #81 