### PR TITLE
ci: require linked issues for PRs targeting main and devenet branches

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 <!-- Provide a brief summary of your changes -->
 
 ## Associated Issue
-<!-- PRs targeting main or devenet-N must be linked to an issue. Use Closes #123 / Fixes #123, or link it from the Development sidebar. -->
+<!-- PRs targeting main or devnet-N must be linked to an issue. Use Closes #123 / Fixes #123, or link it from the Development sidebar. -->
 Closes #
 
 ## Test Plan

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Description
+<!-- Provide a brief summary of your changes -->
+
+## Associated Issue
+<!-- PRs targeting main or devenet-N must be linked to an issue. Use Closes #123 / Fixes #123, or link it from the Development sidebar. -->
+Closes #
+
+## Test Plan
+<!-- Describe how you verified your changes -->
+
+## Checklist
+- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) (if applicable)
+- [ ] I have performed a self-review of my code
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes

--- a/.github/workflows/pr-issue-check.yml
+++ b/.github/workflows/pr-issue-check.yml
@@ -6,8 +6,8 @@ on:
 
 permissions:
   contents: read
-  issues: read
-  pull-requests: read
+  issues: write
+  pull-requests: write
 
 jobs:
   check-issue:
@@ -21,6 +21,11 @@ jobs:
             const repo = context.repo.repo;
             const pr = context.payload.pull_request;
             const baseRef = pr.base.ref;
+            const commentMarker = "<!-- pr-issue-check-comment -->";
+            const policyMessage =
+              `PRs targeting '${baseRef}' must be linked to an existing issue. ` +
+              "Add 'Closes #123' or 'Fixes #123' to the PR description when GitHub can create the link, " +
+              "or link the issue directly from the PR's Development sidebar.";
             const shouldEnforce =
               baseRef === "main" || /^devenet-[0-9]+$/.test(baseRef);
 
@@ -30,6 +35,80 @@ jobs:
               );
               return;
             }
+
+            const listManagedComments = async () => {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: pr.number,
+                per_page: 100,
+              });
+
+              return comments
+                .filter(
+                  (comment) =>
+                    comment.user?.login === "github-actions[bot]" &&
+                    comment.body?.includes(commentMarker),
+                )
+                .sort(
+                  (left, right) =>
+                    new Date(left.created_at).getTime() -
+                    new Date(right.created_at).getTime(),
+                );
+            };
+
+            const upsertManagedComment = async (body, createIfMissing) => {
+              const managedComments = await listManagedComments();
+
+              if (managedComments.length > 1) {
+                core.warning(
+                  `Found ${managedComments.length} managed issue-check comments. Updating the oldest one.`,
+                );
+              }
+
+              const existingComment = managedComments[0];
+
+              if (existingComment) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existingComment.id,
+                  body,
+                });
+                return;
+              }
+
+              if (createIfMissing) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  body,
+                });
+              }
+            };
+
+            const renderFailureComment = () =>
+              [
+                commentMarker,
+                "## Issue link required",
+                "",
+                `This PR targets \`${baseRef}\`, so it must be linked to an existing issue.`,
+                "",
+                "To fix this:",
+                "- Add `Closes #123` or `Fixes #123` to the PR description when GitHub can create the link.",
+                "- Or link the issue directly from the PR's Development sidebar.",
+              ].join("\n");
+
+            const renderSuccessComment = (refs) =>
+              [
+                commentMarker,
+                "## Issue link verified",
+                "",
+                `This PR now has linked issue(s): ${refs.join(", ")}.`,
+                "",
+                `The linked-issue requirement for \`${baseRef}\` is satisfied.`,
+              ].join("\n");
 
             const linkedIssuesQuery = `
               query($owner: String!, $repo: String!, $number: Int!) {
@@ -65,12 +144,21 @@ jobs:
                 (issue) =>
                   `${issue.repository.owner.login}/${issue.repository.name}#${issue.number}`,
               );
