### PR TITLE
refactor(node): Bootnode peering, causing node0 to be in isolation an…

### DIFF
--- a/network/host.go
+++ b/network/host.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/libp2p/go-libp2p"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
@@ -70,7 +71,7 @@ func (h *Host) Close() error {
 	return h.P2P.Close()
 }
 
-// ConnectBootnodes dials the given addresses (multiaddr or ENR) and connects to them.
+// ConnectBootnodes dials the given addresses once. Returns after attempting all.
 func ConnectBootnodes(ctx context.Context, h host.Host, addrs []string) error {
 	for _, addr := range addrs {
 		pi, err := parseBootnode(addr)
@@ -93,6 +94,90 @@ func ConnectBootnodes(ctx context.Context, h host.Host, addrs []string) error {
 		)
 	}
 	return nil
+}
+
+// ConnectBootnodesWithRetry dials bootnodes immediately and then keeps
+// re-dialing any that are not currently connected, with exponential backoff
+// up to maxInterval. It runs until ctx is cancelled.
+func ConnectBootnodesWithRetry(ctx context.Context, h host.Host, addrs []string) {
+	infos := make([]*peer.AddrInfo, 0, len(addrs))
+	for _, addr := range addrs {
+		pi, err := parseBootnode(addr)
+		if err != nil {
+			netLog.Warn("invalid bootnode", "addr", addr, "err", err)
+			continue
+		}
+		if pi.ID == h.ID() {
+			continue
+		}
+		infos = append(infos, pi)
+	}
+
+	if len(infos) == 0 {
+		return
+	}
+
+	// Initial connect attempt.
+	connectAll(ctx, h, infos)
+
+	go func() {
+		const (
+			minInterval = 5 * time.Second
+			maxInterval = 60 * time.Second
+		)
+		interval := minInterval
+
+		t := time.NewTimer(interval)
+		defer t.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				connected := connectAll(ctx, h, infos)
+				if connected == len(infos) {
+					// All connected — slow down polling.
+					interval = maxInterval
+				} else {
+					// Some missing — back off but not too slow.
+					interval = interval * 2
+					if interval > maxInterval {
+						interval = maxInterval
+					}
+				}
+				t.Reset(interval)
+			}
+		}
+	}()
+}
+
+// connectAll tries to connect to each peer that isn't already connected.
+// Returns the number of peers that are connected after the attempt.
+func connectAll(ctx context.Context, h host.Host, infos []*peer.AddrInfo) int {
+	connected := 0
+	for _, pi := range infos {
+		// Already connected — count it, skip dial.
+		if len(h.Network().ConnsToPeer(pi.ID)) > 0 {
+			connected++
+			continue
+		}
+		dialCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		err := h.Connect(dialCtx, *pi)
+		cancel()
+		if err != nil {
+			netLog.Warn("failed to connect to bootnode",
+				"peer_id", pi.ID.String()[:16]+"...",
+				"err", err,
+			)
+		} else {
+			netLog.Info("connected to bootnode",
+				"peer_id", pi.ID.String()[:16]+"...",
+			)
+			connected++
+		}
+	}
+	return connected
 }
 
 func parseBootnode(addr string) (*peer.AddrInfo, error) {

--- a/node/connections.go
+++ b/node/connections.go
@@ -1,0 +1,30 @@
+package node
+
+import (
+	"context"
+
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/multiformats/go-multiaddr"
+)
+
+// peerNotifee implements network.Notifiee so we can react to peer connections.
+type peerNotifee struct {
+	n   *Node
+	ctx context.Context
+}
+
+func (p *peerNotifee) Connected(_ network.Network, conn network.Conn) {
+	pid := conn.RemotePeer()
+	// Run sync in a goroutine so we don't block the notifier.
+	go p.n.onPeerConnected(p.ctx, pid)
+}
+
+func (p *peerNotifee) Disconnected(_ network.Network, conn network.Conn) {}
+func (p *peerNotifee) Listen(_ network.Network, _ multiaddr.Multiaddr)   {}
+func (p *peerNotifee) ListenClose(_ network.Network, _ multiaddr.Multiaddr) {}
+
+// registerPeerNotifications wires up connection lifecycle callbacks.
+// Call this after the host is created, before Run().
+func (n *Node) registerPeerNotifications(ctx context.Context) {
+	n.Host.P2P.Network().Notify(&peerNotifee{n: n, ctx: ctx})
+}

--- a/node/lifecycle.go
+++ b/node/lifecycle.go
@@ -82,8 +82,14 @@ func New(cfg Config) (*Node, error) {
 		return nil, err
 	}
 
+	// Register peer connect/disconnect callbacks so we sync immediately when
+	// a new peer connects and they are ahead of us.
+	n.registerPeerNotifications(host.Ctx)
+
+	// Start persistent bootnode reconnect loop instead of a one-shot dial.
+	// This means nodes that start after us will eventually be connected.
 	if len(cfg.Bootnodes) > 0 {
-		network.ConnectBootnodes(host.Ctx, host.P2P, cfg.Bootnodes)
+		network.ConnectBootnodesWithRetry(host.Ctx, host.P2P, cfg.Bootnodes)
 	}
 
 	startMetrics(log, cfg)
@@ -123,8 +129,10 @@ func initP2P(cfg Config) (*network.Host, *gossipsub.Topics, error) {
 	}
 
 	netLog := logging.NewComponentLogger(logging.CompNetwork)
+	// Log the full peer ID so operators can verify it matches nodes.yaml.
 	netLog.Info("libp2p host started",
 		"peer_id", host.P2P.ID().String()[:16]+"...",
+		"peer_id_full", host.P2P.ID().String(),
 		"addr", cfg.ListenAddr,
 	)
 

--- a/node/sync.go
+++ b/node/sync.go
@@ -2,12 +2,16 @@ package node
 
 import (
 	"context"
+	"sync"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/geanlabs/gean/network/reqresp"
 	"github.com/geanlabs/gean/types"
 )
+
+// syncMu prevents concurrent sync attempts to the same peer.
+var syncMu sync.Mutex
 
 // syncWithPeer exchanges status and fetches missing blocks from a single peer.
 // It walks backwards from the peer's head to find blocks we're missing, then
@@ -34,6 +38,24 @@ func (n *Node) syncWithPeer(ctx context.Context, pid peer.ID) bool {
 		return false
 	}
 
+	return n.fetchMissingBlocks(ctx, pid, peerStatus)
+}
+
+// fetchMissingBlocks is called when we know the peer has a higher head than us.
+// It walks backwards from the peer's head root until it finds a block we have,
+// then replays the chain forward. Exported so it can be called from the
+// connection-notification path as well.
+func (n *Node) fetchMissingBlocks(ctx context.Context, pid peer.ID, peerStatus *reqresp.Status) bool {
+	// Serialise sync attempts so we don't make duplicate requests.
+	syncMu.Lock()
+	defer syncMu.Unlock()
+
+	// Re-check head inside the lock; another goroutine may have already synced.
+	status := n.FC.GetStatus()
+	if peerStatus.Head.Slot <= status.HeadSlot {
+		return false
+	}
+
 	// Walk backwards: request blocks we don't have, collecting roots to fetch.
 	var pending []*types.SignedBlockWithAttestation
 	nextRoot := peerStatus.Head.Root
@@ -41,7 +63,7 @@ func (n *Node) syncWithPeer(ctx context.Context, pid peer.ID) bool {
 
 	for i := 0; i < maxSyncDepth; i++ {
 		if _, ok := n.FC.GetBlock(nextRoot); ok {
-			break // We have this block, chain is connected.
+			break // We have this block; chain is connected.
 		}
 
 		blocks, err := reqresp.RequestBlocksByRoot(ctx, n.Host.P2P, pid, [][32]byte{nextRoot})
@@ -69,11 +91,40 @@ func (n *Node) syncWithPeer(ctx context.Context, pid peer.ID) bool {
 	return synced > 0
 }
 
-// initialSync exchanges status with connected peers and requests any blocks
-// we're missing. This allows a node that restarts mid-devnet to catch up.
+// initialSync exchanges status with all currently connected peers and requests
+// any blocks we're missing. Called once on startup (after bootnodes connect)
+// to catch up when restarting mid-devnet.
 func (n *Node) initialSync(ctx context.Context) {
 	peers := n.Host.P2P.Network().Peers()
 	for _, pid := range peers {
 		n.syncWithPeer(ctx, pid)
+	}
+}
+
+// onPeerConnected is called whenever a new peer connects. If they are ahead of
+// us we immediately fetch their chain. This is the key path that makes node0
+// catch up after node1/node2 reconnect to it via the retry loop.
+func (n *Node) onPeerConnected(ctx context.Context, pid peer.ID) {
+	status := n.FC.GetStatus()
+	ourStatus := reqresp.Status{
+		Finalized: &types.Checkpoint{Root: status.FinalizedRoot, Slot: status.FinalizedSlot},
+		Head:      &types.Checkpoint{Root: status.Head, Slot: status.HeadSlot},
+	}
+
+	peerStatus, err := reqresp.RequestStatus(ctx, n.Host.P2P, pid, ourStatus)
+	if err != nil {
+		n.log.Debug("status exchange on connect failed", "peer", pid.String()[:16], "err", err)
+		return
+	}
+	n.log.Info("status exchanged",
+		"peer", pid.String()[:16],
+		"peer_head_slot", peerStatus.Head.Slot,
+		"peer_finalized_slot", peerStatus.Finalized.Slot,
+	)
+
+	if peerStatus.Head.Slot > status.HeadSlot {
+		n.log.Info("peer is ahead, syncing", "peer", pid.String()[:16],
+			"peer_slot", peerStatus.Head.Slot, "our_slot", status.HeadSlot)
+		n.fetchMissingBlocks(ctx, pid, peerStatus)
 	}
 }


### PR DESCRIPTION
# Problem 2 — Bootnode peering was one-shot, causing node isolation

### What was happening

`node/lifecycle.go` called `network.ConnectBootnodes` once at startup. If a peer wasn't yet listening when the dial went out (because it started a few seconds later), the connection was never retried. This left the first node permanently isolated with `peers=0`, unable to participate in consensus.

Observed in logs: node0 (the first to start) consistently showed `peers=0` through its entire run while node1 and node2 successfully found each other. node0 built a private fork on its own chain, making finalization impossible since the network only ever had 3 of 5 validators in agreement (below the 2/3 supermajority threshold needed for justification).

### The fixes

**`network/host.go`: `ConnectBootnodesWithRetry`**

Replaces the one-shot `ConnectBootnodes` call with a background goroutine that:
- Dials all bootnodes immediately on startup (same as before)
- Re-dials any that are not currently connected on a timer
- Starts at 5s interval, backs off exponentially to 60s max
- Stops when context is cancelled (node shutdown)

```go
func ConnectBootnodesWithRetry(ctx context.Context, h host.Host, addrs []string) {
    // initial connect attempt...
    go func() {
        interval := 5 * time.Second
        for {
            select {
            case <-ctx.Done(): return
            case <-t.C:
                connected := connectAll(ctx, h, infos)
                if connected == len(infos) {
                    interval = 60 * time.Second  // all connected, slow down
                } else {
                    interval = min(interval*2, 60*time.Second)  // back off
                }
            }
        }
    }()
}
```

**`node/sync.go`: `onPeerConnected`**

When a new peer connects, immediately exchange status and fetch any missing blocks if they are ahead. This is what allows a node that was isolated during startup to catch up as soon as it gains a peer.

```go
func (n *Node) onPeerConnected(ctx context.Context, pid peer.ID) {
    // exchange status
    // if peerStatus.Head.Slot > our head: fetchMissingBlocks(...)
}
```

`fetchMissingBlocks` walks backwards from the peer's head root until it finds a block the local node already has, then replays the chain forward by calling `n.FC.ProcessBlock` on each block — the same code path used for gossip blocks, so all consensus rules apply identically.

**`node/connections.go`: `peerNotifee`**

Implements `network.Notifiee` (libp2p's peer lifecycle interface) to route `Connected` events to `onPeerConnected`:

```go
func (p *peerNotifee) Connected(_ network.Network, conn network.Conn) {
    go p.n.onPeerConnected(p.ctx, conn.RemotePeer())
}
```

**`node/lifecycle.go`**

- Swaps `ConnectBootnodes` → `ConnectBootnodesWithRetry`
- Adds `registerPeerNotifications` call after handler setup
- Logs the full peer ID at startup (`peer_id_full`) so operators can verify it matches `nodes.yaml`

### Spec compliance of networking changes

The leanSpec @ 050fa4a does not specify bootnode retry behavior or peer-triggered sync — these are implementation-level concerns. The networking changes are spec-neutral: they only affect *when* blocks arrive at `ProcessBlock`, not how they are processed. All synced blocks pass through the identical `ProcessBlock` → `StateTransition` → `ProcessAttestations` pipeline as gossip blocks, preserving all consensus invariants.

The `Status` and `BlocksByRoot` request/response messages used during sync match the spec's `subspecs/networking/reqresp/message.py` definitions exactly (existing implementation, unchanged).

---

## Files changed

| File | Type | Change |
|------|------|--------|
| `chain/forkchoice/ghost.go` | **Spec fix** | Remove slot tiebreak, use `(weight, hash)` only |
| `network/host.go` | Networking | Add `ConnectBootnodesWithRetry` with backoff loop |
| `node/lifecycle.go` | Networking | Use retry connect; register peer notifications; log full peer ID |
| `node/sync.go` | Networking | Add `onPeerConnected`, `fetchMissingBlocks` with mutex |
| `node/connections.go` | Networking | New file — libp2p `Notifiee` wiring |

---

## Testing

Run the 3-node local devnet:

```bash
# Terminal 1
make run

# Terminal 2 (a few seconds later)
make run-node-1

# Terminal 3
make run-node-2
```

Expected behaviour after this fix:
- All 3 nodes reach `peers=2` within ~10s regardless of start order
- All 3 nodes converge on the same `head` within 1–2 epochs
- `justified` and `finalized` slots begin advancing once all 5 validators are attesting to the same chain