### PR TITLE
feat(skills): add /debug skill

### DIFF
--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: debug
+description: Debug gean failures and regressions. Use when users want to (1) diagnose failing gean tests, (2) investigate devnet interoperability failures, forks, or finalization stalls, (3) trace networking, forkchoice, state transition, storage, checkpoint sync, or XMSS/FFI bugs, (4) identify which subsystem likely caused an error and what to inspect next, or (5) turn logs and test output into a concrete root-cause investigation plan.
+---
+
+# /debug - Debug gean
+
+Use this skill as the top-level entry point for gean debugging. Start with
+evidence, reduce the failing scope, then route into the right subsystem.
+
+## Usage
+
+- `/debug why is gean not finalizing on devnet`
+- `/debug investigate this failing forkchoice test`
+- `/debug trace checkpoint sync failure in gean`
+- `/debug find why this XMSS test is failing`
+- `/debug analyze these gean devnet logs`
+
+## Default workflow
+
+1. Collect the failing command, exact error text, and whether this is
+   gean-only or multi-client.
+2. Reproduce with the smallest failing surface before proposing fixes:
+   - single package test if possible
+   - existing logs before running a new devnet
+   - one node or one slot range before whole-network guesses
+3. Classify the failure:
+   - devnet / interoperability
+   - networking / gossip / peer connectivity
+   - forkchoice / head selection / reorgs
+   - state transition / block validation
+   - storage / checkpoint sync / persistence
+   - XMSS / Rust FFI / signature verification
+   - test regression after a code change
+4. Inspect the relevant package and only then form a root-cause hypothesis.
+5. End with a short diagnosis:
+   - likely subsystem
+   - evidence observed
+   - next verification command or file to inspect
+
+## Routing and stop conditions
+
+- If devnet logs already exist, start with
+  `./.claude/skills/devnet-log-review/scripts/analyze-logs.sh` and use the
+  `devnet-log-review` skill for log-specific investigation.
+- If the issue needs a fresh multi-client reproduction, use the
+  `devnet-runner` skill.
+- If the task is validating a branch/PR against peer clients, use the
+  `test-pr-devnet` skill.
+- Do not re-run a whole devnet when a targeted `go test` reproduces the issue.
+- If the user has not provided logs, error text, a failing command, or a clear
+  reproduction path, stop and ask for the missing evidence before guessing.
+- If no minimal reproduction can be identified, say that clearly and return the
+  best next step for obtaining one.
+
+## Investigation entry points
+
+### Devnet / interoperability
+
+Use this when gean disagrees with peers, stalls, or produces invalid blocks.
+
+```bash
+# Analyze existing logs in repo root or a specified directory
+./.claude/skills/devnet-log-review/scripts/analyze-logs.sh
+
+# Show detailed gean errors from the current log set
+./.claude/skills/devnet-log-review/scripts/show-errors.sh -n gean_0 -w
+```
+
+Focus on the first divergent slot or first rejected block, not the tail of the
+failure. Compare gean's view of head, justified, and finalized slots against
+peer clients before changing code.
+
+### gean unit or package regressions
+
+Use this when the failure is local to one package or appears in CI/unit tests.
+
+```bash
+# Fast default suite: excludes XMSS FFI and spec fixtures
+make test
+
+# Package-focused run
+go test ./forkchoice -run TestName -v -count=1
+go test ./node -run TestName -v -count=1
+go test ./statetransition -run TestName -v -count=1
+```
+
+Prefer the narrowest failing package and search for the exact error string
+before opening unrelated code:
+
+```bash
+rg -n "error text here|panic text here" .
+```
+
+### Spec fixture failures
+
+Use this when gean diverges from the pinned leanSpec behavior.
+
+```bash
+make test-spec
+go test ./spectests/ -count=1 -tags=spectests -run TestName -v
+```
+
+Treat spec fixture failures as deterministic until proven otherwise. Inspect
+`spectests/`, `statetransition/`, `forkchoice/`, and `types/` before assuming
+networking problems.
+
+### XMSS / Rust FFI / signature issues
+
+Use this when signatures fail, FFI panics, or aggregate proofs look wrong.
+
+```bash
+make test-ffi
+go test ./xmss -run TestName -v -count=1
+```
+
+Inspect `xmss/ffi.go`, key/proof handling, and `xmss/rust/` before making
+changes elsewhere. Verify whether the failure is in Go-side marshaling, Rust
+glue, or test fixtures.
+
+### Checkpoint sync / storage / persistence
+
+Use this when nodes fail to resume, finalized state looks wrong, or sync from a
+checkpoint diverges.
+
+```bash
+# Inspect the finalized state endpoint from a running source node
+curl http://127.0.0.1:5052/lean/v0/states/finalized -o /tmp/finalized.ssz
+
+# Read the justified checkpoint JSON
+curl http://127.0.0.1:5052/lean/v0/checkpoints/justified
+```
+
+Confirm the source node is healthy before blaming the syncing node. Only clear
+data directories or restart from genesis when the user wants a fresh-state
+reproduction.
+
+## Gean-specific heuristics
+
+- Forks usually become visible first as a slot-level disagreement, not a final
+  error line.
+- Finalization stalls are usually easier to debug from participation/head
+  progress than from the eventual timeout symptom.
+- If a block is reproducibly invalid from the same inputs, investigate
+  `statetransition/` or `types/` before `p2p/`.
+- If gean receives and publishes but does not advance head, inspect
+  `forkchoice/` and `node/store_block.go`.
+- If peers do not connect or topics are silent, inspect `p2p/` and node startup
+  flags before touching consensus logic.
+
+## References
+
+- See [references/debug-paths.md](references/debug-paths.md) for symptom to
+  subsystem mapping.
+- See [references/debug-workflows.md](references/debug-workflows.md) for the
+  detailed triage flows.
+
+## Response format
+
+Always end with this structure:
+
+```markdown
+## Debug Summary
+
+**Scope:** {gean-only | multi-client}
+**Failing surface:** {test | spec fixture | xmss/ffi | devnet | checkpoint sync | unknown}
+**Likely subsystem:** {subsystem}
+**Evidence:** {1-3 concrete observations}
+**Next step:** {single best verification command or file to inspect}
+```
+
+Do not end with a generic conclusion. If the root cause is still unproven, say
+that explicitly and use `Next step` for the best verification action.