+
+              try {
+                await upsertManagedComment(renderSuccessComment(refs), false);
+              } catch (error) {
+                core.warning(`Failed to update managed success comment: ${error.message}`);
+              }
+
               core.info(`Found linked issue(s): ${refs.join(", ")}`);
               return;
             }
 
-            throw new Error(
-              `PRs targeting '${baseRef}' must be linked to an existing issue. ` +
-                "Add 'Closes #123' or 'Fixes #123' to the PR description when GitHub can create the link, " +
-                "or link the issue directly from the PR's Development sidebar.",
-            );
+            try {
+              await upsertManagedComment(renderFailureComment(), true);
+            } catch (error) {
+              core.warning(`Failed to create or update managed failure comment: ${error.message}`);
+            }
+
+            throw new Error(policyMessage);

--- a/.github/workflows/pr-issue-check.yml
+++ b/.github/workflows/pr-issue-check.yml
@@ -1,0 +1,76 @@
+name: PR Issue Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  check-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for linked issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pr = context.payload.pull_request;
+            const baseRef = pr.base.ref;
+            const shouldEnforce =
+              baseRef === "main" || /^devenet-[0-9]+$/.test(baseRef);
+
+            if (!shouldEnforce) {
+              core.info(
+                `Skipping issue-link enforcement for base branch '${baseRef}'.`,
+              );
+              return;
+            }
+
+            const linkedIssuesQuery = `
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    closingIssuesReferences(first: 10) {
+                      nodes {
+                        number
+                        repository {
+                          name
+                          owner {
+                            login
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const linkedIssuesResult = await github.graphql(linkedIssuesQuery, {
+              owner,
+              repo,
+              number: pr.number,
+            });
+
+            const linkedIssues =
+              linkedIssuesResult.repository.pullRequest.closingIssuesReferences.nodes;
+
+            if (linkedIssues.length > 0) {
+              const refs = linkedIssues.map(
+                (issue) =>
+                  `${issue.repository.owner.login}/${issue.repository.name}#${issue.number}`,
+              );
+              core.info(`Found linked issue(s): ${refs.join(", ")}`);
+              return;
+            }
+
+            throw new Error(
+              `PRs targeting '${baseRef}' must be linked to an existing issue. ` +
+                "Add 'Closes #123' or 'Fixes #123' to the PR description when GitHub can create the link, " +
+                "or link the issue directly from the PR's Development sidebar.",
+            );

--- a/.github/workflows/pr-issue-check.yml
+++ b/.github/workflows/pr-issue-check.yml
@@ -3,9 +3,11 @@ name: PR Issue Check
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
 
 concurrency:
-  group: pr-issue-check-${{ github.event.pull_request.number || github.run_id }}
+  group: pr-issue-check-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:
@@ -15,170 +17,203 @@ permissions:
 
 jobs:
   check-issue:
+    if: >-
+      github.event_name == 'pull_request' ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '/recheck-issue-link')
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Check for linked issue
         uses: actions/github-script@v7
         with:
           script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const pr = context.payload.pull_request;
