### PR TITLE
Feat/admin aggregator toggle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ run-node2: build ## Run node2 on port 9002
 
 # --- leanSpec fixtures ---
 
-LEAN_SPEC_COMMIT_HASH := b3d7b3e381dff9765320c287c9c0c9873d4c0853
+LEAN_SPEC_COMMIT_HASH := 9b89651
 
 leanSpec: ## Clone leanSpec at pinned main commit (contains devnet-4 changes)
 	git clone https://github.com/leanEthereum/leanSpec.git --single-branch

--- a/api/handlers_admin.go
+++ b/api/handlers_admin.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/geanlabs/gean/node"
+)
+
+// AggregatorStatusHandler serves GET /lean/v0/admin/aggregator.
+// Returns the current aggregator role as {"is_aggregator": bool}.
+// Spec: leanSpec PR #636.
+func AggregatorStatusHandler(ctl *node.AggregatorController) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"is_aggregator": ctl.Get(),
+		})
+	}
+}
+
+// AggregatorToggleHandler serves POST /lean/v0/admin/aggregator.
+// Body: {"enabled": bool}. Response: {"is_aggregator": new, "previous": old}.
+// Spec: leanSpec PR #636.
+//
+// 400 conditions (match the spec PR):
+//   - empty body
+//   - malformed JSON
+//   - missing "enabled" field
+//   - "enabled" not a boolean
+func AggregatorToggleHandler(ctl *node.AggregatorController) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Decode into a pointer so we can distinguish "missing" from "false".
+		var body struct {
+			Enabled *bool `json:"enabled"`
+		}
+		dec := json.NewDecoder(r.Body)
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&body); err != nil {
+			http.Error(w, "invalid json body", http.StatusBadRequest)
+			return
+		}
+		if body.Enabled == nil {
+			http.Error(w, `missing required field "enabled"`, http.StatusBadRequest)
+			return
+		}
+
+		prev := ctl.Set(*body.Enabled)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"is_aggregator": ctl.Get(),
+			"previous":      prev,
+		})
+	}
+}

