### PR TITLE
refactor(network): remove unused error return from ConnectBootnodes

### DIFF
--- a/network/host.go
+++ b/network/host.go
@@ -71,7 +71,7 @@ func (h *Host) Close() error {
 }
 
 // ConnectBootnodes dials the given addresses (multiaddr or ENR) and connects to them.
-func ConnectBootnodes(ctx context.Context, h host.Host, addrs []string) error {
+func ConnectBootnodes(ctx context.Context, h host.Host, addrs []string) {
 	for _, addr := range addrs {
 		pi, err := parseBootnode(addr)
 		if err != nil {
@@ -92,7 +92,6 @@ func ConnectBootnodes(ctx context.Context, h host.Host, addrs []string) error {
 			"peer_id", pi.ID.String()[:16]+"...",
 		)
 	}
-	return nil
 }
 
 func parseBootnode(addr string) (*peer.AddrInfo, error) {


### PR DESCRIPTION
## Summary

[ConnectBootnodes](cci:1://file:///home/luckify/gean/network/host.go:72:0-94:1) declares an `error` return type but unconditionally returns `nil`. The return value is also discarded at every call site. This misleads readers into thinking bootnode connection failures are propagated when they are intentionally non-fatal and already logged inline.

 
## Changes

- **[network/host.go](cci:7://file:///home/luckify/gean/network/host.go:0:0-0:0)** — Removed `error` return type from [ConnectBootnodes](cci:1://file:///home/luckify/gean/network/host.go:72:0-94:1) signature and deleted the unreachable `return nil`.
- **[node/lifecycle.go](cci:7://file:///home/luckify/gean/node/lifecycle.go:0:0-0:0)** — No change needed; call site already discards the return value.
 
## Testing

| Check | Result |
|---|---|
| `make build` | Compiles cleanly |
| `make unit-test` | All packages pass |
| `go vet ./...` |  No warnings |
 

Closes #88