### PR TITLE
fix: align validator key filename convention with lean-quickstart

### DIFF
--- a/cmd/keygen/main.go
+++ b/cmd/keygen/main.go
@@ -35,8 +35,8 @@ func main() {
 		}
 		defer kp.Free()
 
-		pkPath := filepath.Join(*outDir, fmt.Sprintf("validator_%d.pk", i))
-		skPath := filepath.Join(*outDir, fmt.Sprintf("validator_%d.sk", i))
+		pkPath := filepath.Join(*outDir, fmt.Sprintf("validator_%d_pk.ssz", i))
+		skPath := filepath.Join(*outDir, fmt.Sprintf("validator_%d_sk.ssz", i))
 
 		if err := leansig.SaveKeypair(kp, pkPath, skPath); err != nil {
 			fmt.Fprintf(os.Stderr, "failed to save keypair %d: %v\n", i, err)

--- a/node/lifecycle.go
+++ b/node/lifecycle.go
@@ -178,8 +178,8 @@ func loadValidatorKeys(log *slog.Logger, cfg Config) (map[uint64]forkchoice.Sign
 	}
 
 	for _, idx := range cfg.ValidatorIDs {
-		pkPath := filepath.Join(cfg.ValidatorKeysDir, fmt.Sprintf("validator_%d.pk", idx))
-		skPath := filepath.Join(cfg.ValidatorKeysDir, fmt.Sprintf("validator_%d.sk", idx))
+		pkPath := filepath.Join(cfg.ValidatorKeysDir, fmt.Sprintf("validator_%d_pk.ssz", idx))
+		skPath := filepath.Join(cfg.ValidatorKeysDir, fmt.Sprintf("validator_%d_sk.ssz", idx))
 
 		kp, err := leansig.LoadKeypair(pkPath, skPath)
 		if err != nil {


### PR DESCRIPTION
## Description
This PR aligns `gean` client and the `lean-quickstart` devnet tooling validator key filename conventions. 

Previously:
- `lean-quickstart` generated: `validator_<i>_pk.ssz` and `validator_<i>_sk.ssz` 
- `gean` node expected: `validator_<i>.pk` and `validator_<i>.sk`
- `gean` keygen tool generated: `validator_<i>.pk` and `validator_<i>.sk`

This change updates both the keygen tool and the node's lifecycle loading logic to standardize on the `_pk.ssz` and `_sk.ssz` format for validator keys.

## Changes Made
- **Node**: Updated `node/lifecycle.go` to load `validator_{i}_pk.ssz` and `validator_{i}_sk.ssz` instead of `.pk` and `.sk`.
- **Keygen**: Updated `cmd/keygen/main.go` to generate keys with the `_pk.ssz` and `_sk.ssz` extensions.
- **Tests**: Verified that all unit tests in `gean/node` and `gean/cmd` continue to pass successfully.