--- a/.claude/skills/debug/references/debug-paths.md
+++ b/.claude/skills/debug/references/debug-paths.md
@@ -1,0 +1,43 @@
+# Debug Paths
+
+Map symptoms to the smallest likely gean subsystem before reading code.
+
+## Symptom to subsystem
+
+| Symptom | Inspect first | Notes |
+|---|---|---|
+| Peers do not connect, gossip is quiet, req/resp hangs | `p2p/host.go`, `p2p/gossip.go`, `p2p/reqresp.go`, `p2p/peers.go` | Usually transport, topic, peer, or startup-flag issues before consensus logic |
+| Block received but rejected or not imported | `node/store_block.go`, `node/store_validate.go`, `statetransition/block.go`, `statetransition/transition.go` | Start from the first rejected block or validation error |
+| Head does not advance or reorg behavior looks wrong | `forkchoice/forkchoice.go`, `forkchoice/protoarray.go`, `forkchoice/votes.go`, `node/store_tick.go` | Compare head, justified, and finalized progress first |
+| Finalization stalls | `forkchoice/`, `node/store_aggregate.go`, `node/store_produce.go`, `node/validator.go` | Check whether attestations are present and counted before changing finalization logic |
+| gean produces invalid blocks on devnet | `node/store_build.go`, `node/store_produce.go`, `node/block.go`, `types/` | Correlate proposer slot and attestation count with peer rejection |
+| Deterministic spec fixture failure | `spectests/`, `statetransition/`, `forkchoice/`, `types/` | Treat as logic mismatch with leanSpec, not a networking issue |
+| Checkpoint sync fetches wrong state or resumes incorrectly | `checkpoint/checkpoint.go`, `api/server.go`, `node/node.go`, `storage/pebble.go` | Verify the source endpoint before blaming the syncing node |
+| Data survives incorrectly across restarts or state disappears | `storage/pebble.go`, `storage/keys.go`, `storage/tables.go`, `node/consensus_store.go` | Persistence bugs often show up as missing parents or inconsistent finalized state |
+| Signature verification or aggregation fails | `xmss/ffi.go`, `xmss/keys.go`, `xmss/proof_pool.go`, `node/verify.go` | Separate Go marshaling bugs from Rust FFI failures |
+| API output is wrong but chain logic seems healthy | `api/server.go`, `checkpoint/checkpoint.go` | Distinguish serialization/output bugs from consensus bugs |
+
+## Fast package map
+
+| Package | Responsibility |
+|---|---|
+| `cmd/gean` | Node startup and flag wiring |
+| `node/` | Main event loop, block handling, validator duties, aggregation |
+| `forkchoice/` | Head selection, proto-array state, votes |
+| `statetransition/` | Block and slot processing, validation rules |
+| `p2p/` | Gossip, req/resp, peer connectivity, host setup |
+| `storage/` | Pebble and in-memory storage backends |
+| `checkpoint/` | Checkpoint sync and finalized state handling |
+| `api/` | HTTP endpoints for health, finalized state, checkpoints, fork choice |
+| `types/` | Core data structures and SSZ encoding |
+| `xmss/` | FFI bridge, key handling, aggregate proof logic |
+| `spectests/` | leanSpec fixture-backed conformance tests |
+
+## Choose the smallest useful reproduction
+
+- `make test` for regular Go regressions
+- `go test ./<package> -run TestName -v -count=1` for package-local failures
+- `make test-spec` for leanSpec fixture mismatches
+- `make test-ffi` for XMSS/Rust FFI issues
+- `./.claude/skills/devnet-log-review/scripts/analyze-logs.sh` when logs already exist
+- `devnet-runner` when you need a fresh multi-client reproduction

