### PR TITLE
feat(node): add checkpoint sync bootstrap support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,10 +96,12 @@ run-devnet:
 	cd ../lean-quickstart && NETWORK_DIR=local-devnet ./spin-node.sh --node gean_0 --generateGenesis --metrics
 
 run-node-1: run-setup-if-missing
-	@./bin/gean --genesis config.yaml --bootnodes nodes.yaml --validator-registry-path validators.yaml --validator-keys keys --node-id node1 --listen-addr /ip4/0.0.0.0/tcp/9001 --node-key node1.key --data-dir data/node1 --discovery-port 9001
+	@./bin/gean --genesis config.yaml --bootnodes nodes.yaml --validator-registry-path validators.yaml --validator-keys keys --node-id node1 --listen-addr /ip4/0.0.0.0/tcp/9001 --node-key node1.key --data-dir data/node1 --discovery-port 9001 --api-port 5053 --metrics-port 8081
+
+
 
 run-node-2: run-setup-if-missing
-	@./bin/gean --genesis config.yaml --bootnodes nodes.yaml --validator-registry-path validators.yaml --validator-keys keys --node-id node2 --listen-addr /ip4/0.0.0.0/tcp/9002 --node-key node2.key --data-dir data/node2 --discovery-port 9002
+	@./bin/gean --genesis config.yaml --bootnodes nodes.yaml --validator-registry-path validators.yaml --validator-keys keys --node-id node2 --listen-addr /ip4/0.0.0.0/tcp/9002 --node-key node2.key --data-dir data/node2 --discovery-port 9002 --api-port 5054 --metrics-port 8082
 
 # The commit hash of the leanSpec repository to use for testing and fixtures
 LEAN_SPEC_COMMIT_HASH := 8b7636bb8a95fe4bec414cc4c24e74079e6256b6