--- a/api/handlers_admin_test.go
+++ b/api/handlers_admin_test.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/geanlabs/gean/node"
+)
+
+// TestAggregatorStatusHandler covers GET — returns the controller's current
+// value with the spec-exact JSON key "is_aggregator".
+func TestAggregatorStatusHandler(t *testing.T) {
+	for _, init := range []bool{false, true} {
+		ctl := node.NewAggregatorController(init)
+		rec := httptest.NewRecorder()
+		AggregatorStatusHandler(ctl)(rec, httptest.NewRequest("GET", "/lean/v0/admin/aggregator", nil))
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("init=%v: status=%d, want 200", init, rec.Code)
+		}
+		var body map[string]interface{}
+		if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+			t.Fatalf("init=%v: decode body: %v", init, err)
+		}
+		if got := body["is_aggregator"]; got != init {
+			t.Errorf("init=%v: is_aggregator=%v, want %v", init, got, init)
+		}
+	}
+}
+
+// TestAggregatorToggleHandler covers POST happy paths: activate, deactivate,
+// and idempotent flips. Response shape matches leanSpec PR #636.
+func TestAggregatorToggleHandler(t *testing.T) {
+	tests := []struct {
+		name     string
+		initial  bool
+		body     string
+		wantNow  bool
+		wantPrev bool
+	}{
+		{"activate", false, `{"enabled": true}`, true, false},
+		{"deactivate", true, `{"enabled": false}`, false, true},
+		{"idempotent_enable", true, `{"enabled": true}`, true, true},
+		{"idempotent_disable", false, `{"enabled": false}`, false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctl := node.NewAggregatorController(tc.initial)
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/lean/v0/admin/aggregator", strings.NewReader(tc.body))
+			AggregatorToggleHandler(ctl)(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status=%d, want 200", rec.Code)
+			}
+			var body map[string]interface{}
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if got := body["is_aggregator"]; got != tc.wantNow {
+				t.Errorf("is_aggregator=%v, want %v", got, tc.wantNow)
+			}
+			if got := body["previous"]; got != tc.wantPrev {
+				t.Errorf("previous=%v, want %v", got, tc.wantPrev)
+			}
+			if ctl.Get() != tc.wantNow {
+				t.Errorf("controller not persisted: Get()=%v, want %v", ctl.Get(), tc.wantNow)
+			}
+		})
+	}
+}
+
+// TestAggregatorToggleHandler_BadRequest covers the 400 matrix: empty body,
+// malformed JSON, missing `enabled`, wrong type. All must leave the
+// controller's state untouched.
+func TestAggregatorToggleHandler_BadRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"empty_body", ""},
+		{"malformed_json", `{"enabled": tru`},
+		{"missing_enabled", `{"other": true}`},
+		{"non_bool_enabled", `{"enabled": "yes"}`},
+		{"unknown_field", `{"enabled": true, "extra": 1}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctl := node.NewAggregatorController(true)
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/lean/v0/admin/aggregator", strings.NewReader(tc.body))
+			AggregatorToggleHandler(ctl)(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d, want 400", rec.Code)
+			}
+			if !ctl.Get() {
+				t.Errorf("controller mutated on bad request; want unchanged (true)")
+			}
+		})
+	}
+}

--- a/api/server.go
+++ b/api/server.go
@@ -15,13 +15,15 @@ import (
 )
 
 // StartAPIServer starts the API server on the given address.
-func StartAPIServer(address string, s *node.ConsensusStore, fc *forkchoice.ForkChoice) error {
+func StartAPIServer(address string, s *node.ConsensusStore, fc *forkchoice.ForkChoice, aggCtl *node.AggregatorController) error {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("GET /lean/v0/health", HealthHandler)
 	mux.HandleFunc("GET /lean/v0/states/finalized", FinalizedStateHandler(s))
 	mux.HandleFunc("GET /lean/v0/checkpoints/justified", JustifiedCheckpointHandler(s))
 	mux.HandleFunc("GET /lean/v0/fork_choice", ForkChoiceHandler(s, fc))
+	mux.HandleFunc("GET /lean/v0/admin/aggregator", AggregatorStatusHandler(aggCtl))
+	mux.HandleFunc("POST /lean/v0/admin/aggregator", AggregatorToggleHandler(aggCtl))
 
 	listener, err := net.Listen("tcp", address)
 	if err != nil {

--- a/cmd/gean/main.go
+++ b/cmd/gean/main.go
@@ -234,7 +234,7 @@ func main() {
 	metricsAddr := fmt.Sprintf("%s:%d", *httpAddr, *metricsPort)
 
 	go func() {
-		if err := api.StartAPIServer(apiAddr, s, fc); err != nil {
+		if err := api.StartAPIServer(apiAddr, s, fc, aggCtl); err != nil {
 			logger.Error(logger.Node, "api server error: %v", err)
 		}
 	}()

--- a/cmd/gean/main.go
+++ b/cmd/gean/main.go
@@ -197,7 +197,14 @@ func main() {
 
 	// --- Initialize engine ---
 
-	n := node.New(s, fc, p2pHost, keyManager, *isAggregator, *committeeCount)
+	// Runtime-toggleable aggregator role. Seeded from --is-aggregator; the
+	// admin API endpoint flips this without restart. Boot-time subscription
+	// decisions (p2p.NewHost above, XMSS prover pre-init below) still use
+	// the CLI flag per leanSpec PR #636 — only publishing behavior follows
+	// the controller at runtime.
+	aggCtl := node.NewAggregatorController(*isAggregator)
+
+	n := node.New(s, fc, p2pHost, keyManager, aggCtl, *committeeCount)
 
 	// Register P2P stream handlers.
 	p2pHost.RegisterReqRespHandlers(

--- a/node/aggregator_controller.go
+++ b/node/aggregator_controller.go
@@ -1,0 +1,42 @@
+package node
+
+import "sync/atomic"
+
+// AggregatorController holds the runtime aggregator-role flag exposed by the
+// admin API (leanSpec PR #636). Reads are lock-free via atomic.Bool; Set
+// atomically swaps the value and returns the previous state so the HTTP
+// handler can report {"previous": ...}. The Prometheus lean_is_aggregator
+// gauge is synced on every transition so observability stays accurate across
+// toggles.
+//
+// Contract: each logical decision that branches on is_aggregator should call
+// Get() exactly once and cache the result locally if the same value is
+// needed in multiple places within the same decision. Re-reading mid-
+// decision can observe a toggle in flight.
+type AggregatorController struct {
+	flag atomic.Bool
+}
+
+// NewAggregatorController seeds the controller with initial and syncs the
+// Prometheus gauge to match, so metrics are correct from boot onward.
+func NewAggregatorController(initial bool) *AggregatorController {
+	c := &AggregatorController{}
+	c.flag.Store(initial)
+	SetIsAggregator(initial)
+	return c
+}
+
+// Get returns the current aggregator-role flag.
+func (c *AggregatorController) Get() bool {
+	return c.flag.Load()
+}
+
+// Set atomically swaps the flag to v and returns the previous value. The
+// Prometheus gauge is updated only when the value actually changes.
+func (c *AggregatorController) Set(v bool) bool {
+	prev := c.flag.Swap(v)
+	if prev != v {
+		SetIsAggregator(v)
+	}
+	return prev
+}

--- a/node/aggregator_controller_test.go
+++ b/node/aggregator_controller_test.go
@@ -1,0 +1,66 @@
+package node
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestAggregatorController_InitialValue(t *testing.T) {
+	if !NewAggregatorController(true).Get() {
+		t.Fatal("seeded=true but Get returned false")
+	}
+	if NewAggregatorController(false).Get() {
+		t.Fatal("seeded=false but Get returned true")
+	}
+}
+
+func TestAggregatorController_SetReturnsPrevious(t *testing.T) {
+	c := NewAggregatorController(false)
+	if prev := c.Set(true); prev {
+		t.Fatalf("first flip: prev=%v, want false", prev)
+	}
+	if !c.Get() {
+		t.Fatal("after Set(true), Get returned false")
+	}
+	if prev := c.Set(false); !prev {
+		t.Fatalf("second flip: prev=%v, want true", prev)
+	}
+	if c.Get() {
+		t.Fatal("after Set(false), Get returned true")
+	}
+}
+
+func TestAggregatorController_Idempotent(t *testing.T) {
+	c := NewAggregatorController(true)
+	if prev := c.Set(true); !prev {
+		t.Fatalf("idempotent enable: prev=%v, want true", prev)
+	}
+	if !c.Get() {
+		t.Fatal("idempotent enable drifted value")
+	}
+
+	c2 := NewAggregatorController(false)
+	if prev := c2.Set(false); prev {
+		t.Fatalf("idempotent disable: prev=%v, want false", prev)
+	}
+	if c2.Get() {
+		t.Fatal("idempotent disable drifted value")
+	}
+}
+
+// TestAggregatorController_Concurrent exercises the atomic read/write path
+// under -race. Final state isn't deterministic; success is surviving the
+// race detector without a data race or panic.
+func TestAggregatorController_Concurrent(t *testing.T) {
+	c := NewAggregatorController(false)
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func(v bool) {
+			defer wg.Done()
+			_ = c.Set(v)
+			_ = c.Get()
+		}(i%2 == 0)
+	}
+	wg.Wait()
+}

--- a/node/block.go
+++ b/node/block.go
@@ -336,7 +336,7 @@ func (e *Engine) discardPendingSubtree(blockRoot [32]byte) {
 // aggregation gossip topic instead.
 // Spec: lean_spec/subspecs/forkchoice/store.py on_gossip_attestation (line 385)
 func (e *Engine) onGossipAttestation(att *types.SignedAttestation) {
-	if !e.IsAggregator {
+	if !e.AggCtl.Get() {
 		return
 	}
 

--- a/node/node.go
+++ b/node/node.go
@@ -26,7 +26,7 @@ type Engine struct {
 	FC                  *forkchoice.ForkChoice
 	P2P                 *p2p.Host
 	Keys                *xmss.KeyManager
-	IsAggregator        bool
+	AggCtl              *AggregatorController
 	CommitteeCount      uint64
 	PendingBlocks       map[[32]byte]map[[32]byte]bool // parent_root -> {child_roots}
 	PendingBlockParents map[[32]byte][32]byte          // block_root -> missing_ancestor
@@ -46,7 +46,7 @@ func New(
 	fc *forkchoice.ForkChoice,
 	p2pHost *p2p.Host,
 	keys *xmss.KeyManager,
-	isAggregator bool,
+	aggCtl *AggregatorController,
 	committeeCount uint64,
 ) *Engine {
 	return &Engine{
@@ -54,7 +54,7 @@ func New(
 		FC:                  fc,
 		P2P:                 p2pHost,
 		Keys:                keys,
-		IsAggregator:        isAggregator,
+		AggCtl:              aggCtl,
 		CommitteeCount:      committeeCount,
 		PendingBlocks:       make(map[[32]byte]map[[32]byte]bool),
 		PendingBlockParents: make(map[[32]byte][32]byte),
@@ -89,9 +89,10 @@ func (e *Engine) Run(ctx context.Context) {
 	SetSyncStatus("idle")
 
 	// Initialize static metrics.
+	// lean_is_aggregator is kept in sync via AggregatorController.Set on
+	// every transition; NewAggregatorController already seeded it at boot.
 	SetNodeInfo("gean", "dev")
 	SetNodeStartTime(float64(time.Now().Unix()))
-	SetIsAggregator(e.IsAggregator)
 	SetAttestationCommitteeCount(e.CommitteeCount)
 	if e.Keys != nil {
 		vids := e.Keys.ValidatorIDs()

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -42,7 +42,7 @@ func makeTestEngine() *Engine {
 
 	fc := forkchoice.New(0, genesisRoot)
 
-	return New(s, fc, nil, nil, false, 1)
+	return New(s, fc, nil, nil, NewAggregatorController(false), 1)
 }
 
 func TestEngineCreation(t *testing.T) {

--- a/node/tick.go
+++ b/node/tick.go
@@ -19,6 +19,11 @@ func (e *Engine) onTick() {
 	SetCurrentSlot(currentSlot)
 	e.updateSyncStatus(currentSlot)
 
+	// Snapshot the aggregator role once per tick. A mid-tick toggle must
+	// not cause OnTick below and the interval-2 branch to observe different
+	// values (store_tick relies on the bool being stable for the tick).
+	isAgg := e.AggCtl.Get()
+
 	// Check if we're the proposer for this slot.
 	hasProposal := false
 	var proposerValidatorID uint64
@@ -28,13 +33,13 @@ func (e *Engine) onTick() {
 
 	// Tick the store — handles interval dispatch (promote attestations).
 	// Aggregation is handled async below to avoid blocking the tick loop.
-	_ = OnTick(e.Store, timestampMs, hasProposal, e.IsAggregator)
+	_ = OnTick(e.Store, timestampMs, hasProposal, isAgg)
 
 	// Interval 2: synchronous aggregation. Blocks the tick loop for 1-4s
 	// but keeps source consistency — headState doesn't change during proving.
 	// Async aggregation breaks source alignment because head drifts during
 	// the background prover run. Acceptable until prover is <800ms.
-	if currentInterval == 2 && e.IsAggregator {
+	if currentInterval == 2 && isAgg {
 		aggs := AggregateCommitteeSignatures(e.Store)
 		for _, agg := range aggs {
 			if e.P2P != nil {

--- a/node/validator.go
+++ b/node/validator.go
@@ -111,7 +111,7 @@ func (e *Engine) produceAttestations(slot uint64) {
 
 		// Self-deliver for aggregation if we are the aggregator.
 		// Skip signature verification — we just signed it ourselves.
-		if e.IsAggregator {
+		if e.AggCtl.Get() {
 			dataRoot, _ := attData.HashTreeRoot()
 			sigHandle, parseErr := xmss.ParseSignature(sig[:])
 			e.Store.AttestationSignatures.InsertWithHandle(dataRoot, attData, vid, sig, sigHandle, parseErr)

--- a/spectests/api_test.go
+++ b/spectests/api_test.go
@@ -3,6 +3,7 @@
 package spectests
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"io"
@@ -37,7 +38,10 @@ type apiFixture struct {
 	Network             string                 `json:"network"`
 	LeanEnv             string                 `json:"leanEnv"`
 	Endpoint            string                 `json:"endpoint"`
+	Method              string                 `json:"method"` // leanSpec PR #636; defaults "GET" when absent
 	GenesisParams       apiGenesisParams       `json:"genesisParams"`
+	RequestBody         json.RawMessage        `json:"requestBody"`         // POST bodies (admin endpoints)
+	InitialIsAggregator *bool                  `json:"initialIsAggregator"` // seeds AggregatorController before replay
 	ExpectedStatusCode  int                    `json:"expectedStatusCode"`
 	ExpectedContentType string                 `json:"expectedContentType"`
 	ExpectedBody        json.RawMessage        `json:"expectedBody"`
@@ -129,14 +133,33 @@ func runAPIFixture(t *testing.T, fx apiFixture) {
 
 	fc := forkchoice.New(0, blockRoot)
 
+	// Per-fixture aggregator controller, seeded from initialIsAggregator
+	// (leanSpec PR #636). Nil means the fixture doesn't exercise the admin
+	// endpoints; defaulting to false keeps the controller present for every
+	// replay so lookupAPIHandler never hits a nil pointer.
+	initialAgg := false
+	if fx.InitialIsAggregator != nil {
+		initialAgg = *fx.InitialIsAggregator
+	}
+	aggCtl := node.NewAggregatorController(initialAgg)
+
+	method := fx.Method
+	if method == "" {
+		method = "GET"
+	}
+
 	// Resolve and invoke the handler via httptest.
-	handler := lookupAPIHandler(fx.Endpoint, s, fc)
+	handler := lookupAPIHandler(method, fx.Endpoint, s, fc, aggCtl)
 	if handler == nil {
-		t.Skipf("endpoint %q not wired into test harness", fx.Endpoint)
+		t.Skipf("endpoint %q (%s) not wired into test harness", fx.Endpoint, method)
 		return
 	}
 
-	req := httptest.NewRequest("GET", fx.Endpoint, nil)
+	var reqBody io.Reader
+	if len(fx.RequestBody) > 0 && string(fx.RequestBody) != "null" {
+		reqBody = bytes.NewReader(fx.RequestBody)
+	}
+	req := httptest.NewRequest(method, fx.Endpoint, reqBody)
 	rec := httptest.NewRecorder()
 	handler(rec, req)
 
@@ -182,18 +205,22 @@ func runAPIFixture(t *testing.T, fx apiFixture) {
 	}
 }
 
-// lookupAPIHandler maps a spec endpoint to the in-process http.HandlerFunc.
-// Matches the route registrations in api.StartAPIServer.
-func lookupAPIHandler(endpoint string, s *node.ConsensusStore, fc *forkchoice.ForkChoice) http.HandlerFunc {
-	switch endpoint {
-	case "/lean/v0/health":
+// lookupAPIHandler maps a spec (method, endpoint) to the in-process
+// http.HandlerFunc. Matches the route registrations in api.StartAPIServer.
+func lookupAPIHandler(method, endpoint string, s *node.ConsensusStore, fc *forkchoice.ForkChoice, aggCtl *node.AggregatorController) http.HandlerFunc {
+	switch method + " " + endpoint {
+	case "GET /lean/v0/health":
 		return api.HealthHandler
-	case "/lean/v0/checkpoints/justified":
+	case "GET /lean/v0/checkpoints/justified":
 		return api.JustifiedCheckpointHandler(s)
-	case "/lean/v0/fork_choice":
+	case "GET /lean/v0/fork_choice":
 		return api.ForkChoiceHandler(s, fc)
-	case "/lean/v0/states/finalized":
+	case "GET /lean/v0/states/finalized":
 		return api.FinalizedStateHandler(s)
+	case "GET /lean/v0/admin/aggregator":
+		return api.AggregatorStatusHandler(aggCtl)
+	case "POST /lean/v0/admin/aggregator":
+		return api.AggregatorToggleHandler(aggCtl)
 	default:
 		return nil
 	}


### PR DESCRIPTION
## Summary

- Implements leanSpec PR #636 runtime aggregator toggle: `GET/POST /lean/v0/admin/aggregator` flips the aggregator role without restart, enabling hot-standby failover.
- Replaces the captured `Engine.IsAggregator` bool with an atomic `AggregatorController` that every gossip-event and tick handler reads fresh; Prometheus gauge stays in sync on every toggle.
- Keeps `--is-aggregator` as the boot-time decider for attestation-subnet subscriptions and XMSS prover pre-init (matches spec PR's hot-standby model — subscribe at boot, toggle publishing at runtime).
- Bumps leanSpec pin to `9b896512` and extends the `TestSpecAPI` fixture schema with `method` / `requestBody` / `initialIsAggregator` to run the 6 new conformance vectors.

## Test plan

- `go test ./node/ -race` — AggregatorController unit tests pass (seed, swap-returns-prev, idempotent, concurrent).
- `go test ./api/ -race -run TestAggregator` — handler happy-path + 400 matrix (empty body / malformed JSON / missing enabled / non-bool / unknown field).
- `go test -tags=spectests -run TestSpecAPI ./spectests/` — 6 existing fixtures pass with the extended harness.
- Full 12-fixture run against regenerated leanSpec fixtures.
- Smoke-test multi-client interop (no wire format change, but confirm no regression).