### PR TITLE
fix(forkchoice): remove premature PutState before signature verification

### DIFF
--- a/chain/forkchoice/block.go
+++ b/chain/forkchoice/block.go
@@ -82,8 +82,6 @@ func (c *Store) ProcessBlock(envelope *types.SignedBlockWithAttestation) error {
 		}
 	}
 
-	c.storage.PutState(blockHash, state)
-
 	// Step 1b: Verify signatures (skipped when skip_sig_verify build tag is set).
 	if c.shouldVerifySignatures() {
 		// Verify Body Attestations.


### PR DESCRIPTION
## Summary

This PR removes the premature `c.storage.PutState(blockHash, state)` call in `ProcessBlock` (`chain/forkchoice/block.go`, line 85) that writes state to storage **before** XMSS signature verification runs.

## Problem

If any signature check fails after the early `PutState`, the function returns an error but the state is already written to the store. This leaves an orphaned state object attached to a block that was never fully accepted.

**Security impact:**
- An attacker can submit a block with an invalid signature and cause a state to be permanently stored in memory with no corresponding block entry.
- The orphaned state is unreachable for normal chain operations but wastes memory and could mask bugs in future store-iteration logic.

## Fix

Removed the `PutState` call (`c.storage.PutState(blockHash, state)`) at line 85. The existing call at line 108 (after all verification passes) is the only write that currently exist.

## Testing

- Existing `ProcessBlock` tests continue to pass.
- Verified that submitting a block with an invalid signature no longer leaves orphaned state in storage.

Closes #80 