### PR TITLE
metrics: add lean_attestations_production_time_seconds

### DIFF
--- a/node/metrics.go
+++ b/node/metrics.go
@@ -133,6 +133,11 @@ var (
 		Help:    "Time to sign an attestation",
 		Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 1},
 	})
+	metricAttestationsProductionTime = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "lean_attestations_production_time_seconds",
+		Help:    "Time taken to produce attestation",
+		Buckets: []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1},
+	})
 	metricPqSigVerificationTime = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "lean_pq_sig_attestation_verification_time_seconds",
 		Help:    "Time to verify an individual attestation signature",
@@ -269,7 +274,10 @@ func ObserveAttestationValidationTime(seconds float64) {
 func ObserveCommitteeAggregationTime(seconds float64) {
 	metricCommitteeAggregationTime.Observe(seconds)
 }
-func ObservePqSigSigningTime(seconds float64)      { metricPqSigSigningTime.Observe(seconds) }
+func ObservePqSigSigningTime(seconds float64) { metricPqSigSigningTime.Observe(seconds) }
+func ObserveAttestationsProductionTime(seconds float64) {
+	metricAttestationsProductionTime.Observe(seconds)
+}
 func ObservePqSigVerificationTime(seconds float64) { metricPqSigVerificationTime.Observe(seconds) }
 func ObservePqSigAggBuildingTime(seconds float64)  { metricPqSigAggBuildingTime.Observe(seconds) }
 func ObservePqSigAggVerificationTime(seconds float64) {

--- a/node/validator.go
+++ b/node/validator.go
@@ -93,6 +93,8 @@ func (e *Engine) produceAttestations(slot uint64) {
 	}
 
 	for _, vid := range e.Keys.ValidatorIDs() {
+		prodStart := time.Now()
+
 		sStart := time.Now()
 		sig, err := e.Keys.SignAttestation(vid, attData)
 		ObservePqSigSigningTime(time.Since(sStart).Seconds())
@@ -125,5 +127,11 @@ func (e *Engine) produceAttestations(slot uint64) {
 				logger.Info(logger.Network, "published attestation to network slot=%d validator=%d", slot, vid)
 			}
 		}
+
+		// Sign failures hit `continue` above and are not sampled — the
+		// histogram only records iterations that actually produced an
+		// attestation. Publish failures still count as produced (the
+		// attestation exists; only delivery to gossip failed).
+		ObserveAttestationsProductionTime(time.Since(prodStart).Seconds())
 	}
 }


### PR DESCRIPTION
Closes #217.

## Summary

Adds the `lean_attestations_production_time_seconds` histogram introduced by leanMetrics PR [#30](https://github.com/leanEthereum/leanMetrics/pull/30) (merged 2026-04-19). Sampled per validator per slot at the end of the successful production path in `produceAttestations`.

## Motivation

Until any client emits this metric the dashboard panel that depends on it shows "No data". gean is first to implement; the spec table for this metric is empty across every client. This gives operators a per-validator production-cost distribution and pins the sampling semantics in commit history so the next client can match without ambiguity.

## What changed

- **`node/metrics.go`**
  - New histogram `metricAttestationsProductionTime` with the spec's exact name, help text (`"Time taken to produce attestation"`), and buckets (`0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1`).
  - New setter `ObserveAttestationsProductionTime(seconds float64)` following the existing pattern.

- **`node/validator.go`**
  - Captures `prodStart := time.Now()` at the top of each per-validator iteration in `produceAttestations`.
  - Calls `ObserveAttestationsProductionTime(time.Since(prodStart).Seconds())` at the end of the successful path (after sign + self-deliver + publish).

## Sampling semantics

- One Observe per validator per slot. With one validator per node (current devnet-4 deployment) that's one sample per slot per node.
- **Sign failures** hit `continue` and are not sampled — \"production\" means an attestation actually got produced.
- **Publish failures** still count as produced — the attestation exists; only delivery to gossip failed.
- The existing narrower `lean_pq_sig_attestation_signing_time_seconds` is preserved for isolating XMSS FFI cost from Go overhead.

## Backward compatibility

Purely additive. No public API changed, no existing metric renamed or removed, no wire-format / consensus changes, no new flags or config required. Sub-microsecond runtime overhead per validator iteration.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./node/` passes
- [x] `gofmt -w` applied (no diff)
- [ ] Manual verification on a running devnet node that the metric appears in `/metrics` output and that the Grafana panel populates