--- a/README.md
+++ b/README.md
@@ -141,6 +141,26 @@ curl http://localhost:5058/lean/v0/fork_choice
 curl -o finalized.ssz http://localhost:5058/lean/v0/states/finalized
 ```
 
+Checkpoint sync example:
+
+```sh
+curl -I http://127.0.0.1:5058/lean/v0/states/finalized
+
+./bin/gean \
+  --genesis config.yaml \
+  --bootnodes nodes.yaml \
+  --validator-registry-path validators.yaml \
+  --validator-keys keys \
+  --node-id node1 \
+  --listen-addr /ip4/0.0.0.0/tcp/9001 \
+  --node-key node1.key \
+  --data-dir data/node1 \
+  --discovery-port 9001 \
+  --api-port 5053 \
+  --metrics-port 8081 \
+  --checkpoint-sync-url http://127.0.0.1:5058/lean/v0/states/finalized
+```
+
 See `api/README.md` for full route details.
 
 ## Running in a devnet

--- a/chain/forkchoice/api_snapshot.go
+++ b/chain/forkchoice/api_snapshot.go
@@ -30,7 +30,7 @@ func (c *Store) ForkChoiceSnapshot() ForkChoiceSnapshot {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	blocks := c.storage.GetAllBlocks()
+	blocks := c.allKnownBlockSummaries()
 	weights := computeBlockWeights(blocks, c.latestKnownAttestations)
 
 	finalized := types.Checkpoint{}
@@ -101,7 +101,7 @@ func (c *Store) FinalizedStateSSZ() ([]byte, bool, error) {
 	return sszBytes, true, nil
 }
 
-func computeBlockWeights(blocks map[[32]byte]*types.Block, latestAttestations map[uint64]*types.SignedAttestation) map[[32]byte]int {
+func computeBlockWeights(blocks map[[32]byte]blockSummary, latestAttestations map[uint64]*types.SignedAttestation) map[[32]byte]int {
 	weights := make(map[[32]byte]int, len(blocks))
 	for _, sa := range latestAttestations {
 		if sa == nil || sa.Message == nil || sa.Message.Head == nil {

--- a/chain/forkchoice/attestation.go
+++ b/chain/forkchoice/attestation.go
@@ -171,15 +171,15 @@ func (c *Store) validateAttestationData(data *types.AttestationData) string {
 	}
 
 	// Availability check: source, target, and head blocks must exist.
-	sourceBlock, ok := c.storage.GetBlock(data.Source.Root)
+	sourceBlock, ok := c.lookupBlockSummary(data.Source.Root)
 	if !ok {
 		return "source block unknown"
 	}
-	targetBlock, ok := c.storage.GetBlock(data.Target.Root)
+	targetBlock, ok := c.lookupBlockSummary(data.Target.Root)
 	if !ok {
 		return "target block unknown"
 	}
-	if _, ok := c.storage.GetBlock(data.Head.Root); !ok {
+	if _, ok := c.lookupBlockSummary(data.Head.Root); !ok {
 		return "head block unknown"
 	}
 

--- a/chain/forkchoice/ghost.go
+++ b/chain/forkchoice/ghost.go
@@ -1,19 +1,14 @@
 package forkchoice
 
-import (
-	"github.com/geanlabs/gean/storage"
-	"github.com/geanlabs/gean/types"
-)
+import "github.com/geanlabs/gean/types"
 
 // GetForkChoiceHead uses LMD GHOST to find the head block from a given root.
 func GetForkChoiceHead(
-	store storage.Store,
+	blocks map[[32]byte]blockSummary,
 	root [32]byte,
 	latestAttestations map[uint64]*types.SignedAttestation,
 	minScore int,
 ) [32]byte {
-	blocks := store.GetAllBlocks()
-
 	// Start at earliest block if root is zero hash.
 	if root == types.ZeroHash {
 		var earliest [32]byte

--- a/chain/forkchoice/produce.go
+++ b/chain/forkchoice/produce.go
@@ -34,9 +34,9 @@ func (c *Store) getVoteTargetLocked() (*types.Checkpoint, error) {
 	targetRoot := c.head
 
 	// Walk back up to JustificationLookback steps if safe target is newer.
-	safeBlock, safeOK := c.storage.GetBlock(c.safeTarget)
+	safeBlock, safeOK := c.lookupBlockSummary(c.safeTarget)
 	for i := 0; i < types.JustificationLookback; i++ {
-		tBlock, ok := c.storage.GetBlock(targetRoot)
+		tBlock, ok := c.lookupBlockSummary(targetRoot)
 		if ok && safeOK && tBlock.Slot > safeBlock.Slot {
 			targetRoot = tBlock.ParentRoot
 		}
@@ -44,7 +44,7 @@ func (c *Store) getVoteTargetLocked() (*types.Checkpoint, error) {
 
 	// Ensure target is in justifiable slot range.
 	for {
-		tBlock, ok := c.storage.GetBlock(targetRoot)
+		tBlock, ok := c.lookupBlockSummary(targetRoot)
 		if !ok {
 			break
 		}
@@ -54,7 +54,7 @@ func (c *Store) getVoteTargetLocked() (*types.Checkpoint, error) {
 		targetRoot = tBlock.ParentRoot
 	}
 
-	tBlock, ok := c.storage.GetBlock(targetRoot)
+	tBlock, ok := c.lookupBlockSummary(targetRoot)
 	if !ok {
 		return nil, fmt.Errorf("vote target block not found")
 	}

--- a/chain/forkchoice/produce.go
+++ b/chain/forkchoice/produce.go
@@ -67,8 +67,7 @@ func (c *Store) getVoteTargetLocked() (*types.Checkpoint, error) {
 		return c.latestJustified, nil
 	}
 
-	blockHash, _ := tBlock.HashTreeRoot()
-	return &types.Checkpoint{Root: blockHash, Slot: tBlock.Slot}, nil
+	return &types.Checkpoint{Root: targetRoot, Slot: tBlock.Slot}, nil
 }
 
 // ProduceBlock creates a new devnet-2 signed block envelope for the given slot.

--- a/chain/forkchoice/store.go
+++ b/chain/forkchoice/store.go
@@ -150,7 +150,7 @@ func RestoreFromDB(store storage.Store) *Store {
 		latestJustified:               headState.LatestJustified,
 		latestFinalized:               headState.LatestFinalized,
 		storage:                       store,
-		checkpointRoots:               nil,
+		checkpointRoots:               buildCheckpointRootIndex(headState, headRoot),
 		latestKnownAttestations:       make(map[uint64]*types.SignedAttestation),
 		latestNewAttestations:         make(map[uint64]*types.SignedAttestation),
 		latestKnownAggregatedPayloads: make(map[[32]byte]aggregatedPayload),

--- a/chain/forkchoice/store.go
+++ b/chain/forkchoice/store.go
@@ -184,3 +184,74 @@ func NewStore(state *types.State, anchorBlock *types.Block, store storage.Store)
 		aggregatedPayloads:            make(map[signatureKey][]storedAggregatedPayload),
 	}
 }
+
+// NewStoreFromCheckpointState initializes a store from a checkpoint state.
+// The checkpoint state is expected to have a latest block header whose
+// hash-tree-root matches anchorRoot after the header state root has been set.
+func NewStoreFromCheckpointState(state *types.State, anchorRoot [32]byte, store storage.Store) *Store {
+	anchorHeader := state.LatestBlockHeader
+	anchorBlock := &types.Block{
+		Slot:          anchorHeader.Slot,
+		ProposerIndex: anchorHeader.ProposerIndex,
+		ParentRoot:    checkpointParentRoot(state, anchorRoot),
+		StateRoot:     anchorHeader.StateRoot,
+		Body:          emptyCheckpointBody(),
+	}
+
+	store.PutBlock(anchorRoot, anchorBlock)
+	store.PutSignedBlock(anchorRoot, &types.SignedBlockWithAttestation{
+		Message: &types.BlockWithAttestation{Block: anchorBlock},
+	})
+	store.PutState(anchorRoot, state)
+
+	putCheckpointPlaceholder(store, state.LatestJustified.Root, state.LatestJustified.Slot, state.LatestFinalized.Root)
+	putCheckpointPlaceholder(store, state.LatestFinalized.Root, state.LatestFinalized.Slot, types.ZeroHash)
+
+	return &Store{
+		time:                          state.Slot * types.IntervalsPerSlot,
+		genesisTime:                   state.Config.GenesisTime,
+		numValidators:                 uint64(len(state.Validators)),
+		head:                          anchorRoot,
+		safeTarget:                    state.LatestFinalized.Root,
+		latestJustified:               &types.Checkpoint{Root: state.LatestJustified.Root, Slot: state.LatestJustified.Slot},
+		latestFinalized:               &types.Checkpoint{Root: state.LatestFinalized.Root, Slot: state.LatestFinalized.Slot},
+		storage:                       store,
+		latestKnownAttestations:       make(map[uint64]*types.SignedAttestation),
+		latestNewAttestations:         make(map[uint64]*types.SignedAttestation),
+		latestKnownAggregatedPayloads: make(map[[32]byte]aggregatedPayload),
+		latestNewAggregatedPayloads:   make(map[[32]byte]aggregatedPayload),
+		gossipSignatures:              make(map[signatureKey]storedSignature),
+		aggregatedPayloads:            make(map[signatureKey][]storedAggregatedPayload),
+	}
+}
+
+func putCheckpointPlaceholder(store storage.Store, root [32]byte, slot uint64, parentRoot [32]byte) {
+	if root == types.ZeroHash {
+		return
+	}
+	if _, ok := store.GetBlock(root); ok {
+		return
+	}
+	store.PutBlock(root, &types.Block{
+		Slot:          slot,
+		ProposerIndex: 0,
+		ParentRoot:    parentRoot,
+		StateRoot:     types.ZeroHash,
+		Body:          emptyCheckpointBody(),
+	})
+}
+
+func checkpointParentRoot(state *types.State, anchorRoot [32]byte) [32]byte {
+	switch {
+	case state.LatestJustified != nil && state.LatestJustified.Root != types.ZeroHash && state.LatestJustified.Root != anchorRoot:
+		return state.LatestJustified.Root
+	case state.LatestFinalized != nil && state.LatestFinalized.Root != types.ZeroHash && state.LatestFinalized.Root != anchorRoot:
+		return state.LatestFinalized.Root
+	default:
+		return state.LatestBlockHeader.ParentRoot
+	}
+}
+
+func emptyCheckpointBody() *types.BlockBody {
+	return &types.BlockBody{Attestations: []*types.AggregatedAttestation{}}
+}

--- a/chain/forkchoice/store.go
+++ b/chain/forkchoice/store.go
@@ -11,6 +11,12 @@ import (
 
 var log = logging.NewComponentLogger(logging.CompForkChoice)
 
+type blockSummary struct {
+	Slot          uint64
+	ParentRoot    [32]byte
+	ProposerIndex uint64
+}
+
 // Store tracks chain state and validator votes for the LMD GHOST algorithm.
 type Store struct {
 	mu sync.Mutex
@@ -24,6 +30,7 @@ type Store struct {
 	latestJustified *types.Checkpoint
 	latestFinalized *types.Checkpoint
 	storage         storage.Store
+	checkpointRoots map[[32]byte]blockSummary
 	isAggregator    bool
 
 	latestKnownAttestations       map[uint64]*types.SignedAttestation
@@ -51,8 +58,8 @@ func (c *Store) GetStatus() ChainStatus {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	headSlot := uint64(0)
-	if hb, ok := c.storage.GetBlock(c.head); ok {
-		headSlot = hb.Slot
+	if head, ok := c.lookupBlockSummary(c.head); ok {
+		headSlot = head.Slot
 	}
 	return ChainStatus{
 		Head:          c.head,
@@ -143,6 +150,7 @@ func RestoreFromDB(store storage.Store) *Store {
 		latestJustified:               headState.LatestJustified,
 		latestFinalized:               headState.LatestFinalized,
 		storage:                       store,
+		checkpointRoots:               nil,
 		latestKnownAttestations:       make(map[uint64]*types.SignedAttestation),
 		latestNewAttestations:         make(map[uint64]*types.SignedAttestation),
 		latestKnownAggregatedPayloads: make(map[[32]byte]aggregatedPayload),
@@ -176,6 +184,7 @@ func NewStore(state *types.State, anchorBlock *types.Block, store storage.Store)
 		latestJustified:               &types.Checkpoint{Root: anchorRoot, Slot: anchorBlock.Slot},
 		latestFinalized:               &types.Checkpoint{Root: anchorRoot, Slot: anchorBlock.Slot},
 		storage:                       store,
+		checkpointRoots:               nil,
 		latestKnownAttestations:       make(map[uint64]*types.SignedAttestation),
 		latestNewAttestations:         make(map[uint64]*types.SignedAttestation),
 		latestKnownAggregatedPayloads: make(map[[32]byte]aggregatedPayload),
@@ -193,7 +202,7 @@ func NewStoreFromCheckpointState(state *types.State, anchorRoot [32]byte, store 
 	anchorBlock := &types.Block{
 		Slot:          anchorHeader.Slot,
 		ProposerIndex: anchorHeader.ProposerIndex,
-		ParentRoot:    checkpointParentRoot(state, anchorRoot),
+		ParentRoot:    anchorHeader.ParentRoot,
 		StateRoot:     anchorHeader.StateRoot,
 		Body:          emptyCheckpointBody(),
 	}
@@ -204,9 +213,6 @@ func NewStoreFromCheckpointState(state *types.State, anchorRoot [32]byte, store 
 	})
 	store.PutState(anchorRoot, state)
 
-	putCheckpointPlaceholder(store, state.LatestJustified.Root, state.LatestJustified.Slot, state.LatestFinalized.Root)
-	putCheckpointPlaceholder(store, state.LatestFinalized.Root, state.LatestFinalized.Slot, types.ZeroHash)
-
 	return &Store{
 		time:                          state.Slot * types.IntervalsPerSlot,
 		genesisTime:                   state.Config.GenesisTime,
@@ -216,6 +222,7 @@ func NewStoreFromCheckpointState(state *types.State, anchorRoot [32]byte, store 
 		latestJustified:               &types.Checkpoint{Root: state.LatestJustified.Root, Slot: state.LatestJustified.Slot},
 		latestFinalized:               &types.Checkpoint{Root: state.LatestFinalized.Root, Slot: state.LatestFinalized.Slot},
 		storage:                       store,
+		checkpointRoots:               buildCheckpointRootIndex(state, anchorRoot),
 		latestKnownAttestations:       make(map[uint64]*types.SignedAttestation),
 		latestNewAttestations:         make(map[uint64]*types.SignedAttestation),
 		latestKnownAggregatedPayloads: make(map[[32]byte]aggregatedPayload),
@@ -225,33 +232,65 @@ func NewStoreFromCheckpointState(state *types.State, anchorRoot [32]byte, store 
 	}
 }
 
-func putCheckpointPlaceholder(store storage.Store, root [32]byte, slot uint64, parentRoot [32]byte) {
-	if root == types.ZeroHash {
-		return
-	}
-	if _, ok := store.GetBlock(root); ok {
-		return
-	}
-	store.PutBlock(root, &types.Block{
-		Slot:          slot,
-		ProposerIndex: 0,
-		ParentRoot:    parentRoot,
-		StateRoot:     types.ZeroHash,
-		Body:          emptyCheckpointBody(),
-	})
-}
-
-func checkpointParentRoot(state *types.State, anchorRoot [32]byte) [32]byte {
-	switch {
-	case state.LatestJustified != nil && state.LatestJustified.Root != types.ZeroHash && state.LatestJustified.Root != anchorRoot:
-		return state.LatestJustified.Root
-	case state.LatestFinalized != nil && state.LatestFinalized.Root != types.ZeroHash && state.LatestFinalized.Root != anchorRoot:
-		return state.LatestFinalized.Root
-	default:
-		return state.LatestBlockHeader.ParentRoot
-	}
-}
-
 func emptyCheckpointBody() *types.BlockBody {
 	return &types.BlockBody{Attestations: []*types.AggregatedAttestation{}}
+}
+
+func summarizeBlock(block *types.Block) blockSummary {
+	return blockSummary{
+		Slot:          block.Slot,
+		ParentRoot:    block.ParentRoot,
+		ProposerIndex: block.ProposerIndex,
+	}
+}
+
+func buildCheckpointRootIndex(state *types.State, anchorRoot [32]byte) map[[32]byte]blockSummary {
+	if state == nil || state.LatestBlockHeader == nil {
+		return nil
+	}
+
+	refs := make(map[[32]byte]blockSummary, len(state.HistoricalBlockHashes)+1)
+	lastNonZeroRoot := types.ZeroHash
+	for slot, root := range state.HistoricalBlockHashes {
+		if root == types.ZeroHash {
+			continue
+		}
+		refs[root] = blockSummary{
+			Slot:       uint64(slot),
+			ParentRoot: lastNonZeroRoot,
+		}
+		lastNonZeroRoot = root
+	}
+
+	refs[anchorRoot] = blockSummary{
+		Slot:          state.LatestBlockHeader.Slot,
+		ParentRoot:    state.LatestBlockHeader.ParentRoot,
+		ProposerIndex: state.LatestBlockHeader.ProposerIndex,
+	}
+	return refs
+}
+
+func (c *Store) lookupBlockSummary(root [32]byte) (blockSummary, bool) {
+	if block, ok := c.storage.GetBlock(root); ok {
+		return summarizeBlock(block), true
+	}
+	if c.checkpointRoots == nil {
+		return blockSummary{}, false
+	}
+	summary, ok := c.checkpointRoots[root]
+	return summary, ok
+}
+
+func (c *Store) allKnownBlockSummaries() map[[32]byte]blockSummary {
+	blocks := c.storage.GetAllBlocks()
+	summaries := make(map[[32]byte]blockSummary, len(blocks)+len(c.checkpointRoots))
+	for root, block := range blocks {
+		summaries[root] = summarizeBlock(block)
+	}
+	for root, summary := range c.checkpointRoots {
+		if _, ok := summaries[root]; !ok {
+			summaries[root] = summary
+		}
+	}
+	return summaries
 }

--- a/chain/forkchoice/store_test.go
+++ b/chain/forkchoice/store_test.go
@@ -14,6 +14,13 @@ func TestNewStoreFromCheckpointState(t *testing.T) {
 
 	fc := NewStoreFromCheckpointState(state, anchorRoot, store)
 
+	if _, ok := store.GetBlock(state.LatestJustified.Root); ok {
+		t.Fatal("expected no stored placeholder for justified checkpoint root")
+	}
+	if _, ok := store.GetBlock(state.LatestFinalized.Root); ok {
+		t.Fatal("expected no stored placeholder for finalized checkpoint root")
+	}
+
 	if proposalHead := fc.GetProposalHead(state.Slot + 1); proposalHead != anchorRoot {
 		t.Fatalf("proposal head = %x, want %x", proposalHead, anchorRoot)
 	}
@@ -24,6 +31,16 @@ func TestNewStoreFromCheckpointState(t *testing.T) {
 	}
 	if target.Root != state.LatestJustified.Root {
 		t.Fatalf("vote target root = %x, want %x", target.Root, state.LatestJustified.Root)
+	}
+
+	valid := fc.validateAttestationData(&types.AttestationData{
+		Slot:   3,
+		Head:   &types.Checkpoint{Root: anchorRoot, Slot: 3},
+		Source: &types.Checkpoint{Root: state.LatestJustified.Root, Slot: state.LatestJustified.Slot},
+		Target: &types.Checkpoint{Root: anchorRoot, Slot: 3},
+	})
+	if valid != "" {
+		t.Fatalf("validateAttestationData returned %q, want success", valid)
 	}
 }
 
@@ -63,13 +80,13 @@ func makeCheckpointState() *types.State {
 		LatestBlockHeader: &types.BlockHeader{
 			Slot:          3,
 			ProposerIndex: 0,
-			ParentRoot:    [32]byte{0xAA},
+			ParentRoot:    [32]byte{0x11},
 			StateRoot:     types.ZeroHash,
 			BodyRoot:      bodyRoot,
 		},
 		LatestJustified:          &types.Checkpoint{Root: [32]byte{0x11}, Slot: 2},
 		LatestFinalized:          &types.Checkpoint{Root: [32]byte{0x22}, Slot: 1},
-		HistoricalBlockHashes:    [][32]byte{},
+		HistoricalBlockHashes:    [][32]byte{{0x33}, {0x22}, {0x11}},
 		JustifiedSlots:           []byte{0x01},
 		Validators:               validators,
 		JustificationsRoots:      [][32]byte{},

--- a/chain/forkchoice/store_test.go
+++ b/chain/forkchoice/store_test.go
@@ -1,0 +1,78 @@
+package forkchoice
+
+import (
+	"testing"
+
+	"github.com/geanlabs/gean/storage/memory"
+	"github.com/geanlabs/gean/types"
+)
+
+func TestNewStoreFromCheckpointState(t *testing.T) {
+	state := makeCheckpointState()
+	anchorRoot := prepareCheckpointStateForStore(t, state)
+	store := memory.New()
+
+	fc := NewStoreFromCheckpointState(state, anchorRoot, store)
+
+	if proposalHead := fc.GetProposalHead(state.Slot + 1); proposalHead != anchorRoot {
+		t.Fatalf("proposal head = %x, want %x", proposalHead, anchorRoot)
+	}
+
+	target, err := fc.GetVoteTarget()
+	if err != nil {
+		t.Fatalf("GetVoteTarget returned error: %v", err)
+	}
+	if target.Root != state.LatestJustified.Root {
+		t.Fatalf("vote target root = %x, want %x", target.Root, state.LatestJustified.Root)
+	}
+}
+
+func prepareCheckpointStateForStore(t *testing.T, state *types.State) [32]byte {
+	t.Helper()
+
+	originalStateRoot := state.LatestBlockHeader.StateRoot
+	state.LatestBlockHeader.StateRoot = types.ZeroHash
+	stateRoot, err := state.HashTreeRoot()
+	if err != nil {
+		t.Fatalf("HashTreeRoot returned error: %v", err)
+	}
+	state.LatestBlockHeader.StateRoot = originalStateRoot
+
+	prepared := state.Copy()
+	prepared.LatestBlockHeader.StateRoot = stateRoot
+	anchorRoot, err := prepared.LatestBlockHeader.HashTreeRoot()
+	if err != nil {
+		t.Fatalf("HashTreeRoot header returned error: %v", err)
+	}
+	*state = *prepared
+	return anchorRoot
+}
+
+func makeCheckpointState() *types.State {
+	emptyBody := &types.BlockBody{Attestations: []*types.AggregatedAttestation{}}
+	bodyRoot, _ := emptyBody.HashTreeRoot()
+
+	validators := []*types.Validator{
+		{Index: 0, Pubkey: [52]byte{0x01}},
+		{Index: 1, Pubkey: [52]byte{0x02}},
+	}
+
+	return &types.State{
+		Config: &types.Config{GenesisTime: 1234},
+		Slot:   3,
+		LatestBlockHeader: &types.BlockHeader{
+			Slot:          3,
+			ProposerIndex: 0,
+			ParentRoot:    [32]byte{0xAA},
+			StateRoot:     types.ZeroHash,
+			BodyRoot:      bodyRoot,
+		},
+		LatestJustified:          &types.Checkpoint{Root: [32]byte{0x11}, Slot: 2},
+		LatestFinalized:          &types.Checkpoint{Root: [32]byte{0x22}, Slot: 1},
+		HistoricalBlockHashes:    [][32]byte{},
+		JustifiedSlots:           []byte{0x01},
+		Validators:               validators,
+		JustificationsRoots:      [][32]byte{},
+		JustificationsValidators: []byte{0x01},
+	}
+}

--- a/chain/forkchoice/time.go
+++ b/chain/forkchoice/time.go
@@ -94,7 +94,7 @@ func (c *Store) acceptNewAttestationsLocked() {
 }
 
 func (c *Store) updateHeadLocked() {
-	c.head = GetForkChoiceHead(c.storage, c.latestJustified.Root, c.latestKnownAttestations, 0)
+	c.head = GetForkChoiceHead(c.allKnownBlockSummaries(), c.latestJustified.Root, c.latestKnownAttestations, 0)
 }
 
 // UpdateSafeTarget finds the head with sufficient (2/3+) vote support.
@@ -110,8 +110,8 @@ func (c *Store) updateSafeTargetLocked() {
 	mergedPayloads = mergeAggregatedPayloads(mergedPayloads, c.latestKnownAggregatedPayloads)
 	mergedPayloads = mergeAggregatedPayloads(mergedPayloads, c.latestNewAggregatedPayloads)
 	attestations := extractAttestationsFromAggregatedPayloads(mergedPayloads)
-	c.safeTarget = GetForkChoiceHead(c.storage, c.latestJustified.Root, attestations, minScore)
-	if block, ok := c.storage.GetBlock(c.safeTarget); ok {
+	c.safeTarget = GetForkChoiceHead(c.allKnownBlockSummaries(), c.latestJustified.Root, attestations, minScore)
+	if block, ok := c.lookupBlockSummary(c.safeTarget); ok {
 		metrics.SafeTargetSlot.Set(float64(block.Slot))
 	}
 }

--- a/cmd/gean/main.go
+++ b/cmd/gean/main.go
@@ -31,6 +31,7 @@ func main() {
 	apiEnabled := flag.Bool("api-enabled", true, "Enable API server")
 	discoveryPort := flag.Int("discovery-port", 9000, "Discovery v5 UDP port")
 	dataDir := flag.String("data-dir", ".", "Data directory for node database and keys")
+	checkpointSyncURL := flag.String("checkpoint-sync-url", "", "URL to fetch finalized checkpoint state from for checkpoint sync")
 	devnetID := flag.String("devnet-id", "devnet0", "Devnet identifier for gossip topics")
 	isAggregator := flag.Bool("is-aggregator", false, "Enable aggregator role for this node")
 	attCommCount := flag.Int("attestation-committee-count", 1, "Number of attestation committees (must be 1 for devnet-3)")
@@ -111,21 +112,22 @@ func main() {
 		*apiEnabled = false
 	}
 	nodeCfg := node.Config{
-		GenesisTime:      genCfg.GenesisTime,
-		Validators:       genCfg.Validators,
-		ListenAddr:       *listenAddr,
-		NodeKeyPath:      *nodeKey,
-		Bootnodes:        bootnodes,
-		ValidatorIDs:     validatorIDs,
-		ValidatorKeysDir: *validatorKeys,
-		MetricsPort:      *metricsPort,
-		DiscoveryPort:    *discoveryPort,
-		DataDir:          *dataDir,
-		DevnetID:         *devnetID,
-		IsAggregator:     *isAggregator,
-		APIHost:          *apiHost,
-		APIPort:          *apiPort,
-		APIEnabled:       *apiEnabled,
+		GenesisTime:       genCfg.GenesisTime,
+		Validators:        genCfg.Validators,
+		ListenAddr:        *listenAddr,
+		NodeKeyPath:       *nodeKey,
+		Bootnodes:         bootnodes,
+		ValidatorIDs:      validatorIDs,
+		ValidatorKeysDir:  *validatorKeys,
+		MetricsPort:       *metricsPort,
+		DiscoveryPort:     *discoveryPort,
+		DataDir:           *dataDir,
+		CheckpointSyncURL: *checkpointSyncURL,
+		DevnetID:          *devnetID,
+		IsAggregator:      *isAggregator,
+		APIHost:           *apiHost,
+		APIPort:           *apiPort,
+		APIEnabled:        *apiEnabled,
 	}
 
 	n, err := node.New(nodeCfg)

--- a/node/checkpoint_sync.go
+++ b/node/checkpoint_sync.go
@@ -1,0 +1,102 @@
+package node
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/geanlabs/gean/types"
+)
+
+const checkpointSyncTimeout = 30 * time.Second
+
+func downloadCheckpointState(url string) (*types.State, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build checkpoint request: %w", err)
+	}
+	req.Header.Set("Accept", "application/octet-stream")
+
+	client := &http.Client{Timeout: checkpointSyncTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download checkpoint state: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("checkpoint endpoint returned HTTP %d", resp.StatusCode)
+	}
+
+	payload, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read checkpoint response: %w", err)
+	}
+
+	var state types.State
+	if err := state.UnmarshalSSZ(payload); err != nil {
+		return nil, fmt.Errorf("decode checkpoint state: %w", err)
+	}
+
+	return &state, nil
+}
+
+func verifyCheckpointState(state *types.State, genesisTime uint64, genesisValidators []*types.Validator) (*types.State, [32]byte, [32]byte, error) {
+	if state == nil {
+		return nil, types.ZeroHash, types.ZeroHash, fmt.Errorf("checkpoint state is nil")
+	}
+	if state.Config == nil {
+		return nil, types.ZeroHash, types.ZeroHash, fmt.Errorf("checkpoint state config is nil")
+	}
+	if state.LatestBlockHeader == nil {
+		return nil, types.ZeroHash, types.ZeroHash, fmt.Errorf("checkpoint latest block header is nil")
+	}
+	if state.LatestJustified == nil {
+		return nil, types.ZeroHash, types.ZeroHash, fmt.Errorf("checkpoint latest justified checkpoint is nil")
+	}
+	if state.LatestFinalized == nil {
+		return nil, types.ZeroHash, types.ZeroHash, fmt.Errorf("checkpoint latest finalized checkpoint is nil")
+	}
+	if state.Config.GenesisTime != genesisTime {
+		return nil, types.ZeroHash, types.ZeroHash, fmt.Errorf("genesis time mismatch: expected %d, got %d", genesisTime, state.Config.GenesisTime)
+	}
+	if len(state.Validators) == 0 {
+		return nil, types.ZeroHash, types.ZeroHash, fmt.Errorf("checkpoint state has no validators")
+	}
+	if len(state.Validators) != len(genesisValidators) {
+		return nil, types.ZeroHash, types.ZeroHash, fmt.Errorf("validator count mismatch: expected %d, got %d", len(genesisValidators), len(state.Validators))
+	}
+
+	for i := range genesisValidators {
+		if genesisValidators[i] == nil {
+			return nil, types.ZeroHash, types.ZeroHash, fmt.Errorf("genesis validator %d is nil", i)
+		}
+		if state.Validators[i] == nil {
+			return nil, types.ZeroHash, types.ZeroHash, fmt.Errorf("checkpoint validator %d is nil", i)
+		}
+		if state.Validators[i].Pubkey != genesisValidators[i].Pubkey {
+			return nil, types.ZeroHash, types.ZeroHash, fmt.Errorf("validator pubkey mismatch at index %d", i)
+		}
+	}
+
+	preparedState := state.Copy()
+	originalStateRoot := preparedState.LatestBlockHeader.StateRoot
+	preparedState.LatestBlockHeader.StateRoot = types.ZeroHash
+
+	stateRoot, err := preparedState.HashTreeRoot()
+	if err != nil {
+		return nil, types.ZeroHash, types.ZeroHash, fmt.Errorf("hash checkpoint state: %w", err)
+	}
+	if originalStateRoot != types.ZeroHash && originalStateRoot != stateRoot {
+		return nil, types.ZeroHash, types.ZeroHash, fmt.Errorf("checkpoint header state root mismatch")
+	}
+
+	preparedState.LatestBlockHeader.StateRoot = stateRoot
+	blockRoot, err := preparedState.LatestBlockHeader.HashTreeRoot()
+	if err != nil {
+		return nil, types.ZeroHash, types.ZeroHash, fmt.Errorf("hash checkpoint block header: %w", err)
+	}
+
+	return preparedState, stateRoot, blockRoot, nil
+}

--- a/node/checkpoint_sync.go
+++ b/node/checkpoint_sync.go
@@ -97,6 +97,60 @@ func verifyCheckpointState(state *types.State, genesisTime uint64, genesisValida
 	if err != nil {
 		return nil, types.ZeroHash, types.ZeroHash, fmt.Errorf("hash checkpoint block header: %w", err)
 	}
+	if err := verifyCheckpointHistory(preparedState, blockRoot); err != nil {
+		return nil, types.ZeroHash, types.ZeroHash, err
+	}
 
 	return preparedState, stateRoot, blockRoot, nil
+}
+
+func verifyCheckpointHistory(state *types.State, anchorRoot [32]byte) error {
+	if state.LatestBlockHeader.Slot > state.Slot {
+		return fmt.Errorf("checkpoint latest block header slot %d exceeds state slot %d", state.LatestBlockHeader.Slot, state.Slot)
+	}
+	if state.LatestBlockHeader.Slot > 0 {
+		parentSlot, ok := checkpointRootSlot(state, anchorRoot, state.LatestBlockHeader.ParentRoot)
+		if !ok {
+			return fmt.Errorf("checkpoint parent root not found in canonical history")
+		}
+		if parentSlot >= state.LatestBlockHeader.Slot {
+			return fmt.Errorf("checkpoint parent slot %d is invalid for header slot %d", parentSlot, state.LatestBlockHeader.Slot)
+		}
+	}
+	if err := verifyCheckpointRootAtSlot(state, anchorRoot, state.LatestJustified, "justified"); err != nil {
+		return err
+	}
+	if err := verifyCheckpointRootAtSlot(state, anchorRoot, state.LatestFinalized, "finalized"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func verifyCheckpointRootAtSlot(state *types.State, anchorRoot [32]byte, checkpoint *types.Checkpoint, label string) error {
+	if checkpoint == nil || checkpoint.Root == types.ZeroHash {
+		return nil
+	}
+	slot, ok := checkpointRootSlot(state, anchorRoot, checkpoint.Root)
+	if !ok {
+		return fmt.Errorf("checkpoint %s root not found in canonical history", label)
+	}
+	if slot != checkpoint.Slot {
+		return fmt.Errorf("checkpoint %s slot mismatch: expected %d, got %d", label, checkpoint.Slot, slot)
+	}
+	return nil
+}
+
+func checkpointRootSlot(state *types.State, anchorRoot, root [32]byte) (uint64, bool) {
+	if root == types.ZeroHash || state == nil || state.LatestBlockHeader == nil {
+		return 0, false
+	}
+	if root == anchorRoot {
+		return state.LatestBlockHeader.Slot, true
+	}
+	for slot, historicalRoot := range state.HistoricalBlockHashes {
+		if historicalRoot == root {
+			return uint64(slot), true
+		}
+	}
+	return 0, false
 }

--- a/node/checkpoint_sync_test.go
+++ b/node/checkpoint_sync_test.go
@@ -1,0 +1,98 @@
+package node
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/geanlabs/gean/types"
+)
+
+func TestVerifyCheckpointState(t *testing.T) {
+	genesisValidators := makeCheckpointValidators(3)
+	state := makeCheckpointState(1234, genesisValidators)
+
+	preparedState, stateRoot, blockRoot, err := verifyCheckpointState(state, 1234, genesisValidators)
+	if err != nil {
+		t.Fatalf("verifyCheckpointState returned error: %v", err)
+	}
+	if preparedState.LatestBlockHeader.StateRoot != stateRoot {
+		t.Fatalf("prepared state root mismatch: got %x want %x", preparedState.LatestBlockHeader.StateRoot, stateRoot)
+	}
+	if blockRoot == types.ZeroHash {
+		t.Fatal("expected non-zero checkpoint block root")
+	}
+}
+
+func TestVerifyCheckpointStateRejectsValidatorMismatch(t *testing.T) {
+	genesisValidators := makeCheckpointValidators(2)
+	state := makeCheckpointState(1234, genesisValidators)
+	state.Validators[1].Pubkey[0] = 0xFF
+
+	_, _, _, err := verifyCheckpointState(state, 1234, genesisValidators)
+	if err == nil {
+		t.Fatal("expected validator mismatch error")
+	}
+}
+
+func TestDownloadCheckpointState(t *testing.T) {
+	state := makeCheckpointState(1234, makeCheckpointValidators(2))
+	payload, err := state.MarshalSSZ()
+	if err != nil {
+		t.Fatalf("MarshalSSZ returned error: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(payload)
+	}))
+	defer server.Close()
+
+	downloadedState, err := downloadCheckpointState(server.URL)
+	if err != nil {
+		t.Fatalf("downloadCheckpointState returned error: %v", err)
+	}
+	if downloadedState.Config.GenesisTime != 1234 {
+		t.Fatalf("downloaded genesis time = %d, want 1234", downloadedState.Config.GenesisTime)
+	}
+}
+
+func makeCheckpointState(genesisTime uint64, validators []*types.Validator) *types.State {
+	emptyBody := &types.BlockBody{Attestations: []*types.AggregatedAttestation{}}
+	bodyRoot, _ := emptyBody.HashTreeRoot()
+	stateValidators := make([]*types.Validator, len(validators))
+	for i, validator := range validators {
+		copyValidator := *validator
+		stateValidators[i] = &copyValidator
+	}
+
+	return &types.State{
+		Config: &types.Config{GenesisTime: genesisTime},
+		Slot:   3,
+		LatestBlockHeader: &types.BlockHeader{
+			Slot:          3,
+			ProposerIndex: 0,
+			ParentRoot:    [32]byte{0xCC},
+			StateRoot:     types.ZeroHash,
+			BodyRoot:      bodyRoot,
+		},
+		LatestJustified:          &types.Checkpoint{Root: [32]byte{0x11}, Slot: 2},
+		LatestFinalized:          &types.Checkpoint{Root: [32]byte{0x22}, Slot: 1},
+		HistoricalBlockHashes:    [][32]byte{},
+		JustifiedSlots:           []byte{0x01},
+		Validators:               stateValidators,
+		JustificationsRoots:      [][32]byte{},
+		JustificationsValidators: []byte{0x01},
+	}
+}
+
+func makeCheckpointValidators(n int) []*types.Validator {
+	validators := make([]*types.Validator, n)
+	for i := range validators {
+		validators[i] = &types.Validator{
+			Index:  uint64(i),
+			Pubkey: [52]byte{byte(i + 1)},
+		}
+	}
+	return validators
+}

--- a/node/checkpoint_sync_test.go
+++ b/node/checkpoint_sync_test.go
@@ -35,6 +35,17 @@ func TestVerifyCheckpointStateRejectsValidatorMismatch(t *testing.T) {
 	}
 }
 
+func TestVerifyCheckpointStateRejectsMissingCanonicalHistory(t *testing.T) {
+	genesisValidators := makeCheckpointValidators(2)
+	state := makeCheckpointState(1234, genesisValidators)
+	state.HistoricalBlockHashes = nil
+
+	_, _, _, err := verifyCheckpointState(state, 1234, genesisValidators)
+	if err == nil {
+		t.Fatal("expected missing canonical history error")
+	}
+}
+
 func TestDownloadCheckpointState(t *testing.T) {
 	state := makeCheckpointState(1234, makeCheckpointValidators(2))
 	payload, err := state.MarshalSSZ()
@@ -72,13 +83,13 @@ func makeCheckpointState(genesisTime uint64, validators []*types.Validator) *typ
 		LatestBlockHeader: &types.BlockHeader{
 			Slot:          3,
 			ProposerIndex: 0,
-			ParentRoot:    [32]byte{0xCC},
+			ParentRoot:    [32]byte{0x11},
 			StateRoot:     types.ZeroHash,
 			BodyRoot:      bodyRoot,
 		},
 		LatestJustified:          &types.Checkpoint{Root: [32]byte{0x11}, Slot: 2},
 		LatestFinalized:          &types.Checkpoint{Root: [32]byte{0x22}, Slot: 1},
-		HistoricalBlockHashes:    [][32]byte{},
+		HistoricalBlockHashes:    [][32]byte{{0x33}, {0x22}, {0x11}},
 		JustifiedSlots:           []byte{0x01},
 		Validators:               stateValidators,
 		JustificationsRoots:      [][32]byte{},

--- a/node/lifecycle.go
+++ b/node/lifecycle.go
@@ -121,10 +121,39 @@ func initChain(log *slog.Logger, cfg Config) (*forkchoice.Store, *boltstore.Stor
 		return nil, nil, fmt.Errorf("open database: %w", err)
 	}
 
-	// Try to restore from persisted blocks and states.
-	fc := forkchoice.RestoreFromDB(db)
+	var (
+		fc                      *forkchoice.Store
+		checkpointSyncSucceeded bool
+	)
 
-	if fc != nil {
+	if cfg.CheckpointSyncURL != "" {
+		log.Info("checkpoint sync enabled, downloading state from", "url", cfg.CheckpointSyncURL)
+
+		state, err := downloadCheckpointState(cfg.CheckpointSyncURL)
+		if err != nil {
+			log.Warn("checkpoint sync failed, falling back to database/genesis", "err", err)
+		} else {
+			preparedState, stateRoot, blockRoot, err := verifyCheckpointState(state, cfg.GenesisTime, cfg.Validators)
+			if err != nil {
+				log.Warn("checkpoint state verification failed, falling back to database/genesis", "err", err)
+			} else {
+				log.Info("checkpoint state verified",
+					"slot", preparedState.Slot,
+					"state_root", logging.ShortHash(stateRoot),
+					"block_root", logging.ShortHash(blockRoot),
+				)
+				fc = forkchoice.NewStoreFromCheckpointState(preparedState, blockRoot, db)
+				checkpointSyncSucceeded = true
+				log.Info("checkpoint sync completed successfully, using state as anchor", "slot", preparedState.Slot)
+			}
+		}
+	}
+
+	if fc == nil {
+		fc = forkchoice.RestoreFromDB(db)
+	}
+
+	if fc != nil && !checkpointSyncSucceeded {
 		status := fc.GetStatus()
 		log.Info("chain restored from database",
 			"head", logging.ShortHash(status.Head),
@@ -132,8 +161,15 @@ func initChain(log *slog.Logger, cfg Config) (*forkchoice.Store, *boltstore.Stor
 			"justified_slot", status.JustifiedSlot,
 			"finalized_slot", status.FinalizedSlot,
 		)
+	} else if fc != nil {
+		status := fc.GetStatus()
+		log.Info("chain initialized from checkpoint state",
+			"head", logging.ShortHash(status.Head),
+			"head_slot", status.HeadSlot,
+			"justified_slot", status.JustifiedSlot,
+			"finalized_slot", status.FinalizedSlot,
+		)
 	} else {
-		// Fresh start: generate genesis.
 		genesisState := statetransition.GenerateGenesis(cfg.GenesisTime, cfg.Validators)
 
 		genesisBlock := &types.Block{

--- a/node/node.go
+++ b/node/node.go
@@ -59,19 +59,20 @@ func (n *Node) Close() {
 
 // Config holds node configuration.
 type Config struct {
-	GenesisTime      uint64
-	Validators       []*types.Validator
-	ListenAddr       string
-	NodeKeyPath      string
-	Bootnodes        []string
-	DiscoveryPort    int
-	DataDir          string
-	ValidatorIDs     []uint64
-	ValidatorKeysDir string
-	MetricsPort      int
-	DevnetID         string
-	IsAggregator     bool
-	APIHost          string
-	APIPort          int
-	APIEnabled       bool
+	GenesisTime       uint64
+	Validators        []*types.Validator
+	ListenAddr        string
+	NodeKeyPath       string
+	Bootnodes         []string
+	DiscoveryPort     int
+	DataDir           string
+	CheckpointSyncURL string
+	ValidatorIDs      []uint64
+	ValidatorKeysDir  string
+	MetricsPort       int
+	DevnetID          string
+	IsAggregator      bool
+	APIHost           string
+	APIPort           int
+	APIEnabled        bool
 }


### PR DESCRIPTION
Add checkpoint-sync bootstrap support to Gean.

Summary of file changes:
- add `--checkpoint-sync-url` CLI plumbing in `cmd/gean/main.go`
- extend `node.Config` with checkpoint sync settings in `node/node.go`
- initialize from checkpoint state before DB/genesis fallback in `node/lifecycle.go`
- add checkpoint download and verification helpers in `node/checkpoint_sync.go`
- bootstrap forkchoice from checkpoint state in `chain/forkchoice/store.go`
- preserve canonical checkpoint roots in vote-target selection in `chain/forkchoice/produce.go`
- add checkpoint verification and store bootstrap tests
- update local run targets and README checkpoint-sync example