--- a/.claude/skills/debug/references/debug-workflows.md
+++ b/.claude/skills/debug/references/debug-workflows.md
@@ -1,0 +1,123 @@
+# Debug Workflows
+
+Use these workflows after classifying the failing surface.
+
+## 1. Existing devnet logs
+
+Use this path when `.log` files already exist or a previous run has been
+captured.
+
+```bash
+./.claude/skills/devnet-log-review/scripts/analyze-logs.sh
+./.claude/skills/devnet-log-review/scripts/show-errors.sh -n gean_0 -w
+```
+
+Then:
+
+1. Identify the first slot where gean diverges from peers.
+2. Confirm whether the divergence is:
+   - a rejected incoming block
+   - a bad locally produced block
+   - missing attestations / aggregation
+   - peer connectivity / sync failure
+3. Follow the slot into the relevant code path:
+   - incoming block: `node/store_block.go`, `node/store_validate.go`
+   - local production: `node/store_build.go`, `node/store_produce.go`
+   - head/finalization mismatch: `forkchoice/`
+   - transport mismatch: `p2p/`
+
+Do not diagnose from the last error line if the first divergence is earlier.
+
+## 2. Fresh multi-client reproduction
+
+Use this path when no good logs exist yet.
+
+1. Use the `devnet-runner` skill for a clean reproduction.
+2. If the issue is branch-specific or PR-specific, use `test-pr-devnet`.
+3. Capture logs and return immediately to the existing-log workflow.
+
+Prefer a short run that reproduces the symptom over a long noisy run.
+
+## 3. gean-only Go test failure
+
+Start with the narrowest failing target:
+
+```bash
+make test
+go test ./node -run TestName -v -count=1
+go test ./forkchoice -run TestName -v -count=1
+go test ./statetransition -run TestName -v -count=1
+```
+
+Then:
+
+1. Record the exact failing assertion, panic, or mismatch.
+2. Search for the error string or invariant with `rg`.
+3. Read the nearest production code before scanning unrelated packages.
+4. If the failure depends on leanSpec fixtures, switch to the spec workflow.
+
+## 4. Spec fixture mismatch
+
+Use this when `make test-spec` fails or a consensus rule appears wrong.
+
+```bash
+make test-spec
+go test ./spectests/ -count=1 -tags=spectests -run TestName -v
+```
+
+Then:
+
+1. Identify whether the mismatch is in state transition, forkchoice, or
+   signature verification.
+2. Compare the failing fixture type to the target package:
+   - STF fixture -> `statetransition/`
+   - forkchoice fixture -> `forkchoice/`
+   - signature fixture -> `xmss/`, `node/verify.go`
+3. Treat the fixture as deterministic and investigate logic, encoding, or
+   proof handling before trying a devnet reproduction.
+
+## 5. XMSS / Rust FFI failure
+
+Use this when FFI tests fail, signatures are invalid, or Rust panics appear.
+
+```bash
+make test-ffi
+go test ./xmss -run TestName -v -count=1
+```
+
+Then isolate whether the bug is:
+
+- Go-side encoding or pointer/lifetime handling in `xmss/ffi.go`
+- key/proof preparation in `xmss/keys.go` or `xmss/proof_pool.go`
+- Rust glue/build/runtime behavior in `xmss/rust/`
+
+Avoid editing consensus logic until the signature path is proven sound.
+
+## 6. Checkpoint sync or restart behavior
+
+Use this when a node restarts incorrectly, syncs to the wrong finalized state,
+or behaves differently after persistence.
+
+```bash
+curl http://127.0.0.1:5052/lean/v0/health
+curl http://127.0.0.1:5052/lean/v0/checkpoints/justified
+curl http://127.0.0.1:5052/lean/v0/states/finalized -o /tmp/finalized.ssz
+```
+
+Then:
+
+1. Verify the source node is healthy and exposes the expected finalized state.
+2. Confirm startup flags and node role before assuming corrupted storage.
+3. Inspect `checkpoint/checkpoint.go`, `api/server.go`, `storage/`, and
+   `node/node.go`.
+4. Only wipe data or restart from genesis when the user wants a fresh-state
+   reproduction.
+
+## Root-cause standard
+
+Do not stop at “the test failed in package X.” A good debug result ends with:
+
+- the smallest known failing surface
+- the likely subsystem
+- the concrete evidence
+- the next verification step


### PR DESCRIPTION
 Closes #202

  ## Summary

  Add a new `/debug` Claude skill under `.claude/skills/debug/` as the top-level entry point for debugging `gean` failures and regressions.

  This skill is intended to cover both:
  - multi-client/devnet debugging
  - gean-only debugging

  It gives Claude a structured workflow for:
  - starting from evidence
  - reducing the failing scope
  - classifying the likely subsystem
  - routing into existing skills when appropriate
  - ending with a concise debug summary

  ## What changed

  Added:
  - `.claude/skills/debug/SKILL.md`
  - `.claude/skills/debug/references/debug-paths.md`
  - `.claude/skills/debug/references/debug-workflows.md`

  The new skill:
  - defines `/debug` usage examples
  - adds routing and stop conditions
  - points to existing skills instead of duplicating them
  - maps common symptoms to the relevant `gean` subsystems
  - documents investigation flows for:
    - existing devnet logs
    - fresh multi-client reproductions
    - package-local Go test failures
    - spec fixture mismatches
    - XMSS / Rust FFI failures
    - checkpoint sync / persistence issues

  
