### PR TITLE
fix(api): match leanSpec api_endpoint fixture schema for /health and /fork_choice (devnet-3)

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -66,6 +66,19 @@ func handleFinalizedState(s *node.ConsensusStore) http.HandlerFunc {
 
 		state.LatestBlockHeader.StateRoot = types.ZeroRoot
 
+		// Align embedded checkpoints with the store's current view. The stored
+		// post-state's latest_finalized reflects only what this block's own
+		// attestations finalized, so it lags behind the store once a descendant
+		// block causes this block to itself be finalized. Returning the store's
+		// current finalized checkpoint keeps the served state consistent with
+		// /lean/v0/fork_choice. Also lift latest_justified when it would fall
+		// behind the new finalized slot, preserving the latest_justified.slot
+		// >= latest_finalized.slot invariant.
+		state.LatestFinalized = finalized
+		if state.LatestJustified.Slot < finalized.Slot {
+			state.LatestJustified = s.LatestJustified()
+		}
+
 		data, err := state.MarshalSSZ()
 		if err != nil {
 			http.Error(w, "ssz marshal failed", http.StatusInternalServerError)

--- a/api/server.go
+++ b/api/server.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 
+	"github.com/geanlabs/gean/forkchoice"
 	"github.com/geanlabs/gean/logger"
 	"github.com/geanlabs/gean/node"
 	"github.com/geanlabs/gean/types"
@@ -13,13 +14,13 @@ import (
 )
 
 // StartAPIServer starts the API server on the given address.
-func StartAPIServer(address string, s *node.ConsensusStore) error {
+func StartAPIServer(address string, s *node.ConsensusStore, fc *forkchoice.ForkChoice) error {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("GET /lean/v0/health", handleHealth)
 	mux.HandleFunc("GET /lean/v0/states/finalized", handleFinalizedState(s))
 	mux.HandleFunc("GET /lean/v0/checkpoints/justified", handleJustifiedCheckpoint(s))
-	mux.HandleFunc("GET /lean/v0/fork_choice", handleForkChoice(s))
+	mux.HandleFunc("GET /lean/v0/fork_choice", handleForkChoice(s, fc))
 
 	listener, err := net.Listen("tcp", address)
 	if err != nil {
@@ -47,7 +48,7 @@ func StartMetricsServer(address string) error {
 // handleHealth returns a simple health check.
 func handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	w.Write([]byte(`{"status":"healthy","service":"gean"}`))
+	w.Write([]byte(`{"status":"healthy","service":"lean-rpc-api"}`))
 }
 
 // handleFinalizedState returns the finalized state as SSZ bytes.
@@ -88,20 +89,48 @@ func handleJustifiedCheckpoint(s *node.ConsensusStore) http.HandlerFunc {
 	}
 }
 
-// handleForkChoice returns fork choice info as JSON.
-func handleForkChoice(s *node.ConsensusStore) http.HandlerFunc {
+// handleForkChoice returns fork choice info as JSON, matching leanSpec's
+// api_endpoint fixture schema: {nodes[], head, justified, finalized, safe_target, validator_count}.
+func handleForkChoice(s *node.ConsensusStore, fc *forkchoice.ForkChoice) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		head := s.Head()
 		justified := s.LatestJustified()
 		finalized := s.LatestFinalized()
 		safeTarget := s.SafeTarget()
 
+		// Build nodes[] array from proto-array snapshot. proposer_index comes
+		// from the block header (proto-array doesn't track it).
+		nodes := make([]map[string]interface{}, 0)
+		if fc != nil && fc.Array != nil {
+			for _, pn := range fc.Array.Nodes() {
+				var proposerIndex uint64
+				if hdr := s.GetBlockHeader(pn.Root); hdr != nil {
+					proposerIndex = hdr.ProposerIndex
+				}
+				nodes = append(nodes, map[string]interface{}{
+					"root":           fmt.Sprintf("0x%x", pn.Root),
+					"slot":           pn.Slot,
+					"parent_root":    fmt.Sprintf("0x%x", pn.ParentRoot),
+					"proposer_index": proposerIndex,
+					"weight":         pn.Weight,
+				})
+			}
+		}
+
+		// validator_count from the head state (fallback to 0 if unavailable).
+		var validatorCount uint64
+		if headState := s.GetState(head); headState != nil {
+			validatorCount = headState.NumValidators()
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{
-			"head":        fmt.Sprintf("0x%x", head),
-			"justified":   map[string]interface{}{"slot": justified.Slot, "root": fmt.Sprintf("0x%x", justified.Root)},
-			"finalized":   map[string]interface{}{"slot": finalized.Slot, "root": fmt.Sprintf("0x%x", finalized.Root)},
-			"safe_target": fmt.Sprintf("0x%x", safeTarget),
+			"nodes":           nodes,
+			"head":            fmt.Sprintf("0x%x", head),
+			"justified":       map[string]interface{}{"slot": justified.Slot, "root": fmt.Sprintf("0x%x", justified.Root)},
+			"finalized":       map[string]interface{}{"slot": finalized.Slot, "root": fmt.Sprintf("0x%x", finalized.Root)},
+			"safe_target":     fmt.Sprintf("0x%x", safeTarget),
+			"validator_count": validatorCount,
 		})
 	}
 }

--- a/cmd/gean/main.go
+++ b/cmd/gean/main.go
@@ -189,7 +189,7 @@ func main() {
 	metricsAddr := fmt.Sprintf("%s:%d", *httpAddr, *metricsPort)
 
 	go func() {
-		if err := api.StartAPIServer(apiAddr, s); err != nil {
+		if err := api.StartAPIServer(apiAddr, s, fc); err != nil {
 			logger.Error(logger.Node, "api server error: %v", err)
 		}
 	}()

--- a/forkchoice/protoarray.go
+++ b/forkchoice/protoarray.go
@@ -37,6 +37,14 @@ func NewProtoArray(anchorSlot uint64, anchorRoot [32]byte) *ProtoArray {
 	return pa
 }
 
+// Nodes returns a snapshot copy of all proto-array nodes. Safe to expose to
+// callers since the returned slice is detached from internal storage.
+func (pa *ProtoArray) Nodes() []ProtoNode {
+	out := make([]ProtoNode, len(pa.nodes))
+	copy(out, pa.nodes)
+	return out
+}
+
 // OnBlock registers a new block in the proto-array.
 
 func (pa *ProtoArray) OnBlock(slot uint64, root, parentRoot [32]byte) {


### PR DESCRIPTION
## Summary
- Cherry-picks `aca35d3` from `main` onto `devnet-3` so the published `ghcr.io/geanlabs/gean:devnet3` image serves `/lean/v0/health` and `/lean/v0/fork_choice` bodies that match the leanSpec `api_endpoint` fixture schema.
- Without this, the hive `lean` rpc-compat simulator fails **18 of 32** tests against gean devnet3 (reproduced locally — see [public dashboard run](https://hive.leanroadmap.org/suite.html?suiteid=1776566707-3ebf5c362571b89d95fb26ddd99a5bb4.json&suitename=rpc-compat)).

Closes #215 

## Root cause
The `devnet-3` branch still returns the pre-spec shapes:

| Endpoint | devnet-3 (before) | leanSpec / simulator expectation |
| --- | --- | --- |
| `/lean/v0/health` | `{"status":"healthy","service":"gean"}` | `service:"lean-rpc-api"` |
| `/lean/v0/fork_choice` | `{head, justified, finalized, safe_target}` | adds `nodes[]` (each `{root, slot, parent_root, proposer_index, weight}`) and `validator_count` |

The hive simulator decodes `/fork_choice` into a struct where `nodes` and `validator_count` are required (non-`Option`) fields, so every test that touches forkchoice panics with `error decoding response body` at `simulators/lean/src/main.rs:274`. That cascades into the `state ssz decodes …` tests whose setup helpers also call the forkchoice endpoint.

