### PR TITLE
fix: devnet3 stability — prune on finalization, dedup sync, async recovery

### DIFF
--- a/chain/forkchoice/aggregated_payloads.go
+++ b/chain/forkchoice/aggregated_payloads.go
@@ -2,8 +2,14 @@ package forkchoice
 
 import (
 	"bytes"
+	"math"
 
 	"github.com/geanlabs/gean/types"
+)
+
+const (
+	maxKnownAggregatedPayloads = 4096
+	maxNewAggregatedPayloads   = 512
 )
 
 type aggregatedPayload struct {
@@ -65,6 +71,21 @@ func mergeAggregatedPayloads(dst map[[32]byte]aggregatedPayload, src map[[32]byt
 		}
 	}
 	return dst
+}
+
+// capAggregatedPayloads evicts the oldest entries by slot when the map exceeds maxSize.
+func capAggregatedPayloads(m map[[32]byte]aggregatedPayload, maxSize int) {
+	for len(m) > maxSize {
+		var oldestKey [32]byte
+		oldestSlot := uint64(math.MaxUint64)
+		for key, payload := range m {
+			if payload.data != nil && payload.data.Slot < oldestSlot {
+				oldestSlot = payload.data.Slot
+				oldestKey = key
+			}
+		}
+		delete(m, oldestKey)
+	}
 }
 
 func extractAttestationsFromAggregatedPayloads(payloads map[[32]byte]aggregatedPayload) map[uint64]*types.SignedAttestation {

--- a/chain/forkchoice/aggregation.go
+++ b/chain/forkchoice/aggregation.go
@@ -15,16 +15,19 @@ import (
 // AggregateCommitteeSignatures collects gossip signatures, builds aggregated
 // proofs, and returns SignedAggregatedAttestation objects ready for publishing.
 // Called by aggregators at interval 2.
+//
+// Proof building (leanMultisig.Aggregate) is CPU-intensive (1-4 seconds).
+// To avoid blocking gossip message processing, the mutex is released during
+// proof building and re-acquired to store results.
 func (c *Store) AggregateCommitteeSignatures() ([]*types.SignedAggregatedAttestation, error) {
+	// Phase 1: Collect gossip signatures under lock.
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	headState, ok := c.storage.GetState(c.head)
 	if !ok {
+		c.mu.Unlock()
 		return nil, fmt.Errorf("head state not found")
 	}
 
-	// Collect full attestations from gossip signatures.
 	var attestations []*types.SignedAttestation
 	for key, stored := range c.gossipSignatures {
 		if stored.data == nil {
@@ -38,13 +41,33 @@ func (c *Store) AggregateCommitteeSignatures() ([]*types.SignedAggregatedAttesta
 	}
 
 	if len(attestations) == 0 {
+		c.mu.Unlock()
 		return nil, nil
 	}
 
-	aggAtts, aggProofs, err := c.buildAggregatedAttestationsFromSigned(headState, attestations)
+	// Snapshot reusable proofs and clear consumed gossip signatures while locked.
+	c.gossipSignatures = make(map[signatureKey]storedSignature)
+	c.mu.Unlock()
+
+	// Phase 2: Build proofs WITHOUT the lock. This is the expensive part
+	// (1-4 seconds per proof). Other goroutines can store new gossip
+	// signatures during this time.
+	aggAtts, aggProofs, err := c.buildAggregatedProofs(headState, attestations, false)
 	if err != nil {
 		return nil, fmt.Errorf("build aggregated attestations: %w", err)
 	}
+
+	// Phase 3: Store results under lock.
+	c.mu.Lock()
+	for i, att := range aggAtts {
+		if i >= len(aggProofs) || aggProofs[i] == nil {
+			continue
+		}
+		for _, vid := range bitlistToValidatorIDs(att.AggregationBits) {
+			c.storeAggregatedPayloadLocked(vid, att.Data, aggProofs[i])
+		}
+	}
+	c.mu.Unlock()
 
 	result := make([]*types.SignedAggregatedAttestation, 0, len(aggAtts))
 	for i, att := range aggAtts {
@@ -56,9 +79,6 @@ func (c *Store) AggregateCommitteeSignatures() ([]*types.SignedAggregatedAttesta
 			Proof: aggProofs[i],
 		})
 	}
-
-	// Clear consumed gossip signatures (spec: remove aggregated entries).
-	c.gossipSignatures = make(map[signatureKey]storedSignature)
 
 	return result, nil
 }
@@ -89,15 +109,41 @@ func bitlistsEqual(a, b []byte) bool {
 	return true
 }
 
+// buildAggregatedAttestationsFromSigned builds aggregated attestations and proofs
+// from signed attestations. Called under lock from ProduceBlock (block building).
 func (c *Store) buildAggregatedAttestationsFromSigned(
 	state *types.State,
 	attestations []*types.SignedAttestation,
+) ([]*types.AggregatedAttestation, []*types.AggregatedSignatureProof, error) {
+	atts, proofs, err := c.buildAggregatedProofs(state, attestations, true)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Store proofs for reuse.
+	for i, att := range atts {
+		if i >= len(proofs) || proofs[i] == nil {
+			continue
+		}
+		for _, vid := range bitlistToValidatorIDs(att.AggregationBits) {
+			c.storeAggregatedPayloadLocked(vid, att.Data, proofs[i])
+		}
+	}
+	return atts, proofs, nil
+}
+
+// buildAggregatedProofs builds aggregated proofs. When useCachedSigs is true,
+// it falls back to gossipSignatures for missing signatures (requires lock).
+// When false, it only uses signatures from the provided attestations.
+func (c *Store) buildAggregatedProofs(
+	state *types.State,
+	attestations []*types.SignedAttestation,
+	useCachedSigs bool,
 ) ([]*types.AggregatedAttestation, []*types.AggregatedSignatureProof, error) {
 	if len(attestations) == 0 {
 		return []*types.AggregatedAttestation{}, []*types.AggregatedSignatureProof{}, nil
 	}
 
-	// Group by attestation data root and keep at most one attestation per validator per root.
+	// Group by attestation data root.
 	grouped := make(map[[32]byte]map[uint64]*types.SignedAttestation)
 	dataByRoot := make(map[[32]byte]*types.AttestationData)
 	for _, sa := range attestations {
@@ -108,7 +154,6 @@ func (c *Store) buildAggregatedAttestationsFromSigned(
 		if err != nil {
 			return nil, nil, fmt.Errorf("hash attestation data: %w", err)
 		}
-
 		if _, ok := grouped[dataRoot]; !ok {
 			grouped[dataRoot] = make(map[uint64]*types.SignedAttestation)
 			dataByRoot[dataRoot] = sa.Message
@@ -146,21 +191,6 @@ func (c *Store) buildAggregatedAttestationsFromSigned(
 		}
 
 		data := dataByRoot[root]
-		bits := makeAggregationBits(validatorIDs)
-		if cached := c.findReusableAggregatedProof(data, validatorIDs, bits); cached != nil {
-			aggregatedAttestations = append(aggregatedAttestations, &types.AggregatedAttestation{
-				AggregationBits: bits,
-				Data:            data,
-			})
-			attestationProofs = append(attestationProofs, cached)
-			log.Info(
-				"attestation aggregate proof reused (leanMultisig)",
-				"slot", data.Slot,
-				"participants", len(validatorIDs),
-				"proof_size", fmt.Sprintf("%d bytes", len(cached.ProofData)),
-			)
-			continue
-		}
 
 		signerIDs := make([]uint64, 0, len(validatorIDs))
 		pubkeys := make([][]byte, 0, len(validatorIDs))
@@ -169,25 +199,26 @@ func (c *Store) buildAggregatedAttestationsFromSigned(
 			if validatorID >= uint64(len(state.Validators)) {
 				return nil, nil, fmt.Errorf("validator index out of range: %d", validatorID)
 			}
-
-			pubkey := state.Validators[validatorID].Pubkey
 			sa := group[validatorID]
 			if sa == nil || sa.Message == nil {
 				continue
 			}
-
 			signature := sa.Signature
-			key, keyOK := makeSignatureKey(validatorID, data)
-			if keyOK {
-				if cached, ok := c.gossipSignatures[key]; ok && (!hasNonZeroSignature(signature) || cached.slot >= sa.Message.Slot) {
-					signature = cached.signature
+			// When building blocks (useCachedSigs=true), fall back to stored
+			// gossip signatures for validators whose attestation has no sig.
+			if useCachedSigs {
+				key, keyOK := makeSignatureKey(validatorID, data)
+				if keyOK {
+					if cached, ok := c.gossipSignatures[key]; ok && (!hasNonZeroSignature(signature) || cached.slot >= sa.Message.Slot) {
+						signature = cached.signature
+					}
 				}
 			}
 			if !hasNonZeroSignature(signature) {
 				continue
 			}
-
 			signerIDs = append(signerIDs, validatorID)
+			pubkey := state.Validators[validatorID].Pubkey
 			pubkeys = append(pubkeys, pubkey[:])
 			sig := make([]byte, len(signature))
 			copy(sig, signature[:])
@@ -197,40 +228,27 @@ func (c *Store) buildAggregatedAttestationsFromSigned(
 			continue
 		}
 
-		bits = makeAggregationBits(signerIDs)
-		proof := c.findReusableAggregatedProof(data, signerIDs, bits)
-		if proof == nil {
-			if !proverReady {
-				leanmultisig.SetupProver()
-				proverReady = true
-			}
-			buildStart := time.Now()
-			proofData, err := leanmultisig.Aggregate(pubkeys, signatures, root, uint32(data.Slot))
-			metrics.PQSigSignaturesBuildingTime.Observe(time.Since(buildStart).Seconds())
-			if err != nil {
-				return nil, nil, fmt.Errorf("aggregate signatures: %w", err)
-			}
-			proof = &types.AggregatedSignatureProof{
-				Participants: append([]byte(nil), bits...),
-				ProofData:    proofData,
-			}
-			for _, validatorID := range signerIDs {
-				c.storeAggregatedPayloadLocked(validatorID, data, proof)
-			}
-			log.Info(
-				"attestation aggregate proof built (leanMultisig)",
-				"slot", data.Slot,
-				"participants", len(signerIDs),
-				"proof_size", fmt.Sprintf("%d bytes", len(proofData)),
-			)
-		} else {
-			log.Info(
-				"attestation aggregate proof reused (leanMultisig)",
-				"slot", data.Slot,
-				"participants", len(signerIDs),
-				"proof_size", fmt.Sprintf("%d bytes", len(proof.ProofData)),
-			)
+		bits := makeAggregationBits(signerIDs)
+		if !proverReady {
+			leanmultisig.SetupProver()
+			proverReady = true
 		}
+		buildStart := time.Now()
+		proofData, err := leanmultisig.Aggregate(pubkeys, signatures, root, uint32(data.Slot))
+		metrics.PQSigSignaturesBuildingTime.Observe(time.Since(buildStart).Seconds())
+		if err != nil {
+			return nil, nil, fmt.Errorf("aggregate signatures: %w", err)
+		}
+		proof := &types.AggregatedSignatureProof{
+			Participants: append([]byte(nil), bits...),
+			ProofData:    proofData,
+		}
+		log.Info(
+			"attestation aggregate proof built (leanMultisig)",
+			"slot", data.Slot,
+			"participants", len(signerIDs),
+			"proof_size", fmt.Sprintf("%d bytes", len(proofData)),
+		)
 
 		aggregatedAttestations = append(aggregatedAttestations, &types.AggregatedAttestation{
 			AggregationBits: bits,

--- a/chain/forkchoice/aggregation.go
+++ b/chain/forkchoice/aggregation.go
@@ -27,10 +27,23 @@ func (c *Store) AggregateCommitteeSignatures() ([]*types.SignedAggregatedAttesta
 		c.mu.Unlock()
 		return nil, fmt.Errorf("head state not found")
 	}
+	currentSlot := c.time / types.IntervalsPerSlot
 
 	var attestations []*types.SignedAttestation
+	deferred := make(map[signatureKey]storedSignature)
+	droppedStale := 0
+	deferredFuture := 0
 	for key, stored := range c.gossipSignatures {
 		if stored.data == nil {
+			continue
+		}
+		switch {
+		case stored.data.Slot < currentSlot:
+			droppedStale++
+			continue
+		case stored.data.Slot > currentSlot:
+			deferred[key] = stored
+			deferredFuture++
 			continue
 		}
 		attestations = append(attestations, &types.SignedAttestation{
@@ -40,13 +53,23 @@ func (c *Store) AggregateCommitteeSignatures() ([]*types.SignedAggregatedAttesta
 		})
 	}
 
+	c.gossipSignatures = deferred
+	metrics.GossipSignaturesCount.Set(float64(len(c.gossipSignatures)))
+
 	if len(attestations) == 0 {
 		c.mu.Unlock()
+		if droppedStale > 0 || deferredFuture > 0 {
+			log.Info("aggregation backlog filtered",
+				"current_slot", currentSlot,
+				"eligible_signatures", 0,
+				"dropped_stale_signatures", droppedStale,
+				"deferred_future_signatures", deferredFuture,
+				"built_aggregates", 0,
+			)
+		}
 		return nil, nil
 	}
 
-	// Snapshot reusable proofs and clear consumed gossip signatures while locked.
-	c.gossipSignatures = make(map[signatureKey]storedSignature)
 	c.mu.Unlock()
 
 	// Phase 2: Build proofs WITHOUT the lock. This is the expensive part
@@ -78,6 +101,16 @@ func (c *Store) AggregateCommitteeSignatures() ([]*types.SignedAggregatedAttesta
 			Data:  att.Data,
 			Proof: aggProofs[i],
 		})
+	}
+
+	if droppedStale > 0 || deferredFuture > 0 || len(result) > 0 {
+		log.Info("aggregation backlog filtered",
+			"current_slot", currentSlot,
+			"eligible_signatures", len(attestations),
+			"dropped_stale_signatures", droppedStale,
+			"deferred_future_signatures", deferredFuture,
+			"built_aggregates", len(result),
+		)
 	}
 
 	return result, nil

--- a/chain/forkchoice/aggregation_backlog_test.go
+++ b/chain/forkchoice/aggregation_backlog_test.go
@@ -1,0 +1,165 @@
+package forkchoice
+
+import (
+	"testing"
+
+	"github.com/geanlabs/gean/chain/statetransition"
+	"github.com/geanlabs/gean/storage/memory"
+	"github.com/geanlabs/gean/types"
+	"github.com/geanlabs/gean/xmss/leansig"
+)
+
+const aggregationTestActiveEpochs = 8
+
+func TestAggregateCommitteeSignatures_CurrentSlotOnly(t *testing.T) {
+	fc, signers, cleanup := newAggregationTestStore(t, 2)
+	defer cleanup()
+
+	currentA, err := fc.ProduceAttestation(1, 0, signers[0])
+	if err != nil {
+		t.Fatalf("produce attestation validator 0: %v", err)
+	}
+	currentB, err := fc.ProduceAttestation(1, 1, signers[1])
+	if err != nil {
+		t.Fatalf("produce attestation validator 1: %v", err)
+	}
+
+	stale := cloneSignedAttestationWithSlot(currentA, 0)
+	future := cloneSignedAttestationWithSlot(currentA, 2)
+
+	fc.mu.Lock()
+	fc.storeGossipSignatureLocked(currentA)
+	fc.storeGossipSignatureLocked(currentB)
+	fc.storeGossipSignatureLocked(stale)
+	fc.storeGossipSignatureLocked(future)
+	fc.mu.Unlock()
+
+	aggregated, err := fc.AggregateCommitteeSignatures()
+	if err != nil {
+		t.Fatalf("AggregateCommitteeSignatures returned error: %v", err)
+	}
+	if len(aggregated) != 1 {
+		t.Fatalf("aggregated count = %d, want 1", len(aggregated))
+	}
+	if aggregated[0].Data == nil || aggregated[0].Data.Slot != 1 {
+		t.Fatalf("aggregated attestation slot = %v, want 1", aggregated[0].Data)
+	}
+	if got := len(bitlistToValidatorIDs(aggregated[0].Proof.Participants)); got != 2 {
+		t.Fatalf("participants = %d, want 2", got)
+	}
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	if len(fc.gossipSignatures) != 1 {
+		t.Fatalf("remaining gossip signatures = %d, want 1 future entry", len(fc.gossipSignatures))
+	}
+	for _, stored := range fc.gossipSignatures {
+		if stored.data == nil || stored.data.Slot != 2 {
+			t.Fatalf("remaining gossip signature slot = %v, want 2", stored.data)
+		}
+	}
+}
+
+func TestAggregateCommitteeSignatures_NoCurrentSlotEligible(t *testing.T) {
+	fc, signers, cleanup := newAggregationTestStore(t, 1)
+	defer cleanup()
+
+	current, err := fc.ProduceAttestation(1, 0, signers[0])
+	if err != nil {
+		t.Fatalf("produce attestation: %v", err)
+	}
+
+	stale := cloneSignedAttestationWithSlot(current, 0)
+	future := cloneSignedAttestationWithSlot(current, 2)
+
+	fc.mu.Lock()
+	fc.storeGossipSignatureLocked(stale)
+	fc.storeGossipSignatureLocked(future)
+	fc.mu.Unlock()
+
+	aggregated, err := fc.AggregateCommitteeSignatures()
+	if err != nil {
+		t.Fatalf("AggregateCommitteeSignatures returned error: %v", err)
+	}
+	if len(aggregated) != 0 {
+		t.Fatalf("aggregated count = %d, want 0", len(aggregated))
+	}
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	if len(fc.gossipSignatures) != 1 {
+		t.Fatalf("remaining gossip signatures = %d, want 1 future entry", len(fc.gossipSignatures))
+	}
+	for _, stored := range fc.gossipSignatures {
+		if stored.data == nil || stored.data.Slot != 2 {
+			t.Fatalf("remaining gossip signature slot = %v, want 2", stored.data)
+		}
+	}
+}
+
+func newAggregationTestStore(t *testing.T, numValidators int) (*Store, []*leansig.Keypair, func()) {
+	t.Helper()
+
+	validators := make([]*types.Validator, numValidators)
+	signers := make([]*leansig.Keypair, numValidators)
+	for i := 0; i < numValidators; i++ {
+		kp, err := leansig.GenerateKeypair(uint64(101+i), 0, aggregationTestActiveEpochs)
+		if err != nil {
+			t.Fatalf("generate keypair %d: %v", i, err)
+		}
+		pkBytes, err := kp.PublicKeyBytes()
+		if err != nil {
+			kp.Free()
+			t.Fatalf("serialize pubkey %d: %v", i, err)
+		}
+		var pubkey [52]byte
+		if len(pkBytes) != len(pubkey) {
+			kp.Free()
+			t.Fatalf("pubkey length = %d, want 52", len(pkBytes))
+		}
+
+		copy(pubkey[:], pkBytes)
+		validators[i] = &types.Validator{
+			Index:  uint64(i),
+			Pubkey: pubkey,
+		}
+		signers[i] = kp
+	}
+
+	state := statetransition.GenerateGenesis(1000, validators)
+	emptyBody := &types.BlockBody{Attestations: []*types.AggregatedAttestation{}}
+	genesisBlock := &types.Block{
+		Slot:          0,
+		ProposerIndex: 0,
+		ParentRoot:    types.ZeroHash,
+		StateRoot:     types.ZeroHash,
+		Body:          emptyBody,
+	}
+	stateRoot, err := state.HashTreeRoot()
+	if err != nil {
+		t.Fatalf("hash genesis state: %v", err)
+	}
+	genesisBlock.StateRoot = stateRoot
+
+	fc := NewStore(state, genesisBlock, memory.New())
+	fc.SetIsAggregator(true)
+
+	cleanup := func() {
+		for _, kp := range signers {
+			if kp != nil {
+				kp.Free()
+			}
+		}
+	}
+	return fc, signers, cleanup
+}
+
+func cloneSignedAttestationWithSlot(sa *types.SignedAttestation, slot uint64) *types.SignedAttestation {
+	cloned := *sa
+	if sa.Message != nil {
+		msg := *sa.Message
+		msg.Slot = slot
+		cloned.Message = &msg
+	}
+	return &cloned
+}

--- a/chain/forkchoice/attestation.go
+++ b/chain/forkchoice/attestation.go
@@ -294,6 +294,7 @@ func (c *Store) processAggregatedAttestationLocked(saa *types.SignedAggregatedAt
 	// Store into the aggregated payloads buffer.
 	// Attestations are expanded into per-validator votes during acceptNewAttestationsLocked.
 	addAggregatedPayload(c.latestNewAggregatedPayloads, data, proof)
+	capAggregatedPayloads(c.latestNewAggregatedPayloads, maxNewAggregatedPayloads)
 	metrics.LatestNewAggregatedPayloads.Set(float64(len(c.latestNewAggregatedPayloads)))
 
 	// Also cache per-validator proof in aggregatedPayloads for proposer reuse.

--- a/chain/forkchoice/block.go
+++ b/chain/forkchoice/block.go
@@ -172,6 +172,7 @@ func (c *Store) ProcessBlock(envelope *types.SignedBlockWithAttestation) error {
 		c.latestFinalized = state.LatestFinalized
 		metrics.FinalizationsTotal.WithLabelValues("success").Inc()
 		metrics.LatestFinalizedSlot.Set(float64(state.LatestFinalized.Slot))
+		c.pruneOnFinalizationLocked(state.LatestFinalized.Slot)
 	}
 
 	// Step 2: Process body attestations as on-chain votes.

--- a/chain/forkchoice/block.go
+++ b/chain/forkchoice/block.go
@@ -47,11 +47,12 @@ func (c *Store) verifyAttestationSignatureWithState(
 }
 
 // ProcessBlock processes a new signed block envelope and updates chain state.
-// Attestation processing follows leanSpec on_block ordering:
-//  1. State transition on the bare block.
-//  2. Process body attestations as on-chain votes (is_from_block=true).
-//  3. Update head.
-//  4. Process proposer attestation as gossip vote (is_from_block=false).
+// Processing order follows leanSpec on_block:
+//  1. Verify signatures (reject invalid blocks before expensive state transition).
+//  2. State transition on the bare block.
+//  3. Process body attestations as on-chain votes (is_from_block=true).
+//  4. Update head.
+//  5. Process proposer attestation as gossip vote (is_from_block=false).
 func (c *Store) ProcessBlock(envelope *types.SignedBlockWithAttestation) error {
 	start := time.Now()
 	c.mu.Lock()
@@ -76,14 +77,8 @@ func (c *Store) ProcessBlock(envelope *types.SignedBlockWithAttestation) error {
 		return fmt.Errorf("parent state not found for %x", block.ParentRoot)
 	}
 
-	stStart := time.Now()
-	state, err := statetransition.StateTransition(parentState, block)
-	metrics.StateTransitionTime.Observe(time.Since(stStart).Seconds())
-	if err != nil {
-		return fmt.Errorf("state_transition: %w", err)
-	}
-
-	// Validate signature container shape.
+	// Step 1: Validate signature container shape and verify signatures.
+	// Done before state transition to reject invalid blocks cheaply.
 	numBodyAtts := len(block.Body.Attestations)
 	if len(envelope.Signature.AttestationSignatures) != numBodyAtts {
 		return fmt.Errorf(
@@ -96,11 +91,9 @@ func (c *Store) ProcessBlock(envelope *types.SignedBlockWithAttestation) error {
 		return fmt.Errorf("missing proposer attestation")
 	}
 
-	// Step 1b: Verify signatures (skipped when skip_sig_verify build tag is set).
 	if c.shouldVerifySignatures() {
 		leanmultisig.SetupVerifier()
 
-		// Verify aggregated body attestations and their matching proofs.
 		for i, aggregated := range block.Body.Attestations {
 			if aggregated == nil || aggregated.Data == nil {
 				return fmt.Errorf("invalid body attestation at index %d", i)
@@ -147,7 +140,6 @@ func (c *Store) ProcessBlock(envelope *types.SignedBlockWithAttestation) error {
 			)
 		}
 
-		// Verify proposer signature (always individual XMSS).
 		proposerAtt := envelope.Message.ProposerAttestation
 		if err := c.verifyAttestationSignatureWithState(
 			parentState,
@@ -157,6 +149,14 @@ func (c *Store) ProcessBlock(envelope *types.SignedBlockWithAttestation) error {
 		); err != nil {
 			return fmt.Errorf("invalid proposer attestation signature: %w", err)
 		}
+	}
+
+	// Step 2: State transition.
+	stStart := time.Now()
+	state, err := statetransition.StateTransition(parentState, block)
+	metrics.StateTransitionTime.Observe(time.Since(stStart).Seconds())
+	if err != nil {
+		return fmt.Errorf("state_transition: %w", err)
 	}
 
 	c.storage.PutBlock(blockHash, block)

--- a/chain/forkchoice/store.go
+++ b/chain/forkchoice/store.go
@@ -236,6 +236,58 @@ func emptyCheckpointBody() *types.BlockBody {
 	return &types.BlockBody{Attestations: []*types.AggregatedAttestation{}}
 }
 
+// pruneOnFinalizationLocked removes data for slots older than the finalized slot.
+// Called when finalization advances to bound memory growth.
+func (c *Store) pruneOnFinalizationLocked(finalizedSlot uint64) {
+	for id, sa := range c.latestKnownAttestations {
+		if sa != nil && sa.Message != nil && sa.Message.Slot < finalizedSlot {
+			delete(c.latestKnownAttestations, id)
+		}
+	}
+	for root, ap := range c.latestKnownAggregatedPayloads {
+		if ap.data != nil && ap.data.Slot < finalizedSlot {
+			delete(c.latestKnownAggregatedPayloads, root)
+		}
+	}
+	for key, entries := range c.aggregatedPayloads {
+		// Keep only entries at or after the finalized slot.
+		kept := entries[:0]
+		for _, e := range entries {
+			if e.slot >= finalizedSlot {
+				kept = append(kept, e)
+			}
+		}
+		if len(kept) == 0 {
+			delete(c.aggregatedPayloads, key)
+		} else {
+			c.aggregatedPayloads[key] = kept
+		}
+	}
+	for key, sig := range c.gossipSignatures {
+		if sig.slot < finalizedSlot {
+			delete(c.gossipSignatures, key)
+		}
+	}
+
+	// Prune old blocks and states from storage.
+	for root, block := range c.storage.GetAllBlocks() {
+		if block.Slot < finalizedSlot {
+			c.storage.DeleteBlock(root)
+			c.storage.DeleteSignedBlock(root)
+		}
+	}
+	for root, state := range c.storage.GetAllStates() {
+		if state.Slot < finalizedSlot {
+			c.storage.DeleteState(root)
+		}
+	}
+
+	// Rebuild checkpoint root index from head state.
+	if headState, ok := c.storage.GetState(c.head); ok {
+		c.checkpointRoots = buildCheckpointRootIndex(headState, c.head)
+	}
+}
+
 func summarizeBlock(block *types.Block) blockSummary {
 	return blockSummary{
 		Slot:          block.Slot,

--- a/chain/forkchoice/time.go
+++ b/chain/forkchoice/time.go
@@ -82,6 +82,7 @@ func (c *Store) acceptNewAttestationsLocked() {
 		}
 	}
 	c.latestKnownAggregatedPayloads = mergeAggregatedPayloads(c.latestKnownAggregatedPayloads, c.latestNewAggregatedPayloads)
+	capAggregatedPayloads(c.latestKnownAggregatedPayloads, maxKnownAggregatedPayloads)
 	c.latestNewAggregatedPayloads = make(map[[32]byte]aggregatedPayload)
 	metrics.LatestNewAggregatedPayloads.Set(0)
 

--- a/network/gossipsub/gossip.go
+++ b/network/gossipsub/gossip.go
@@ -7,7 +7,6 @@ import (
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/host"
-	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 // Gossip topic names.
@@ -25,8 +24,7 @@ type Topics struct {
 }
 
 // NewGossipSub creates a configured gossipsub instance.
-// directPeers are always messaged regardless of mesh or subscription state (used for bootnodes).
-func NewGossipSub(ctx context.Context, h host.Host, directPeers []peer.AddrInfo) (*pubsub.PubSub, error) {
+func NewGossipSub(ctx context.Context, h host.Host) (*pubsub.PubSub, error) {
 	return pubsub.NewGossipSub(ctx, h,
 		pubsub.WithMessageSignaturePolicy(pubsub.StrictNoSign),
 		pubsub.WithNoAuthor(), // Omit author (From) and sequence number for anonymous mode compatibility
@@ -56,8 +54,7 @@ func NewGossipSub(ctx context.Context, h host.Host, directPeers []peer.AddrInfo)
 		}),
 		pubsub.WithSeenMessagesTTL(24*time.Second),
 		pubsub.WithMessageIdFn(ComputeMessageID),
-		pubsub.WithFloodPublish(false),      // Use mesh-only publishing to avoid IDONTWANT pressure
-		pubsub.WithDirectPeers(directPeers), // Always message bootnodes regardless of mesh/subscription state
+		pubsub.WithFloodPublish(false), // Use mesh-only publishing to avoid IDONTWANT pressure
 	)
 }
 

--- a/network/gossipsub/gossip.go
+++ b/network/gossipsub/gossip.go
@@ -56,7 +56,7 @@ func NewGossipSub(ctx context.Context, h host.Host, directPeers []peer.AddrInfo)
 		}),
 		pubsub.WithSeenMessagesTTL(24*time.Second),
 		pubsub.WithMessageIdFn(ComputeMessageID),
-		pubsub.WithFloodPublish(true),       // Send to all subscribed peers, bypassing mesh for small devnets
+		pubsub.WithFloodPublish(false),      // Use mesh-only publishing to avoid IDONTWANT pressure
 		pubsub.WithDirectPeers(directPeers), // Always message bootnodes regardless of mesh/subscription state
 	)
 }

--- a/network/host.go
+++ b/network/host.go
@@ -98,25 +98,20 @@ func NewHost(listenAddr string, nodeKeyPath string, bootnodes []string) (*Host, 
 		netLog.Info("listening on", "addr", a.String())
 	}
 
-	var directPeers []peer.AddrInfo
+	bootnodeMap := make(map[peer.ID]peer.AddrInfo, len(bootnodes))
 	for _, addr := range bootnodes {
 		pi, err := parseBootnode(addr)
 		if err != nil || pi.ID == h.ID() {
 			continue
 		}
-		directPeers = append(directPeers, *pi)
+		bootnodeMap[pi.ID] = *pi
 	}
 
-	gs, err := gossipsub.NewGossipSub(ctx, h, directPeers)
+	gs, err := gossipsub.NewGossipSub(ctx, h)
 	if err != nil {
 		h.Close()
 		cancel()
 		return nil, fmt.Errorf("gossipsub: %w", err)
-	}
-
-	bootnodeMap := make(map[peer.ID]peer.AddrInfo, len(directPeers))
-	for _, dp := range directPeers {
-		bootnodeMap[dp.ID] = dp
 	}
 
 	hostWrapper := &Host{P2P: h, PubSub: gs, Ctx: ctx, Cancel: cancel, bootnodePeers: bootnodeMap}

--- a/network/host.go
+++ b/network/host.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/libp2p/go-libp2p"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
@@ -45,12 +46,15 @@ func (g *allowAllGater) InterceptUpgraded(c libp2pnetwork.Conn) (bool, control.D
 
 const nodeKeyFilePerms = 0600
 
+const bootnodeRedialDelay = 12 * time.Second
+
 // Host wraps a libp2p host with gossipsub and protocol handlers.
 type Host struct {
-	P2P    host.Host
-	PubSub *pubsub.PubSub
-	Ctx    context.Context
-	Cancel context.CancelFunc
+	P2P           host.Host
+	PubSub        *pubsub.PubSub
+	Ctx           context.Context
+	Cancel        context.CancelFunc
+	bootnodePeers map[peer.ID]peer.AddrInfo
 }
 
 // NewHost creates a libp2p host with QUIC transport and secp256k1 identity.
@@ -110,6 +114,13 @@ func NewHost(listenAddr string, nodeKeyPath string, bootnodes []string) (*Host, 
 		return nil, fmt.Errorf("gossipsub: %w", err)
 	}
 
+	bootnodeMap := make(map[peer.ID]peer.AddrInfo, len(directPeers))
+	for _, dp := range directPeers {
+		bootnodeMap[dp.ID] = dp
+	}
+
+	hostWrapper := &Host{P2P: h, PubSub: gs, Ctx: ctx, Cancel: cancel, bootnodePeers: bootnodeMap}
+
 	// Register peer connection/disconnection notification handler for metrics and logging.
 	h.Network().Notify(&libp2pnetwork.NotifyBundle{
 		ConnectedF: func(n libp2pnetwork.Network, conn libp2pnetwork.Conn) {
@@ -126,21 +137,36 @@ func NewHost(listenAddr string, nodeKeyPath string, bootnodes []string) (*Host, 
 			)
 		},
 		DisconnectedF: func(n libp2pnetwork.Network, conn libp2pnetwork.Conn) {
+			pid := conn.RemotePeer()
 			dir := "inbound"
 			if conn.Stat().Direction == libp2pnetwork.DirOutbound {
 				dir = "outbound"
 			}
 			metrics.PeerDisconnectionEventsTotal.WithLabelValues(dir, "remote_close").Inc()
 			netLog.Info("peer disconnected",
-				"peer_id", conn.RemotePeer().String(),
+				"peer_id", pid.String(),
 				"direction", dir,
 				"remote_addr", conn.RemoteMultiaddr().String(),
 				"peers", len(n.Peers()),
 			)
+
+			// Schedule bootnode redial after delay.
+			if ai, ok := hostWrapper.bootnodePeers[pid]; ok {
+				go func() {
+					time.Sleep(bootnodeRedialDelay)
+					if n.Connectedness(pid) == libp2pnetwork.Connected {
+						return
+					}
+					netLog.Info("redialing disconnected bootnode", "peer_id", pid.String())
+					if err := h.Connect(ctx, ai); err != nil {
+						netLog.Warn("bootnode redial failed", "peer_id", pid.String(), "err", err)
+					}
+				}()
+			}
 		},
 	})
 
-	return &Host{P2P: h, PubSub: gs, Ctx: ctx, Cancel: cancel}, nil
+	return hostWrapper, nil
 }
 
 // Close shuts down the host.

--- a/node/handler.go
+++ b/node/handler.go
@@ -56,34 +56,27 @@ func (n *Node) registerGossipHandlers() error {
 			if err := n.FC.ProcessBlock(sb); err != nil {
 				status := n.FC.GetStatus()
 				if isMissingParentStateErr(err) {
-					gossipLog.Warn("parent state missing for gossip block, attempting recovery",
-						"slot", block.Slot,
-						"block_root", logging.LongHash(blockRoot),
-						"parent_root", logging.LongHash(block.ParentRoot),
-						"head_slot", status.HeadSlot,
-						"finalized_slot", status.FinalizedSlot,
-					)
-					if n.recoverMissingParentSync(n.Host.Ctx, block.ParentRoot) {
-						if retryErr := n.FC.ProcessBlock(sb); retryErr == nil {
-							gossipLog.Info("accepted gossip block after parent recovery",
-								"slot", block.Slot,
-								"block_root", logging.LongHash(blockRoot),
-							)
-							// Process any pending children now that this block is available.
-							n.processPendingChildren(blockRoot, gossipLog)
-							return
-						} else {
-							err = retryErr
-						}
-					}
-					// Cache the block for later processing when parent becomes available.
+					// Cache immediately so the block isn't lost.
 					n.PendingBlocks.Add(sb)
-					gossipLog.Info("cached pending block awaiting parent",
+					gossipLog.Info("cached pending block, recovering parent async",
 						"slot", block.Slot,
 						"block_root", logging.LongHash(blockRoot),
 						"parent_root", logging.LongHash(block.ParentRoot),
 						"pending_count", n.PendingBlocks.Len(),
 					)
+					// Recover in background to avoid blocking the gossip goroutine.
+					go func() {
+						if n.recoverMissingParentSync(n.Host.Ctx, block.ParentRoot) {
+							if retryErr := n.FC.ProcessBlock(sb); retryErr == nil {
+								gossipLog.Info("accepted gossip block after parent recovery",
+									"slot", block.Slot,
+									"block_root", logging.LongHash(blockRoot),
+								)
+								n.PendingBlocks.Remove(blockRoot)
+								n.processPendingChildren(blockRoot, gossipLog)
+							}
+						}
+					}()
 					return
 				}
 				gossipLog.Warn("rejected gossip block",

--- a/node/handler.go
+++ b/node/handler.go
@@ -115,33 +115,38 @@ func (n *Node) registerGossipHandlers() error {
 	return nil
 }
 
-// processPendingChildren processes any cached blocks that were waiting for this parent.
-// This implements the leanSpec requirement to process cached blocks when their parent arrives.
+// processPendingChildren processes cached blocks whose parent became available.
+// Uses iterative queue to avoid stack overflow from deep chains.
 func (n *Node) processPendingChildren(parentRoot [32]byte, log *slog.Logger) {
-	children := n.PendingBlocks.GetChildrenOf(parentRoot)
-	for _, sb := range children {
-		block := sb.Message.Block
-		blockRoot, _ := block.HashTreeRoot()
+	queue := [][32]byte{parentRoot}
 
-		if err := n.FC.ProcessBlock(sb); err != nil {
-			// Still can't process - may be missing a deeper ancestor.
-			log.Debug("pending child still not processable",
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+
+		children := n.PendingBlocks.GetChildrenOf(current)
+		for _, sb := range children {
+			block := sb.Message.Block
+			blockRoot, _ := block.HashTreeRoot()
+
+			if err := n.FC.ProcessBlock(sb); err != nil {
+				log.Debug("pending child still not processable",
+					"slot", block.Slot,
+					"block_root", logging.LongHash(blockRoot),
+					"err", err,
+				)
+				continue
+			}
+
+			n.PendingBlocks.Remove(blockRoot)
+			log.Info("processed pending child block",
 				"slot", block.Slot,
 				"block_root", logging.LongHash(blockRoot),
-				"err", err,
+				"parent_root", logging.LongHash(current),
 			)
-			continue
+
+			// Enqueue this block's children for processing.
+			queue = append(queue, blockRoot)
 		}
-
-		// Successfully processed - remove from pending and recurse.
-		n.PendingBlocks.Remove(blockRoot)
-		log.Info("processed pending child block",
-			"slot", block.Slot,
-			"block_root", logging.LongHash(blockRoot),
-			"parent_root", logging.LongHash(parentRoot),
-		)
-
-		// Recursively process any children of this block.
-		n.processPendingChildren(blockRoot, log)
 	}
 }

--- a/node/handler.go
+++ b/node/handler.go
@@ -56,27 +56,16 @@ func (n *Node) registerGossipHandlers() error {
 			if err := n.FC.ProcessBlock(sb); err != nil {
 				status := n.FC.GetStatus()
 				if isMissingParentStateErr(err) {
-					// Cache immediately so the block isn't lost.
+					// Cache the block and request the missing parent asynchronously.
+					// The fetcher deduplicates and retries with backoff.
 					n.PendingBlocks.Add(sb)
-					gossipLog.Info("cached pending block, recovering parent async",
+					n.Fetcher.fetchBlock(n.Host.Ctx, block.ParentRoot)
+					gossipLog.Info("cached pending block, fetching parent",
 						"slot", block.Slot,
 						"block_root", logging.LongHash(blockRoot),
 						"parent_root", logging.LongHash(block.ParentRoot),
 						"pending_count", n.PendingBlocks.Len(),
 					)
-					// Recover in background to avoid blocking the gossip goroutine.
-					go func() {
-						if n.recoverMissingParentSync(n.Host.Ctx, block.ParentRoot) {
-							if retryErr := n.FC.ProcessBlock(sb); retryErr == nil {
-								gossipLog.Info("accepted gossip block after parent recovery",
-									"slot", block.Slot,
-									"block_root", logging.LongHash(blockRoot),
-								)
-								n.PendingBlocks.Remove(blockRoot)
-								n.processPendingChildren(blockRoot, gossipLog)
-							}
-						}
-					}()
 					return
 				}
 				gossipLog.Warn("rejected gossip block",

--- a/node/lifecycle.go
+++ b/node/lifecycle.go
@@ -80,10 +80,11 @@ func New(cfg Config) (*Node, error) {
 		P2PManager:    p2pManager,
 		P2PDiscovery:  p2pDiscovery,
 		PendingBlocks: NewPendingBlockCache(),
-		syncingRoots:  make(map[[32]byte]time.Time),
 		dbCloser:      db,
 		log:           log,
 	}
+
+	n.Fetcher = newBlockFetcher(n)
 
 	// Register req/resp handlers for sync. Gossip handlers are registered
 	// before initial sync in ticker.go so blocks arriving during sync are

--- a/node/lifecycle.go
+++ b/node/lifecycle.go
@@ -80,6 +80,7 @@ func New(cfg Config) (*Node, error) {
 		P2PManager:    p2pManager,
 		P2PDiscovery:  p2pDiscovery,
 		PendingBlocks: NewPendingBlockCache(),
+		syncingRoots:  make(map[[32]byte]time.Time),
 		dbCloser:      db,
 		log:           log,
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"io"
 	"log/slog"
-	"sync"
-	"time"
 
 	apiserver "github.com/geanlabs/gean/api/server"
 	"github.com/geanlabs/gean/chain/forkchoice"
@@ -32,9 +30,8 @@ type Node struct {
 	// PendingBlocks caches blocks awaiting parent availability.
 	PendingBlocks *PendingBlockCache
 
-	// syncingRoots tracks roots currently being fetched to prevent duplicate requests.
-	syncMu       sync.Mutex
-	syncingRoots map[[32]byte]time.Time
+	// Fetcher manages root-targeted block fetching with dedup and backoff.
+	Fetcher *blockFetcher
 
 	Clock    *Clock
 	dbCloser io.Closer

--- a/node/node.go
+++ b/node/node.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"sync"
+	"time"
 
 	apiserver "github.com/geanlabs/gean/api/server"
 	"github.com/geanlabs/gean/chain/forkchoice"
@@ -29,6 +31,10 @@ type Node struct {
 
 	// PendingBlocks caches blocks awaiting parent availability.
 	PendingBlocks *PendingBlockCache
+
+	// syncingRoots tracks roots currently being fetched to prevent duplicate requests.
+	syncMu       sync.Mutex
+	syncingRoots map[[32]byte]time.Time
 
 	Clock    *Clock
 	dbCloser io.Closer

--- a/node/sync.go
+++ b/node/sync.go
@@ -2,26 +2,227 @@ package node
 
 import (
 	"context"
-	"fmt"
+	"log/slog"
 	"math/rand"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/geanlabs/gean/chain/forkchoice"
-	"github.com/geanlabs/gean/observability/logging"
-	"github.com/libp2p/go-libp2p/core/peer"
-
 	"github.com/geanlabs/gean/network/reqresp"
+	"github.com/geanlabs/gean/observability/logging"
 	"github.com/geanlabs/gean/types"
+	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 func isMissingParentStateErr(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "parent state not found")
 }
 
+const (
+	maxFetchRetries   = 10
+	initialBackoffMs  = 5
+	backoffMultiplier = 2
+	maxFetchDepth     = 512
+)
+
+// pendingFetch tracks an in-flight block fetch with retry state.
+type pendingFetch struct {
+	attempts    int
+	failedPeers map[peer.ID]struct{}
+}
+
+// blockFetcher manages root-targeted block fetching with dedup, backoff, and
+// per-peer failure tracking. Modeled after ethlambda's P2P fetch orchestration.
+type blockFetcher struct {
+	mu      sync.Mutex
+	pending map[[32]byte]*pendingFetch
+	node    *Node
+	log     *slog.Logger
+}
+
+func newBlockFetcher(n *Node) *blockFetcher {
+	return &blockFetcher{
+		pending: make(map[[32]byte]*pendingFetch),
+		node:    n,
+		log:     logging.NewComponentLogger(logging.CompNode),
+	}
+}
+
+// fetchBlock requests a specific block root from the network.
+// Deduplicates: if the root is already being fetched, this is a no-op.
+func (bf *blockFetcher) fetchBlock(ctx context.Context, root [32]byte) {
+	bf.mu.Lock()
+	if _, ok := bf.pending[root]; ok {
+		bf.mu.Unlock()
+		return
+	}
+	bf.pending[root] = &pendingFetch{
+		failedPeers: make(map[peer.ID]struct{}),
+	}
+	bf.mu.Unlock()
+
+	go bf.fetchWithRetry(ctx, root)
+}
+
+// fetchWithRetry attempts to fetch a block root with exponential backoff.
+func (bf *blockFetcher) fetchWithRetry(ctx context.Context, root [32]byte) {
+	for {
+		bf.mu.Lock()
+		pf, ok := bf.pending[root]
+		if !ok {
+			bf.mu.Unlock()
+			return // resolved externally
+		}
+		if pf.attempts >= maxFetchRetries {
+			bf.log.Warn("block fetch failed after max retries",
+				"root", logging.LongHash(root),
+				"attempts", pf.attempts,
+			)
+			delete(bf.pending, root)
+			bf.mu.Unlock()
+			return
+		}
+		pf.attempts++
+		attempts := pf.attempts
+		failedPeers := make(map[peer.ID]struct{}, len(pf.failedPeers))
+		for p := range pf.failedPeers {
+			failedPeers[p] = struct{}{}
+		}
+		bf.mu.Unlock()
+
+		// Backoff: 5ms, 10ms, 20ms, 40ms, ...
+		if attempts > 1 {
+			backoff := time.Duration(initialBackoffMs) * time.Millisecond
+			for i := 1; i < attempts; i++ {
+				backoff *= time.Duration(backoffMultiplier)
+			}
+			select {
+			case <-time.After(backoff):
+			case <-ctx.Done():
+				return
+			}
+		}
+
+		// Check if resolved during backoff.
+		if bf.node.FC.HasState(root) {
+			bf.resolve(root)
+			return
+		}
+
+		// Select a random peer, excluding failed ones.
+		pid, ok := bf.selectPeer(failedPeers)
+		if !ok {
+			// All peers failed — reset and retry with full pool.
+			bf.mu.Lock()
+			if pf, ok := bf.pending[root]; ok {
+				pf.failedPeers = make(map[peer.ID]struct{})
+			}
+			bf.mu.Unlock()
+			continue
+		}
+
+		blocks, err := reqresp.RequestBlocksByRoot(ctx, bf.node.Host.P2P, pid, [][32]byte{root})
+		if err != nil || len(blocks) == 0 {
+			bf.mu.Lock()
+			if pf, ok := bf.pending[root]; ok {
+				pf.failedPeers[pid] = struct{}{}
+			}
+			bf.mu.Unlock()
+			continue
+		}
+
+		sb := blocks[0]
+		bf.resolve(root)
+
+		// Process the block. If its parent is also missing, that will trigger
+		// another fetchBlock call — the chain walks itself.
+		if err := bf.node.FC.ProcessBlock(sb); err != nil {
+			if isMissingParentStateErr(err) {
+				bf.node.PendingBlocks.Add(sb)
+				bf.fetchBlock(ctx, sb.Message.Block.ParentRoot)
+			}
+			return
+		}
+
+		blockRoot, _ := sb.Message.Block.HashTreeRoot()
+		bf.log.Info("fetched block",
+			"slot", sb.Message.Block.Slot,
+			"block_root", logging.LongHash(blockRoot),
+			"peer_id", pid.String(),
+		)
+		bf.node.processPendingChildren(blockRoot, bf.log)
+		return
+	}
+}
+
+func (bf *blockFetcher) selectPeer(excluded map[peer.ID]struct{}) (peer.ID, bool) {
+	peers := bf.node.Host.P2P.Network().Peers()
+	if len(peers) == 0 {
+		return "", false
+	}
+
+	// Filter out excluded peers.
+	var pool []peer.ID
+	for _, p := range peers {
+		if _, failed := excluded[p]; !failed {
+			pool = append(pool, p)
+		}
+	}
+	if len(pool) == 0 {
+		return "", false
+	}
+
+	return pool[rand.Intn(len(pool))], true
+}
+
+func (bf *blockFetcher) resolve(root [32]byte) {
+	bf.mu.Lock()
+	delete(bf.pending, root)
+	bf.mu.Unlock()
+}
+
+// fetchParentChain fetches missing ancestors for a block, walking backwards
+// from parentRoot up to maxFetchDepth. Returns true if the parent state became
+// available (either it was already known or was fetched synchronously).
+// Used by initialSync and ticker sync where we need blocking behavior.
+func (n *Node) fetchParentChain(ctx context.Context, pid peer.ID, parentRoot [32]byte) bool {
+	nextRoot := parentRoot
+	var pending []*types.SignedBlockWithAttestation
+
+	for i := 0; i < maxFetchDepth; i++ {
+		if n.FC.HasState(nextRoot) {
+			break
+		}
+
+		blocks, err := reqresp.RequestBlocksByRoot(ctx, n.Host.P2P, pid, [][32]byte{nextRoot})
+		if err != nil || len(blocks) == 0 {
+			break
+		}
+
+		sb := blocks[0]
+		pending = append(pending, sb)
+		nextRoot = sb.Message.Block.ParentRoot
+	}
+
+	if !n.FC.HasState(nextRoot) {
+		return false
+	}
+
+	// Process in forward order (oldest first).
+	for i := len(pending) - 1; i >= 0; i-- {
+		if err := n.FC.ProcessBlock(pending[i]); err != nil {
+			n.log.Debug("sync block rejected",
+				"slot", pending[i].Message.Block.Slot,
+				"err", err,
+			)
+		}
+	}
+	return true
+}
+
 // syncWithPeer exchanges status and fetches missing blocks from a single peer.
-// It walks backwards from the peer's head to find blocks we're missing, then
-// processes them in forward order.
+// Uses root-targeted fetch: walks from peer head backward until a known state is found.
 func (n *Node) syncWithPeer(ctx context.Context, pid peer.ID) bool {
 	status := n.FC.GetStatus()
 	ourStatus := reqresp.Status{
@@ -46,9 +247,6 @@ func (n *Node) syncWithPeer(ctx context.Context, pid peer.ID) bool {
 		"peer_finalized_root", logging.LongHash(peerStatus.Finalized.Root),
 	)
 
-	// Skip sync only if peer is strictly behind us, or at the exact same position.
-	// If peer is at the same slot but with a different head root, we should still
-	// sync to ensure we have their chain (potential re-org or fork).
 	if peerStatus.Head.Slot < status.HeadSlot {
 		return false
 	}
@@ -56,128 +254,7 @@ func (n *Node) syncWithPeer(ctx context.Context, pid peer.ID) bool {
 		return false
 	}
 
-	// Walk backwards: request blocks we don't have, collecting roots to fetch.
-	var pending []*types.SignedBlockWithAttestation
-	nextRoot := peerStatus.Head.Root
-	// Late-join nodes can be hundreds of slots behind. Use a backlog-sized walk
-	// rather than a fixed depth, otherwise we only fetch a disconnected suffix.
-	backlog := uint64(1)
-	if peerStatus.Head.Slot > status.HeadSlot {
-		backlog = peerStatus.Head.Slot - status.HeadSlot
-	}
-	maxSyncDepth := int(backlog + 16)
-	const maxSyncDepthCap = 512
-	if maxSyncDepth > maxSyncDepthCap {
-		maxSyncDepth = maxSyncDepthCap
-	}
-
-	for i := 0; i < maxSyncDepth; i++ {
-		// Check for state existence, not just block. ProcessBlock requires the
-		// parent state to succeed, so we need to walk back until we find a root
-		// for which we have the state.
-		if n.FC.HasState(nextRoot) {
-			break // We have state for this block, chain is connected.
-		}
-
-		blocks, err := reqresp.RequestBlocksByRoot(ctx, n.Host.P2P, pid, [][32]byte{nextRoot})
-		if err != nil || len(blocks) == 0 {
-			n.log.Debug("blocks_by_root failed during sync walk",
-				"peer_id", pid.String(),
-				"requested_root", logging.LongHash(nextRoot),
-				"err", err,
-			)
-			break
-		}
-
-		sb := blocks[0]
-		pending = append(pending, sb)
-		nextRoot = sb.Message.Block.ParentRoot
-	}
-
-	// If we could not reach any known ancestor with state, imported blocks would
-	// fail with "parent state not found".
-	if !n.FC.HasState(nextRoot) {
-		n.log.Debug("sync walk did not reach known ancestor with state",
-			"peer_id", pid.String(),
-			"ancestor_root", logging.LongHash(nextRoot),
-			"fetched", len(pending),
-			"max_depth", maxSyncDepth,
-		)
-		return false
-	}
-
-	// Process in forward order (oldest first).
-	synced := 0
-	total := len(pending)
-	for i := len(pending) - 1; i >= 0; i-- {
-		sb := pending[i]
-		blockRoot, _ := sb.Message.Block.HashTreeRoot()
-		if err := n.FC.ProcessBlock(sb); err != nil {
-			n.log.Debug("sync block rejected",
-				"slot", sb.Message.Block.Slot,
-				"block_root", logging.LongHash(blockRoot),
-				"err", err,
-			)
-		} else {
-			synced++
-			n.log.Info("synced block",
-				"slot", sb.Message.Block.Slot,
-				"block_root", logging.LongHash(blockRoot),
-				"peer_id", pid.String(),
-				"progress", fmt.Sprintf("%d/%d", synced, total),
-			)
-		}
-	}
-	return synced > 0
-}
-
-const (
-	syncCooldown     = 5 * time.Second
-	maxRecoveryPeers = 3
-)
-
-// recoverMissingParentSync attempts to fill a missing parent chain by syncing with
-// a few random peers, then checks whether the requested parent state became available.
-// Deduplicates concurrent requests for the same root via syncingRoots.
-func (n *Node) recoverMissingParentSync(ctx context.Context, parentRoot [32]byte) bool {
-	if n.FC.HasState(parentRoot) {
-		return true
-	}
-
-	// Skip if this root was recently attempted. Let the TTL expire naturally
-	// so rapid re-triggers after failure are throttled.
-	n.syncMu.Lock()
-	now := time.Now()
-	for root, t := range n.syncingRoots {
-		if now.Sub(t) >= syncCooldown {
-			delete(n.syncingRoots, root)
-		}
-	}
-	if t, ok := n.syncingRoots[parentRoot]; ok && now.Sub(t) < syncCooldown {
-		n.syncMu.Unlock()
-		return false
-	}
-	n.syncingRoots[parentRoot] = now
-	n.syncMu.Unlock()
-
-	peers := n.Host.P2P.Network().Peers()
-	if len(peers) == 0 {
-		return false
-	}
-
-	// Shuffle and try up to maxRecoveryPeers.
-	rand.Shuffle(len(peers), func(i, j int) { peers[i], peers[j] = peers[j], peers[i] })
-	if len(peers) > maxRecoveryPeers {
-		peers = peers[:maxRecoveryPeers]
-	}
-
-	for _, pid := range peers {
-		n.syncWithPeer(ctx, pid)
-		if n.FC.HasState(parentRoot) {
-			return true
-		}
-	}
-	return false
+	return n.fetchParentChain(ctx, pid, peerStatus.Head.Root)
 }
 
 // initialSync exchanges status with connected peers and requests any blocks
@@ -200,8 +277,7 @@ func (n *Node) initialSync(ctx context.Context) {
 }
 
 // isBehindPeers reports whether our head is behind the highest head slot
-// advertised by connected peers. This fires even when finalization is stalled,
-// ensuring we sync from peers who have blocks we haven't yet received via gossip.
+// advertised by connected peers.
 func (n *Node) isBehindPeers(ctx context.Context, status forkchoice.ChainStatus) (bool, uint64) {
 	maxPeerHeadSlot := status.HeadSlot
 	peers := n.Host.P2P.Network().Peers()
@@ -226,6 +302,5 @@ func (n *Node) isBehindPeers(ctx context.Context, status forkchoice.ChainStatus)
 		}
 	}
 
-	behind := status.HeadSlot < maxPeerHeadSlot
-	return behind, maxPeerHeadSlot
+	return status.HeadSlot < maxPeerHeadSlot, maxPeerHeadSlot
 }

--- a/node/sync.go
+++ b/node/sync.go
@@ -100,6 +100,7 @@ func (bf *blockFetcher) fetchWithRetry(ctx context.Context, root [32]byte) {
 			select {
 			case <-time.After(backoff):
 			case <-ctx.Done():
+				bf.resolve(root)
 				return
 			}
 		}
@@ -133,6 +134,14 @@ func (bf *blockFetcher) fetchWithRetry(ctx context.Context, root [32]byte) {
 		}
 
 		sb := blocks[0]
+		if sb == nil || sb.Message == nil || sb.Message.Block == nil {
+			bf.mu.Lock()
+			if pf, ok := bf.pending[root]; ok {
+				pf.failedPeers[pid] = struct{}{}
+			}
+			bf.mu.Unlock()
+			continue
+		}
 		blockRoot, _ := sb.Message.Block.HashTreeRoot()
 		if blockRoot != root {
 			bf.log.Warn("fetched block root mismatch, ignoring",
@@ -214,6 +223,9 @@ func (n *Node) fetchParentChain(ctx context.Context, pid peer.ID, parentRoot [32
 		}
 
 		sb := blocks[0]
+		if sb == nil || sb.Message == nil || sb.Message.Block == nil {
+			break
+		}
 		blockRoot, _ := sb.Message.Block.HashTreeRoot()
 		if blockRoot != nextRoot {
 			n.log.Warn("fetched block root mismatch, aborting sync walk",
@@ -253,7 +265,7 @@ func (n *Node) syncWithPeer(ctx context.Context, pid peer.ID) bool {
 	}
 
 	peerStatus, err := reqresp.RequestStatus(ctx, n.Host.P2P, pid, ourStatus)
-	if err != nil {
+	if err != nil || peerStatus.Head == nil || peerStatus.Finalized == nil {
 		n.log.Debug("status exchange failed", "peer_id", pid.String(), "err", err)
 		return false
 	}

--- a/node/sync.go
+++ b/node/sync.go
@@ -133,6 +133,20 @@ func (bf *blockFetcher) fetchWithRetry(ctx context.Context, root [32]byte) {
 		}
 
 		sb := blocks[0]
+		blockRoot, _ := sb.Message.Block.HashTreeRoot()
+		if blockRoot != root {
+			bf.log.Warn("fetched block root mismatch, ignoring",
+				"requested", logging.LongHash(root),
+				"received", logging.LongHash(blockRoot),
+				"peer_id", pid.String(),
+			)
+			bf.mu.Lock()
+			if pf, ok := bf.pending[root]; ok {
+				pf.failedPeers[pid] = struct{}{}
+			}
+			bf.mu.Unlock()
+			continue
+		}
 		bf.resolve(root)
 
 		// Process the block. If its parent is also missing, that will trigger
@@ -145,7 +159,6 @@ func (bf *blockFetcher) fetchWithRetry(ctx context.Context, root [32]byte) {
 			return
 		}
 
-		blockRoot, _ := sb.Message.Block.HashTreeRoot()
 		bf.log.Info("fetched block",
 			"slot", sb.Message.Block.Slot,
 			"block_root", logging.LongHash(blockRoot),
@@ -201,6 +214,15 @@ func (n *Node) fetchParentChain(ctx context.Context, pid peer.ID, parentRoot [32
 		}
 
 		sb := blocks[0]
+		blockRoot, _ := sb.Message.Block.HashTreeRoot()
+		if blockRoot != nextRoot {
+			n.log.Warn("fetched block root mismatch, aborting sync walk",
+				"requested", logging.LongHash(nextRoot),
+				"received", logging.LongHash(blockRoot),
+				"peer_id", pid.String(),
+			)
+			break
+		}
 		pending = append(pending, sb)
 		nextRoot = sb.Message.Block.ParentRoot
 	}

--- a/node/sync.go
+++ b/node/sync.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"strings"
 	"time"
 
@@ -65,7 +66,7 @@ func (n *Node) syncWithPeer(ctx context.Context, pid peer.ID) bool {
 		backlog = peerStatus.Head.Slot - status.HeadSlot
 	}
 	maxSyncDepth := int(backlog + 16)
-	const maxSyncDepthCap = 32768
+	const maxSyncDepthCap = 128
 	if maxSyncDepth > maxSyncDepthCap {
 		maxSyncDepth = maxSyncDepthCap
 	}
@@ -130,14 +131,46 @@ func (n *Node) syncWithPeer(ctx context.Context, pid peer.ID) bool {
 	return synced > 0
 }
 
+const (
+	syncCooldown     = 5 * time.Second
+	maxRecoveryPeers = 3
+)
+
 // recoverMissingParentSync attempts to fill a missing parent chain by syncing with
-// connected peers, then checks whether the requested parent state became available.
+// a few random peers, then checks whether the requested parent state became available.
+// Deduplicates concurrent requests for the same root via syncingRoots.
 func (n *Node) recoverMissingParentSync(ctx context.Context, parentRoot [32]byte) bool {
 	if n.FC.HasState(parentRoot) {
 		return true
 	}
 
-	for _, pid := range n.Host.P2P.Network().Peers() {
+	// Skip if another goroutine is already recovering this root.
+	n.syncMu.Lock()
+	if t, ok := n.syncingRoots[parentRoot]; ok && time.Since(t) < syncCooldown {
+		n.syncMu.Unlock()
+		return false
+	}
+	n.syncingRoots[parentRoot] = time.Now()
+	n.syncMu.Unlock()
+
+	defer func() {
+		n.syncMu.Lock()
+		delete(n.syncingRoots, parentRoot)
+		n.syncMu.Unlock()
+	}()
+
+	peers := n.Host.P2P.Network().Peers()
+	if len(peers) == 0 {
+		return false
+	}
+
+	// Shuffle and try up to maxRecoveryPeers.
+	rand.Shuffle(len(peers), func(i, j int) { peers[i], peers[j] = peers[j], peers[i] })
+	if len(peers) > maxRecoveryPeers {
+		peers = peers[:maxRecoveryPeers]
+	}
+
+	for _, pid := range peers {
 		n.syncWithPeer(ctx, pid)
 		if n.FC.HasState(parentRoot) {
 			return true

--- a/node/sync.go
+++ b/node/sync.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/geanlabs/gean/chain/forkchoice"
 	"github.com/geanlabs/gean/network/reqresp"
 	"github.com/geanlabs/gean/observability/logging"
 	"github.com/geanlabs/gean/types"
@@ -308,33 +307,4 @@ func (n *Node) initialSync(ctx context.Context) {
 		"finalized_slot", status.FinalizedSlot,
 		"finalized_root", logging.LongHash(status.FinalizedRoot),
 	)
-}
-
-// isBehindPeers reports whether our head is behind the highest head slot
-// advertised by connected peers.
-func (n *Node) isBehindPeers(ctx context.Context, status forkchoice.ChainStatus) (bool, uint64) {
-	maxPeerHeadSlot := status.HeadSlot
-	peers := n.Host.P2P.Network().Peers()
-	if len(peers) == 0 {
-		return false, maxPeerHeadSlot
-	}
-
-	ourStatus := reqresp.Status{
-		Finalized: &types.Checkpoint{Root: status.FinalizedRoot, Slot: status.FinalizedSlot},
-		Head:      &types.Checkpoint{Root: status.Head, Slot: status.HeadSlot},
-	}
-
-	for _, pid := range peers {
-		peerCtx, cancel := context.WithTimeout(ctx, 1200*time.Millisecond)
-		peerStatus, err := reqresp.RequestStatus(peerCtx, n.Host.P2P, pid, ourStatus)
-		cancel()
-		if err != nil || peerStatus.Head == nil {
-			continue
-		}
-		if peerStatus.Head.Slot > maxPeerHeadSlot {
-			maxPeerHeadSlot = peerStatus.Head.Slot
-		}
-	}
-
-	return status.HeadSlot < maxPeerHeadSlot, maxPeerHeadSlot
 }

--- a/node/sync.go
+++ b/node/sync.go
@@ -66,7 +66,7 @@ func (n *Node) syncWithPeer(ctx context.Context, pid peer.ID) bool {
 		backlog = peerStatus.Head.Slot - status.HeadSlot
 	}
 	maxSyncDepth := int(backlog + 16)
-	const maxSyncDepthCap = 128
+	const maxSyncDepthCap = 512
 	if maxSyncDepth > maxSyncDepthCap {
 		maxSyncDepth = maxSyncDepthCap
 	}
@@ -144,20 +144,21 @@ func (n *Node) recoverMissingParentSync(ctx context.Context, parentRoot [32]byte
 		return true
 	}
 
-	// Skip if another goroutine is already recovering this root.
+	// Skip if this root was recently attempted. Let the TTL expire naturally
+	// so rapid re-triggers after failure are throttled.
 	n.syncMu.Lock()
-	if t, ok := n.syncingRoots[parentRoot]; ok && time.Since(t) < syncCooldown {
+	now := time.Now()
+	for root, t := range n.syncingRoots {
+		if now.Sub(t) >= syncCooldown {
+			delete(n.syncingRoots, root)
+		}
+	}
+	if t, ok := n.syncingRoots[parentRoot]; ok && now.Sub(t) < syncCooldown {
 		n.syncMu.Unlock()
 		return false
 	}
-	n.syncingRoots[parentRoot] = time.Now()
+	n.syncingRoots[parentRoot] = now
 	n.syncMu.Unlock()
-
-	defer func() {
-		n.syncMu.Lock()
-		delete(n.syncingRoots, parentRoot)
-		n.syncMu.Unlock()
-	}()
 
 	peers := n.Host.P2P.Network().Peers()
 	if len(peers) == 0 {

--- a/node/ticker.go
+++ b/node/ticker.go
@@ -6,8 +6,10 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/geanlabs/gean/network/reqresp"
 	"github.com/geanlabs/gean/observability/logging"
 	"github.com/geanlabs/gean/observability/metrics"
+	"github.com/geanlabs/gean/types"
 )
 
 // Run starts the main event loop.
@@ -72,12 +74,22 @@ func (n *Node) Run(ctx context.Context) error {
 		if slot != lastSyncCheckSlot {
 			behindPeers, maxPeerHeadSlot = n.isBehindPeers(ctx, status)
 			if behindPeers {
+				// Fetch peer head via the async fetcher to avoid blocking the event loop.
 				if peers := n.Host.P2P.Network().Peers(); len(peers) > 0 {
 					pid := peers[rand.Intn(len(peers))]
-					if n.syncWithPeer(ctx, pid) {
-						status = n.FC.GetStatus()
+					peerCtx, cancel := context.WithTimeout(ctx, 1200*time.Millisecond)
+					ourStatus := n.FC.GetStatus()
+					peerStatus, err := reqresp.RequestStatus(peerCtx, n.Host.P2P, pid, reqresp.Status{
+						Finalized: &types.Checkpoint{Root: ourStatus.FinalizedRoot, Slot: ourStatus.FinalizedSlot},
+						Head:      &types.Checkpoint{Root: ourStatus.Head, Slot: ourStatus.HeadSlot},
+					})
+					cancel()
+					if err == nil && peerStatus.Head != nil && peerStatus.Head.Slot > ourStatus.HeadSlot {
+						n.Fetcher.fetchBlock(ctx, peerStatus.Head.Root)
 					}
 				}
+				// Re-check after giving fetcher a chance to resolve.
+				status = n.FC.GetStatus()
 				behindPeers, maxPeerHeadSlot = n.isBehindPeers(ctx, status)
 				if behindPeers {
 					n.log.Warn(

--- a/node/ticker.go
+++ b/node/ticker.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"time"
 
 	"github.com/geanlabs/gean/observability/logging"
@@ -71,7 +72,8 @@ func (n *Node) Run(ctx context.Context) error {
 		if slot != lastSyncCheckSlot {
 			behindPeers, maxPeerHeadSlot = n.isBehindPeers(ctx, status)
 			if behindPeers {
-				for _, pid := range n.Host.P2P.Network().Peers() {
+				if peers := n.Host.P2P.Network().Peers(); len(peers) > 0 {
+					pid := peers[rand.Intn(len(peers))]
 					if n.syncWithPeer(ctx, pid) {
 						status = n.FC.GetStatus()
 					}

--- a/node/ticker.go
+++ b/node/ticker.go
@@ -62,16 +62,10 @@ func (n *Node) Run(ctx context.Context) error {
 		// Advance fork choice time.
 		n.FC.AdvanceTimeMillis(n.Clock.CurrentTime(), hasProposal)
 
-		// Execute validator duties on the clock.
-		// Aggregation (interval 2) runs in a background goroutine because
-		// proof building takes 1-6 seconds — longer than the 800ms interval.
-		// This matches Lantern's approach of running aggregation off the
-		// main thread so the tick loop continues to interval 3 on time.
-		if interval == 2 && n.Validator.IsAggregator {
-			go n.Validator.OnInterval(ctx, slot, interval)
-		} else {
-			n.Validator.OnInterval(ctx, slot, interval)
-		}
+		// Always execute validator duties on the clock.
+		// No sync gating — matches ethlambda/leanSpec. Gossip delivers blocks,
+		// the fetcher handles missing parents asynchronously.
+		n.Validator.OnInterval(ctx, slot, interval)
 
 		// Update metrics and log on slot boundary.
 		if slot != lastLogSlot {

--- a/node/ticker.go
+++ b/node/ticker.go
@@ -3,13 +3,10 @@ package node
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"time"
 
-	"github.com/geanlabs/gean/network/reqresp"
 	"github.com/geanlabs/gean/observability/logging"
 	"github.com/geanlabs/gean/observability/metrics"
-	"github.com/geanlabs/gean/types"
 )
 
 // Run starts the main event loop.
@@ -30,10 +27,7 @@ func (n *Node) Run(ctx context.Context) error {
 	n.initialSync(ctx)
 	n.log.Info("initial sync completed")
 
-	var lastSyncCheckSlot uint64 = ^uint64(0)
 	var lastLogSlot uint64 = ^uint64(0)
-	behindPeers := false
-	maxPeerHeadSlot := uint64(0)
 
 	for {
 		wait := n.Clock.DurationUntilNextInterval()
@@ -68,52 +62,16 @@ func (n *Node) Run(ctx context.Context) error {
 		// Advance fork choice time.
 		n.FC.AdvanceTimeMillis(n.Clock.CurrentTime(), hasProposal)
 
-		status := n.FC.GetStatus()
-
-		// Re-evaluate sync gating once per slot using peer head status.
-		if slot != lastSyncCheckSlot {
-			behindPeers, maxPeerHeadSlot = n.isBehindPeers(ctx, status)
-			if behindPeers {
-				// Fetch peer head via the async fetcher to avoid blocking the event loop.
-				if peers := n.Host.P2P.Network().Peers(); len(peers) > 0 {
-					pid := peers[rand.Intn(len(peers))]
-					peerCtx, cancel := context.WithTimeout(ctx, 1200*time.Millisecond)
-					ourStatus := n.FC.GetStatus()
-					peerStatus, err := reqresp.RequestStatus(peerCtx, n.Host.P2P, pid, reqresp.Status{
-						Finalized: &types.Checkpoint{Root: ourStatus.FinalizedRoot, Slot: ourStatus.FinalizedSlot},
-						Head:      &types.Checkpoint{Root: ourStatus.Head, Slot: ourStatus.HeadSlot},
-					})
-					cancel()
-					if err == nil && peerStatus.Head != nil && peerStatus.Head.Slot > ourStatus.HeadSlot {
-						n.Fetcher.fetchBlock(ctx, peerStatus.Head.Root)
-					}
-				}
-				// Re-check after giving fetcher a chance to resolve.
-				status = n.FC.GetStatus()
-				behindPeers, maxPeerHeadSlot = n.isBehindPeers(ctx, status)
-				if behindPeers {
-					n.log.Warn(
-						"skipping validator duties while behind peers",
-						"slot", slot,
-						"head_slot", status.HeadSlot,
-						"finalized_slot", status.FinalizedSlot,
-						"max_peer_head_slot", maxPeerHeadSlot,
-					)
-				}
-			}
-			lastSyncCheckSlot = slot
-		}
-
-		// Execute validator duties unless we are behind peers' head.
-		if !behindPeers {
-			n.Validator.OnInterval(ctx, slot, interval)
-		}
+		// Always execute validator duties on the clock.
+		// No sync gating — matches ethlambda/leanSpec. Gossip delivers blocks,
+		// the fetcher handles missing parents asynchronously.
+		n.Validator.OnInterval(ctx, slot, interval)
 
 		// Update metrics and log on slot boundary.
 		if slot != lastLogSlot {
 			start := time.Now()
 			// Refresh status for metrics if not already current.
-			status = n.FC.GetStatus()
+			status := n.FC.GetStatus()
 
 			metrics.CurrentSlot.Set(float64(slot))
 			metrics.HeadSlot.Set(float64(status.HeadSlot))
@@ -130,8 +88,6 @@ func (n *Node) Run(ctx context.Context) error {
 				"finalized_root", logging.LongHash(status.FinalizedRoot),
 				"justified_slot", status.JustifiedSlot,
 				"justified_root", logging.LongHash(status.JustifiedRoot),
-				"behind_peers", behindPeers,
-				"max_peer_head", maxPeerHeadSlot,
 				"peers", peerCount,
 				"elapsed", logging.TimeSince(start),
 			)

--- a/node/ticker.go
+++ b/node/ticker.go
@@ -62,10 +62,16 @@ func (n *Node) Run(ctx context.Context) error {
 		// Advance fork choice time.
 		n.FC.AdvanceTimeMillis(n.Clock.CurrentTime(), hasProposal)
 
-		// Always execute validator duties on the clock.
-		// No sync gating — matches ethlambda/leanSpec. Gossip delivers blocks,
-		// the fetcher handles missing parents asynchronously.
-		n.Validator.OnInterval(ctx, slot, interval)
+		// Execute validator duties on the clock.
+		// Aggregation (interval 2) runs in a background goroutine because
+		// proof building takes 1-6 seconds — longer than the 800ms interval.
+		// This matches Lantern's approach of running aggregation off the
+		// main thread so the tick loop continues to interval 3 on time.
+		if interval == 2 && n.Validator.IsAggregator {
+			go n.Validator.OnInterval(ctx, slot, interval)
+		} else {
+			n.Validator.OnInterval(ctx, slot, interval)
+		}
 
 		// Update metrics and log on slot boundary.
 		if slot != lastLogSlot {

--- a/storage/bolt/bolt.go
+++ b/storage/bolt/bolt.go
@@ -88,6 +88,18 @@ func (s *Store) PutState(root [32]byte, state *types.State) {
 	s.put(statesBucket, root[:], state)
 }
 
+func (s *Store) DeleteBlock(root [32]byte) {
+	s.delete(blocksBucket, root[:])
+}
+
+func (s *Store) DeleteSignedBlock(root [32]byte) {
+	s.delete(signedBlockBucket, root[:])
+}
+
+func (s *Store) DeleteState(root [32]byte) {
+	s.delete(statesBucket, root[:])
+}
+
 func (s *Store) GetAllBlocks() map[[32]byte]*types.Block {
 	result := make(map[[32]byte]*types.Block)
 	s.db.View(func(tx *bolt.Tx) error {
@@ -144,6 +156,15 @@ func (s *Store) put(bucket, key []byte, val sszMarshaler) {
 	})
 	if err != nil {
 		log.Fatalf("bolt: write %s: %v", bucket, err)
+	}
+}
+
+func (s *Store) delete(bucket, key []byte) {
+	err := s.db.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket(bucket).Delete(key)
+	})
+	if err != nil {
+		log.Printf("bolt: delete from %s: %v", bucket, err)
 	}
 }
 

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -10,6 +10,9 @@ type Store interface {
 	PutSignedBlock(root [32]byte, sb *types.SignedBlockWithAttestation)
 	GetState(root [32]byte) (*types.State, bool)
 	PutState(root [32]byte, state *types.State)
+	DeleteBlock(root [32]byte)
+	DeleteSignedBlock(root [32]byte)
+	DeleteState(root [32]byte)
 	GetAllBlocks() map[[32]byte]*types.Block
 	GetAllStates() map[[32]byte]*types.State
 }

--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -62,6 +62,24 @@ func (m *Store) PutState(root [32]byte, state *types.State) {
 	m.states[root] = state
 }
 
+func (m *Store) DeleteBlock(root [32]byte) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.blocks, root)
+}
+
+func (m *Store) DeleteSignedBlock(root [32]byte) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.signedBlocks, root)
+}
+
+func (m *Store) DeleteState(root [32]byte) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.states, root)
+}
+
 func (m *Store) GetAllBlocks() map[[32]byte]*types.Block {
 	m.mu.RLock()
 	defer m.mu.RUnlock()


### PR DESCRIPTION
## Summary

Fixes #172

- **Memory leak:** Add `pruneOnFinalizationLocked()` — cleans attestations, payloads, signatures, and storage when finalization advances. Add `Delete` methods to storage interface (bolt + memory).
- **Excessive BlocksByRoot:** Cap sync walk from 32,768 to 128. Deduplicate recovery via `syncingRoots` with 5s cooldown. Limit to 3 random peers instead of sweeping all. Single random peer in ticker sync.
- **Stalling:** Run gossip parent recovery in background goroutine. Cache pending block immediately before recovery.

## Test plan

- [ ] `make fmt && make lint` passes
- [ ] `make unit-test` passes
- [ ] `make spec-test` passes
- [ ] Local devnet via lean-quickstart: verify gean follows chain, memory stays bounded, no peer flooding