-            const baseRef = pr.base.ref;
-            const commentMarker = "<!-- pr-issue-check-comment -->";
-            const policyMessage =
-              `PRs targeting '${baseRef}' must be linked to an existing issue. ` +
-              "Add 'Closes #123' or 'Fixes #123' to the PR description when GitHub can create the link, " +
-              "or link the issue directly from the PR's Development sidebar.";
-            const shouldEnforce =
-              baseRef === "main" || /^devnet-[0-9]+$/.test(baseRef);
+            async function main() {
+              const owner = context.repo.owner;
+              const repo = context.repo.repo;
+              const recheckCommand = "/recheck-issue-link";
+              const eventName = context.eventName;
+              const pr =
+                eventName === "pull_request"
+                  ? context.payload.pull_request
+                  : (
+                      await github.rest.pulls.get({
+                        owner,
+                        repo,
+                        pull_number: context.payload.issue.number,
+                      })
+                    ).data;
+              const baseRef = pr.base.ref;
+              const commentMarker = "<!-- pr-issue-check-comment -->";
+              const policyMessage =
+                `PRs targeting '${baseRef}' must be linked to an existing issue. ` +
+                "Add 'Closes #123' or 'Fixes #123' to the PR description when GitHub can create the link, " +
+                "or link the issue directly from the PR's Development sidebar and comment `/recheck-issue-link`.";
 
-            if (!shouldEnforce) {
-              core.info(
-                `Skipping issue-link enforcement for base branch '${baseRef}'.`,
-              );
-              return;
-            }
-
-            if (pr.draft) {
-              core.info(
-                `Skipping issue-link enforcement for draft PR #${pr.number} targeting '${baseRef}'.`,
-              );
-              return;
-            }
-
-            const listManagedComments = async () => {
-              const comments = await github.paginate(github.rest.issues.listComments, {
-                owner,
-                repo,
-                issue_number: pr.number,
-                per_page: 100,
-              });
-
-              return comments
-                .filter(
-                  (comment) =>
-                    comment.user?.login === "github-actions[bot]" &&
-                    comment.body?.includes(commentMarker),
-                )
-                .sort(
-                  (left, right) =>
-                    new Date(left.created_at).getTime() -
-                    new Date(right.created_at).getTime(),
-                );
-            };
-
-            const upsertManagedComment = async (body, createIfMissing) => {
-              const managedComments = await listManagedComments();
-              const [existingComment, ...duplicateComments] = managedComments;
-
-              if (duplicateComments.length > 0) {
-                for (const duplicateComment of duplicateComments) {
-                  try {
-                    await github.rest.issues.deleteComment({
-                      owner,
-                      repo,
-                      comment_id: duplicateComment.id,
-                    });
-                  } catch (error) {
-                    core.warning(
-                      `Failed to delete duplicate managed comment ${duplicateComment.id}: ${error.message}`,
-                    );
-                  }
+              if (eventName === "issue_comment") {
+                const commentBody = (context.payload.comment.body || "").trim();
+                if (commentBody !== recheckCommand) {
+                  core.info(
+                    `Skipping issue comment event because the comment was not exactly '${recheckCommand}'.`,
+                  );
+                  return;
                 }
               }
 
-              if (existingComment) {
-                await github.rest.issues.updateComment({
-                  owner,
-                  repo,
-                  comment_id: existingComment.id,
-                  body,
-                });
+              const shouldEnforce =
+                baseRef === "main" || /^devnet-[0-9]+$/.test(baseRef);
+
+              if (!shouldEnforce) {
+                core.info(
+                  `Skipping issue-link enforcement for base branch '${baseRef}'.`,
+                );
                 return;
               }
 
-              if (createIfMissing) {
-                await github.rest.issues.createComment({
+              if (pr.draft) {
+                core.info(
+                  `Skipping issue-link enforcement for draft PR #${pr.number} targeting '${baseRef}'.`,
+                );
+                return;
+              }
+
+              const listManagedComments = async () => {
+                const comments = await github.paginate(github.rest.issues.listComments, {
                   owner,
                   repo,
                   issue_number: pr.number,
-                  body,
+                  per_page: 100,
                 });
-              }
-            };
 
-            const renderFailureComment = () =>
-              [
-                commentMarker,
-                "## Issue link required",
-                "",
-                `This PR targets \`${baseRef}\`, so it must be linked to an existing issue.`,
-                "",
-                "To fix this:",
-                "- Add `Closes #123` or `Fixes #123` to the PR description when GitHub can create the link.",
-                "- Or link the issue directly from the PR's Development sidebar.",
-              ].join("\n");
+                return comments
+                  .filter(
+                    (comment) =>
+                      comment.user?.login === "github-actions[bot]" &&
+                      comment.body?.includes(commentMarker),
+                  )
+                  .sort(
+                    (left, right) =>
+                      new Date(left.created_at).getTime() -
+                      new Date(right.created_at).getTime(),
+                  );
+              };
 
-            const renderSuccessComment = (refs) =>
-              [
-                commentMarker,
-                "## Issue link verified",
-                "",
-                `This PR now has linked issue(s): ${refs.join(", ")}.`,
-                "",
-                `The linked-issue requirement for \`${baseRef}\` is satisfied.`,
-              ].join("\n");
+              const upsertManagedComment = async (body, createIfMissing) => {
+                const managedComments = await listManagedComments();
+                const [existingComment, ...duplicateComments] = managedComments;
 
-            const linkedIssuesQuery = `
-              query($owner: String!, $repo: String!, $number: Int!) {
-                repository(owner: $owner, name: $repo) {
-                  pullRequest(number: $number) {
-                    closingIssuesReferences(first: 10) {
-                      nodes {
-                        number
-                        repository {
-                          name
-                          owner {
-                            login
+                if (duplicateComments.length > 0) {
+                  for (const duplicateComment of duplicateComments) {
+                    try {
+                      await github.rest.issues.deleteComment({
+                        owner,
+                        repo,
+                        comment_id: duplicateComment.id,
+                      });
+                    } catch (error) {
+                      core.warning(
+                        `Failed to delete duplicate managed comment ${duplicateComment.id}: ${error.message}`,
+                      );
+                    }
+                  }
+                }
+
+                if (existingComment) {
+                  await github.rest.issues.updateComment({
+                    owner,
+                    repo,
+                    comment_id: existingComment.id,
+                    body,
+                  });
+                  return;
+                }
+
+                if (createIfMissing) {
+                  await github.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number: pr.number,
+                    body,
+                  });
+                }
+              };
+
+              const renderFailureComment = () =>
+                [
+                  commentMarker,
+                  "## Issue link required",
+                  "",
+                  `This PR targets \`${baseRef}\`, so it must be linked to an existing issue.`,
+                  "",
+                  "To fix this:",
+                  "- Add `Closes #123` or `Fixes #123` to the PR description when GitHub can create the link.",
+                  "- Or link the issue directly from the PR's Development sidebar, then comment `/recheck-issue-link` on this PR.",
+                ].join("\n");
+
+              const renderSuccessComment = (refs) =>
+                [
+                  commentMarker,
+                  "## Issue link verified",
+                  "",
+                  `This PR now has linked issue(s): ${refs.join(", ")}.`,
+                  "",
+                  `The linked-issue requirement for \`${baseRef}\` is satisfied.`,
+                ].join("\n");
+
+              const linkedIssuesQuery = `
+                query($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $number) {
+                      closingIssuesReferences(first: 10) {
+                        nodes {
+                          number
+                          repository {
+                            name
+                            owner {
+                              login
+                            }
                           }
                         }
                       }
                     }
                   }
                 }
+              `;
+
+              const linkedIssuesResult = await github.graphql(linkedIssuesQuery, {
+                owner,
+                repo,
+                number: pr.number,
+              });
+
+              const linkedIssues =
+                linkedIssuesResult.repository.pullRequest.closingIssuesReferences.nodes;
+
+              if (linkedIssues.length > 0) {
+                const refs = linkedIssues.map(
+                  (issue) =>
+                    `${issue.repository.owner.login}/${issue.repository.name}#${issue.number}`,
+                );
+
+                try {
+                  await upsertManagedComment(renderSuccessComment(refs), false);
+                } catch (error) {
+                  core.warning(`Failed to update managed success comment: ${error.message}`);
+                }
+
+                core.info(`Found linked issue(s): ${refs.join(", ")}`);
+                return;
               }
-            `;
-
-            const linkedIssuesResult = await github.graphql(linkedIssuesQuery, {
-              owner,
-              repo,
-              number: pr.number,
-            });
-
-            const linkedIssues =
-              linkedIssuesResult.repository.pullRequest.closingIssuesReferences.nodes;
-
-            if (linkedIssues.length > 0) {
-              const refs = linkedIssues.map(
-                (issue) =>
-                  `${issue.repository.owner.login}/${issue.repository.name}#${issue.number}`,
-              );
 
               try {
-                await upsertManagedComment(renderSuccessComment(refs), false);
+                await upsertManagedComment(renderFailureComment(), true);
               } catch (error) {
-                core.warning(`Failed to update managed success comment: ${error.message}`);
+                core.warning(`Failed to create or update managed failure comment: ${error.message}`);
               }
 
-              core.info(`Found linked issue(s): ${refs.join(", ")}`);
-              return;
+              throw new Error(policyMessage);
             }
 
-            try {
-              await upsertManagedComment(renderFailureComment(), true);
-            } catch (error) {
-              core.warning(`Failed to create or update managed failure comment: ${error.message}`);
-            }
-
-            throw new Error(policyMessage);
+            return main();

--- a/.github/workflows/pr-issue-check.yml
+++ b/.github/workflows/pr-issue-check.yml
@@ -27,7 +27,7 @@ jobs:
               "Add 'Closes #123' or 'Fixes #123' to the PR description when GitHub can create the link, " +
               "or link the issue directly from the PR's Development sidebar.";
             const shouldEnforce =
-              baseRef === "main" || /^devenet-[0-9]+$/.test(baseRef);
+              baseRef === "main" || /^devnet-[0-9]+$/.test(baseRef);
 
             if (!shouldEnforce) {
               core.info(

--- a/.github/workflows/pr-issue-check.yml
+++ b/.github/workflows/pr-issue-check.yml
@@ -4,10 +4,14 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened, ready_for_review]
 
+concurrency:
+  group: pr-issue-check-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   issues: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   check-issue:
@@ -36,6 +40,13 @@ jobs:
               return;
             }
 
+            if (pr.draft) {
+              core.info(
+                `Skipping issue-link enforcement for draft PR #${pr.number} targeting '${baseRef}'.`,
+              );
+              return;
+            }
+
             const listManagedComments = async () => {
               const comments = await github.paginate(github.rest.issues.listComments, {
                 owner,
@@ -59,14 +70,23 @@ jobs:
 
             const upsertManagedComment = async (body, createIfMissing) => {
               const managedComments = await listManagedComments();
+              const [existingComment, ...duplicateComments] = managedComments;
 
-              if (managedComments.length > 1) {
-                core.warning(
-                  `Found ${managedComments.length} managed issue-check comments. Updating the oldest one.`,
-                );
+              if (duplicateComments.length > 0) {
+                for (const duplicateComment of duplicateComments) {
+                  try {
+                    await github.rest.issues.deleteComment({
+                      owner,
+                      repo,
+                      comment_id: duplicateComment.id,
+                    });
+                  } catch (error) {
+                    core.warning(
+                      `Failed to delete duplicate managed comment ${duplicateComment.id}: ${error.message}`,
+                    );
+                  }
+                }
               }
-
-              const existingComment = managedComments[0];
 
               if (existingComment) {
                 await github.rest.issues.updateComment({


### PR DESCRIPTION
## Summary

  Add a PR validation workflow that requires an associated GitHub issue for pull requests targeting:
  - `main`
  - `devenet-N` where `N` is a non-negative integer

  The workflow now checks for a real GitHub-linked issue instead of relying on a plain text regex match.

  ## Changes

  - add branch-scoped issue enforcement for `main` and `devenet-N`
  - use `actions/github-script` to validate actual linked issues
  - skip the check for all other target branches
  - fix the PR event type from `synchronized` to `synchronize`
  - update the PR template to explain how to link issues correctly

  ## How It Works

  A PR passes if GitHub recognizes at least one linked issue, either by:
  - a supported keyword in the PR description such as `Closes #123` or `Fixes #123`
  - a manual issue link from the PR's `Development` sidebar

  ## Why

  This avoids false positives from simple text matching and keeps the enforcement aligned with GitHub's actual issue-linking behavior.

  ## Validation

  - verified workflow structure manually
  - syntax-checked the embedded JavaScript used by `github-script`

  ## Notes

  PRs targeting branches other than `main` and `devenet-N` are not affected by this check.