### PR TITLE
node: buffer attestations for unknown head blocks; fetch and replay on arrival

### DIFF
--- a/node/block.go
+++ b/node/block.go
@@ -372,8 +372,30 @@ func (e *Engine) onGossipAttestation(att *types.SignedAttestation) {
 		return
 	}
 
-	// Validate attestation data.
+	// Validate attestation data. If the attestation references a head block
+	// we don't yet know about, buffer it under that head root and fire a
+	// targeted BlocksByRoot fetch — when the block arrives, the block import
+	// path drains the bucket and replays each attestation through this same
+	// function. Source/target unknowns stay strict-drop for now: head is the
+	// dominant ordering race in practice (proposer's own block delayed in
+	// gossip dispersion); source/target races are rarer and can be handled
+	// the same way later if metrics show it matters.
 	if err := ValidateAttestationData(e.Store, att.Data); err != nil {
+		if se, ok := err.(*StoreError); ok && se.Kind == ErrUnknownHeadBlock && att.Data.Head != nil {
+			added, dropped := e.PendingAttestations.Add(att.Data.Head.Root, att)
+			if added {
+				select {
+				case e.FetchRootCh <- att.Data.Head.Root:
+				default:
+					// Batcher channel full — that's fine. Multiple attestations
+					// for the same root would otherwise produce one extra fetch
+					// each anyway, and the batcher dedups within its grace window.
+				}
+			}
+			if dropped > 0 {
+				IncAttestationsBufferEvicted(dropped)
+			}
+		}
 		return
 	}
 

--- a/node/block.go
+++ b/node/block.go
@@ -156,8 +156,33 @@ func (e *Engine) processOneBlock(signedBlock *types.SignedBlock, queue *[]*types
 	// Clear depth tracking for this block (now processed).
 	delete(e.PendingBlockDepths, blockRoot)
 
+	// Replay any gossip attestations that were buffered awaiting this exact
+	// head block. Fires for every successful import — cascaded children
+	// (added via collectPendingChildren below) re-enter processOneBlock and
+	// run their own replay pass, so a multi-block chain repair drains the
+	// buffer for each block in order. Replay fans out to one goroutine per
+	// attestation, matching the existing live-gossip pattern in Run().
+	e.replayPendingAttestations(blockRoot)
+
 	// Cascade: enqueue pending children for processing.
 	e.collectPendingChildren(blockRoot, queue)
+}
+
+// replayPendingAttestations drains every gossip attestation that was buffered
+// awaiting this head block and fires each one back through onGossipAttestation.
+// Each replay runs in its own goroutine because XMSS verification is ~500ms
+// per attestation and would otherwise serialize behind the engine main loop.
+func (e *Engine) replayPendingAttestations(headRoot [32]byte) {
+	pending := e.PendingAttestations.Drain(headRoot)
+	if len(pending) == 0 {
+		return
+	}
+	logger.Info(logger.Gossip, "replaying %d buffered attestations for newly arrived head=0x%x",
+		len(pending), headRoot)
+	for _, att := range pending {
+		att := att
+		go e.onGossipAttestation(att)
+	}
 }
 
 // collectPendingChildren moves pending children of parent into the work queue.
@@ -220,6 +245,13 @@ func (e *Engine) discardFinalizedPending(finalizedSlot uint64) {
 
 	if discarded > 0 {
 		logger.Info(logger.Store, "discarded %d finalized pending blocks (finalized_slot=%d)", discarded, finalizedSlot)
+	}
+
+	// Drop buffered attestations whose target slot is at or below the new
+	// finalized slot — their head block (if it ever arrives) will likewise
+	// be too old to act on, so the attestation can never be replayed.
+	if removed := e.PendingAttestations.PruneBelow(finalizedSlot); removed > 0 {
+		logger.Info(logger.Store, "discarded %d finalized pending attestations (finalized_slot=%d)", removed, finalizedSlot)
 	}
 }
 

--- a/node/metrics.go
+++ b/node/metrics.go
@@ -72,6 +72,9 @@ var (
 	metricAttestationsInvalid = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "lean_attestations_invalid_total", Help: "Total invalid attestations rejected",
 	})
+	metricAttestationsBufferEvicted = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "lean_attestations_buffer_evicted_total", Help: "Pending attestations dropped due to per-root FIFO overflow",
+	})
 	metricForkChoiceReorgs = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "lean_fork_choice_reorgs_total", Help: "Total fork choice reorgs",
 	})
@@ -262,6 +265,7 @@ func SetAttestationCommitteeSubnet(n uint64) { metricAttestationCommitteeSubnet.
 
 func IncAttestationsValid(n uint64)          { metricAttestationsValid.Add(float64(n)) }
 func IncAttestationsInvalid()                { metricAttestationsInvalid.Inc() }
+func IncAttestationsBufferEvicted(n int)     { metricAttestationsBufferEvicted.Add(float64(n)) }
 func IncForkChoiceReorgs()                   { metricForkChoiceReorgs.Inc() }
 func IncPqSigAggregatedTotal()               { metricPqSigAggregatedSignaturesTotal.Inc() }
 func IncPqSigAttestationsInAggregated(n int) { metricPqSigAttestationsInAggregated.Add(float64(n)) }

--- a/node/metrics.go
+++ b/node/metrics.go
@@ -43,6 +43,9 @@ var (
 	metricLatestKnownAggregatedPayloads = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "lean_latest_known_aggregated_payloads", Help: "Number of known (active) aggregated payloads",
 	})
+	metricPendingAttestationsTotal = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "lean_pending_attestations_total", Help: "Gossip attestations buffered awaiting an unknown head block",
+	})
 	metricNodeInfo = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "lean_node_info", Help: "Node information",
 	}, []string{"name", "version"})
@@ -248,6 +251,7 @@ func SetAttestationCommitteeCount(n uint64) { metricAttestationCommitteeCount.Se
 func SetAttestationSignatures(n int)        { metricAttestationSignatures.Set(float64(n)) }
 func SetNewAggregatedPayloads(n int)        { metricLatestNewAggregatedPayloads.Set(float64(n)) }
 func SetKnownAggregatedPayloads(n int)      { metricLatestKnownAggregatedPayloads.Set(float64(n)) }
+func SetPendingAttestationsTotal(n int)     { metricPendingAttestationsTotal.Set(float64(n)) }
 func SetTableBytes(table string, bytes uint64) {
 	metricTableBytes.WithLabelValues(table).Set(float64(bytes))
 }

--- a/node/node.go
+++ b/node/node.go
@@ -21,6 +21,15 @@ const (
 	MaxPendingBlocks   = 1024 // Max pending blocks before rejecting new ones
 )
 
+// Pending-attestation buffer caps. perRoot bounds the depth of any single
+// head-root bucket; total bounds the sum across all buckets. Sized for
+// devnet-4 expectations (low validator counts, short propagation windows);
+// promote to flags if a future deployment needs different ceilings.
+const (
+	PendingAttestationsPerRootCap = 8
+	PendingAttestationsTotalCap   = 512
+)
+
 type Engine struct {
 	Store               *ConsensusStore
 	FC                  *forkchoice.ForkChoice
@@ -31,6 +40,7 @@ type Engine struct {
 	PendingBlocks       map[[32]byte]map[[32]byte]bool // parent_root -> {child_roots}
 	PendingBlockParents map[[32]byte][32]byte          // block_root -> missing_ancestor
 	PendingBlockDepths  map[[32]byte]int               // block_root -> fetch depth
+	PendingAttestations *PendingAttestationBuffer      // gossip atts buffered by unknown head root
 
 	// Channels for receiving messages from P2P goroutine.
 	BlockCh       chan *types.SignedBlock
@@ -59,6 +69,7 @@ func New(
 		PendingBlocks:       make(map[[32]byte]map[[32]byte]bool),
 		PendingBlockParents: make(map[[32]byte][32]byte),
 		PendingBlockDepths:  make(map[[32]byte]int),
+		PendingAttestations: NewPendingAttestationBuffer(PendingAttestationsPerRootCap, PendingAttestationsTotalCap),
 		BlockCh:             make(chan *types.SignedBlock, 64),
 		AttestationCh:       make(chan *types.SignedAttestation, 256),
 		AggregationCh:       make(chan *types.SignedAggregatedAttestation, 64),

--- a/node/node.go
+++ b/node/node.go
@@ -96,6 +96,19 @@ func (e *Engine) Run(ctx context.Context) {
 	p2p.GossipAttestationSizeHook = ObserveGossipAttestationSize
 	p2p.GossipAggregationSizeHook = ObserveGossipAggregationSize
 
+	// Wire peer event hooks. Client label is "unknown" until libp2p
+	// identify-based client detection is added (follow-up); spec result
+	// label is "success" for the accepted-connection path.
+	p2p.PeerConnectedHook = func(direction string) {
+		IncPeerConnection(direction, "success")
+	}
+	p2p.PeerDisconnectedHook = func(direction, reason string) {
+		IncPeerDisconnection(direction, reason)
+	}
+	p2p.PeerCountHook = func(count int) {
+		SetConnectedPeers("unknown", count)
+	}
+
 	// Initial sync status is "idle" until peers connect.
 	SetSyncStatus("idle")
 

--- a/node/pending_attestations.go
+++ b/node/pending_attestations.go
@@ -1,0 +1,132 @@
+package node
+
+import (
+	"sync"
+
+	"github.com/geanlabs/gean/types"
+)
+
+// PendingAttestationBuffer holds gossip attestations whose referenced head
+// block is not yet in the store. When that head block later arrives, the
+// engine drains the bucket and replays the attestations through the normal
+// gossip path so signatures get verified against real state.
+//
+// Keyed by head.Root so draining on block arrival is O(1). Per-root and total
+// caps bound memory under adversarial load; per-root overflow drops the
+// oldest entry in the bucket (FIFO).
+type PendingAttestationBuffer struct {
+	mu         sync.Mutex
+	byHead     map[[32]byte][]*types.SignedAttestation
+	perRootCap int
+	totalCap   int
+	total      int
+	evicted    int // cumulative per-root FIFO evictions
+	rejected   int // cumulative total-cap rejections
+}
+
+// NewPendingAttestationBuffer constructs a buffer with the given caps.
+// perRootCap bounds the depth of any single head-root bucket; totalCap bounds
+// the sum across all buckets.
+func NewPendingAttestationBuffer(perRootCap, totalCap int) *PendingAttestationBuffer {
+	return &PendingAttestationBuffer{
+		byHead:     make(map[[32]byte][]*types.SignedAttestation),
+		perRootCap: perRootCap,
+		totalCap:   totalCap,
+	}
+}
+
+// Add buffers att under headRoot.
+//
+// Returns added=true when the attestation landed in the buffer. Returns
+// dropped>0 when adding this entry evicted an older one in the same bucket
+// (per-root FIFO overflow). Returns added=false when the total cap is hit
+// and the attestation was rejected outright.
+func (b *PendingAttestationBuffer) Add(headRoot [32]byte, att *types.SignedAttestation) (added bool, dropped int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	bucket := b.byHead[headRoot]
+
+	// Per-root overflow: drop oldest, append new. Total count is unchanged
+	// (one in, one out), so the total-cap branch below does not apply.
+	if len(bucket) >= b.perRootCap {
+		bucket = append(bucket[1:], att)
+		b.byHead[headRoot] = bucket
+		b.evicted++
+		return true, 1
+	}
+
+	// Total cap: reject new entries once the buffer is full.
+	if b.total >= b.totalCap {
+		b.rejected++
+		return false, 0
+	}
+
+	b.byHead[headRoot] = append(bucket, att)
+	b.total++
+	return true, 0
+}
+
+// Drain atomically removes and returns the bucket for headRoot. Returns nil
+// when no bucket exists.
+func (b *PendingAttestationBuffer) Drain(headRoot [32]byte) []*types.SignedAttestation {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	bucket, ok := b.byHead[headRoot]
+	if !ok {
+		return nil
+	}
+	delete(b.byHead, headRoot)
+	b.total -= len(bucket)
+	return bucket
+}
+
+// PruneBelow drops every buffered attestation whose Data.Slot <= finalizedSlot.
+// Empty buckets are removed. Returns the number of attestations removed.
+func (b *PendingAttestationBuffer) PruneBelow(finalizedSlot uint64) int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	removed := 0
+	for headRoot, bucket := range b.byHead {
+		kept := bucket[:0]
+		for _, att := range bucket {
+			if att.Data.Slot <= finalizedSlot {
+				removed++
+				continue
+			}
+			kept = append(kept, att)
+		}
+		if len(kept) == 0 {
+			delete(b.byHead, headRoot)
+		} else {
+			b.byHead[headRoot] = kept
+		}
+	}
+	b.total -= removed
+	return removed
+}
+
+// Total returns the current total number of buffered attestations across all
+// head-root buckets.
+func (b *PendingAttestationBuffer) Total() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.total
+}
+
+// Len returns the current number of distinct head-root buckets.
+func (b *PendingAttestationBuffer) Len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.byHead)
+}
+
+// Stats returns cumulative eviction (per-root FIFO overflow) and rejection
+// (total cap exceeded) counters since construction.
+func (b *PendingAttestationBuffer) Stats() (evicted, rejected int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.evicted, b.rejected
+}

--- a/node/pending_attestations_test.go
+++ b/node/pending_attestations_test.go
@@ -15,6 +15,18 @@ func makeAtt(slot uint64) *types.SignedAttestation {
 	}
 }
 
+// makeAttForHead is like makeAtt but also fills in Head.Root so a test can
+// assert which head bucket an attestation lives under without sharing
+// fixtures across tests.
+func makeAttForHead(slot uint64, head [32]byte) *types.SignedAttestation {
+	return &types.SignedAttestation{
+		Data: &types.AttestationData{
+			Slot: slot,
+			Head: &types.Checkpoint{Root: head},
+		},
+	}
+}
+
 func TestPendingAttestationBuffer_AddAndDrain(t *testing.T) {
 	buf := NewPendingAttestationBuffer(8, 64)
 

--- a/node/pending_attestations_test.go
+++ b/node/pending_attestations_test.go
@@ -1,0 +1,258 @@
+package node
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/geanlabs/gean/types"
+)
+
+// makeAtt builds a minimal SignedAttestation with the given slot. Other
+// fields are zero-valued; the buffer only inspects Data.Slot for pruning.
+func makeAtt(slot uint64) *types.SignedAttestation {
+	return &types.SignedAttestation{
+		Data: &types.AttestationData{Slot: slot},
+	}
+}
+
+func TestPendingAttestationBuffer_AddAndDrain(t *testing.T) {
+	buf := NewPendingAttestationBuffer(8, 64)
+
+	var head [32]byte
+	head[0] = 0x01
+
+	att := makeAtt(10)
+	added, dropped := buf.Add(head, att)
+	if !added || dropped != 0 {
+		t.Fatalf("first add: added=%v dropped=%d, want true,0", added, dropped)
+	}
+	if buf.Total() != 1 || buf.Len() != 1 {
+		t.Fatalf("after add: total=%d len=%d, want 1,1", buf.Total(), buf.Len())
+	}
+
+	drained := buf.Drain(head)
+	if len(drained) != 1 || drained[0] != att {
+		t.Fatalf("drain: got %d entries, want 1 matching pointer", len(drained))
+	}
+	if buf.Total() != 0 || buf.Len() != 0 {
+		t.Fatalf("after drain: total=%d len=%d, want 0,0", buf.Total(), buf.Len())
+	}
+}
+
+func TestPendingAttestationBuffer_DrainMissing(t *testing.T) {
+	buf := NewPendingAttestationBuffer(8, 64)
+	var head [32]byte
+	if got := buf.Drain(head); got != nil {
+		t.Fatalf("drain on empty key: got %v, want nil", got)
+	}
+}
+
+func TestPendingAttestationBuffer_PerRootFIFOEviction(t *testing.T) {
+	buf := NewPendingAttestationBuffer(2, 64)
+
+	var head [32]byte
+	head[0] = 0x01
+
+	a, b, c := makeAtt(10), makeAtt(11), makeAtt(12)
+
+	// Fill bucket to per-root cap.
+	if added, dropped := buf.Add(head, a); !added || dropped != 0 {
+		t.Fatalf("add a: added=%v dropped=%d", added, dropped)
+	}
+	if added, dropped := buf.Add(head, b); !added || dropped != 0 {
+		t.Fatalf("add b: added=%v dropped=%d", added, dropped)
+	}
+
+	// Third add overflows: oldest (a) evicted, total stays at 2.
+	added, dropped := buf.Add(head, c)
+	if !added || dropped != 1 {
+		t.Fatalf("add c: added=%v dropped=%d, want true,1", added, dropped)
+	}
+	if buf.Total() != 2 {
+		t.Fatalf("total after FIFO eviction: %d, want 2", buf.Total())
+	}
+
+	drained := buf.Drain(head)
+	if len(drained) != 2 {
+		t.Fatalf("drain: %d entries, want 2", len(drained))
+	}
+	// FIFO: oldest evicted, so we expect b then c, not a.
+	if drained[0] != b || drained[1] != c {
+		t.Fatalf("FIFO order broken: got [%p %p], want [%p %p]", drained[0], drained[1], b, c)
+	}
+
+	if evicted, rejected := buf.Stats(); evicted != 1 || rejected != 0 {
+		t.Fatalf("stats: evicted=%d rejected=%d, want 1,0", evicted, rejected)
+	}
+}
+
+func TestPendingAttestationBuffer_TotalCapRejection(t *testing.T) {
+	buf := NewPendingAttestationBuffer(8, 2)
+
+	var h1, h2, h3 [32]byte
+	h1[0], h2[0], h3[0] = 0x01, 0x02, 0x03
+
+	if added, _ := buf.Add(h1, makeAtt(1)); !added {
+		t.Fatalf("first add should succeed")
+	}
+	if added, _ := buf.Add(h2, makeAtt(2)); !added {
+		t.Fatalf("second add should succeed")
+	}
+	// Third distinct-root add hits totalCap=2 → reject.
+	added, dropped := buf.Add(h3, makeAtt(3))
+	if added || dropped != 0 {
+		t.Fatalf("third add (over total cap): added=%v dropped=%d, want false,0", added, dropped)
+	}
+	if buf.Total() != 2 || buf.Len() != 2 {
+		t.Fatalf("after reject: total=%d len=%d, want 2,2", buf.Total(), buf.Len())
+	}
+	if _, rejected := buf.Stats(); rejected != 1 {
+		t.Fatalf("rejected count: got %d, want 1", rejected)
+	}
+
+	// Total cap is hard: an intra-bucket add that does NOT trigger FIFO
+	// eviction is rejected when total == totalCap. (h1 has 1 entry,
+	// perRootCap=8, so we'd otherwise just append — but total is at cap.)
+	if added, dropped := buf.Add(h1, makeAtt(99)); added || dropped != 0 {
+		t.Fatalf("intra-bucket add at total cap: added=%v dropped=%d, want false,0", added, dropped)
+	}
+}
+
+// TestPendingAttestationBuffer_FIFOEvictsEvenAtTotalCap verifies that
+// per-root FIFO eviction is permitted even when the buffer is at totalCap,
+// because the eviction swaps one entry for another and does not grow total.
+func TestPendingAttestationBuffer_FIFOEvictsEvenAtTotalCap(t *testing.T) {
+	// perRootCap=2, totalCap=2 — a single bucket can saturate both caps.
+	buf := NewPendingAttestationBuffer(2, 2)
+
+	var head [32]byte
+	head[0] = 0x01
+
+	a, b, c := makeAtt(10), makeAtt(11), makeAtt(12)
+	buf.Add(head, a)
+	buf.Add(head, b)
+	if buf.Total() != 2 {
+		t.Fatalf("setup: total=%d, want 2", buf.Total())
+	}
+
+	// Bucket is at perRootCap AND total is at totalCap. FIFO eviction must
+	// still succeed (one in, one out — total unchanged).
+	added, dropped := buf.Add(head, c)
+	if !added || dropped != 1 {
+		t.Fatalf("FIFO at total cap: added=%v dropped=%d, want true,1", added, dropped)
+	}
+	if buf.Total() != 2 {
+		t.Fatalf("total after FIFO at cap: %d, want 2", buf.Total())
+	}
+}
+
+func TestPendingAttestationBuffer_PruneBelow(t *testing.T) {
+	buf := NewPendingAttestationBuffer(8, 64)
+
+	var h1, h2 [32]byte
+	h1[0], h2[0] = 0x01, 0x02
+
+	// h1: slots 5, 10, 15. h2: slots 3, 20.
+	for _, slot := range []uint64{5, 10, 15} {
+		buf.Add(h1, makeAtt(slot))
+	}
+	for _, slot := range []uint64{3, 20} {
+		buf.Add(h2, makeAtt(slot))
+	}
+	if buf.Total() != 5 || buf.Len() != 2 {
+		t.Fatalf("setup: total=%d len=%d, want 5,2", buf.Total(), buf.Len())
+	}
+
+	// Prune at slot 10: drops slot<=10 → 5, 10, 3. Keeps 15, 20.
+	removed := buf.PruneBelow(10)
+	if removed != 3 {
+		t.Fatalf("prune removed=%d, want 3", removed)
+	}
+	if buf.Total() != 2 {
+		t.Fatalf("after prune: total=%d, want 2", buf.Total())
+	}
+	// h2's only surviving entry stays under h2; h1's only surviving entry stays under h1.
+	if buf.Len() != 2 {
+		t.Fatalf("after prune: len=%d, want 2 (both buckets non-empty)", buf.Len())
+	}
+
+	// Prune everything → empty buckets removed.
+	removed = buf.PruneBelow(100)
+	if removed != 2 {
+		t.Fatalf("final prune removed=%d, want 2", removed)
+	}
+	if buf.Total() != 0 || buf.Len() != 0 {
+		t.Fatalf("after final prune: total=%d len=%d, want 0,0", buf.Total(), buf.Len())
+	}
+}
+
+// TestPendingAttestationBuffer_Concurrent exercises the buffer under
+// concurrent Add/Drain/PruneBelow load. Run with -race to catch any locking
+// regression. We don't assert exact counts because Drain races with Add by
+// design — we only assert that the buffer's accounting stays consistent
+// (total == sum-of-bucket-lengths) at the end.
+func TestPendingAttestationBuffer_Concurrent(t *testing.T) {
+	buf := NewPendingAttestationBuffer(16, 1024)
+
+	const writers = 8
+	const drainers = 4
+	const pruners = 2
+	const opsPerGoroutine = 500
+
+	var wg sync.WaitGroup
+
+	// Writers each pick from a small set of head roots so buckets fill.
+	wg.Add(writers)
+	for i := 0; i < writers; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			for j := 0; j < opsPerGoroutine; j++ {
+				var root [32]byte
+				root[0] = byte(j % 4) // 4 distinct head roots, contention guaranteed
+				buf.Add(root, makeAtt(uint64(i*1000+j)))
+			}
+		}()
+	}
+
+	// Drainers race against writers on the same root namespace.
+	wg.Add(drainers)
+	for i := 0; i < drainers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < opsPerGoroutine; j++ {
+				var root [32]byte
+				root[0] = byte(j % 4)
+				_ = buf.Drain(root)
+			}
+		}()
+	}
+
+	// Pruners cull below an advancing slot.
+	wg.Add(pruners)
+	for i := 0; i < pruners; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < opsPerGoroutine; j++ {
+				_ = buf.PruneBelow(uint64(j))
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Final consistency: drain every known head root and confirm Total
+	// drops to 0. If the internal counter ever drifted from actual bucket
+	// contents under -race, this would surface as a non-zero residual.
+	for r := 0; r < 4; r++ {
+		var root [32]byte
+		root[0] = byte(r)
+		_ = buf.Drain(root)
+	}
+	if buf.Total() != 0 {
+		t.Fatalf("after universal drain: total=%d, want 0", buf.Total())
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("after universal drain: len=%d, want 0", buf.Len())
+	}
+}

--- a/node/pending_replay_test.go
+++ b/node/pending_replay_test.go
@@ -1,0 +1,71 @@
+package node
+
+import (
+	"testing"
+)
+
+// TestReplayPendingAttestations_DrainsBucket verifies the replay helper
+// empties the bucket for the given head root. We can't easily verify that
+// the spawned goroutines successfully re-validate the attestations without
+// a full Engine + Store + XMSS, so this test focuses on the drain semantics:
+// after replayPendingAttestations returns, the buffer must no longer hold
+// the entries for that root.
+func TestReplayPendingAttestations_DrainsBucket(t *testing.T) {
+	e := &Engine{
+		PendingAttestations: NewPendingAttestationBuffer(8, 64),
+	}
+
+	var head [32]byte
+	head[0] = 0x42
+
+	// Buffer 3 attestations under one head root, plus one under a different
+	// root to confirm the drain is targeted (does not nuke unrelated entries).
+	for _, slot := range []uint64{10, 11, 12} {
+		e.PendingAttestations.Add(head, makeAttForHead(slot, head))
+	}
+	var otherHead [32]byte
+	otherHead[0] = 0x99
+	e.PendingAttestations.Add(otherHead, makeAttForHead(20, otherHead))
+
+	if e.PendingAttestations.Total() != 4 {
+		t.Fatalf("setup: total=%d, want 4", e.PendingAttestations.Total())
+	}
+
+	// Replay for `head` should drain only that bucket. Note that the spawned
+	// onGossipAttestation goroutines will fail/return quickly because the
+	// Engine has no Store/AggCtl; we don't depend on their behavior here,
+	// only on the synchronous Drain that happens inside the helper.
+	//
+	// To avoid the goroutines panicking on nil AggCtl, we wire a controller
+	// disabled by default — onGossipAttestation early-returns on AggCtl.Get()
+	// being false, which is the safe path for this unit-level test.
+	e.AggCtl = NewAggregatorController(false)
+	e.replayPendingAttestations(head)
+
+	if e.PendingAttestations.Total() != 1 {
+		t.Fatalf("after replay: total=%d, want 1 (only the otherHead entry should remain)",
+			e.PendingAttestations.Total())
+	}
+	if e.PendingAttestations.Len() != 1 {
+		t.Fatalf("after replay: len=%d, want 1 bucket left", e.PendingAttestations.Len())
+	}
+}
+
+// TestReplayPendingAttestations_NoBucketIsNoOp verifies the helper handles
+// an unknown head root cleanly — no error, no panic, no spurious work.
+func TestReplayPendingAttestations_NoBucketIsNoOp(t *testing.T) {
+	e := &Engine{
+		PendingAttestations: NewPendingAttestationBuffer(8, 64),
+		AggCtl:              NewAggregatorController(false),
+	}
+
+	var head [32]byte
+	head[0] = 0xff
+
+	// Nothing buffered — must not panic.
+	e.replayPendingAttestations(head)
+
+	if e.PendingAttestations.Total() != 0 {
+		t.Fatalf("total=%d, want 0", e.PendingAttestations.Total())
+	}
+}

--- a/node/store_block.go
+++ b/node/store_block.go
@@ -116,6 +116,7 @@ func onBlockCore(
 	}
 	if newFinalized != nil {
 		s.SetLatestFinalized(newFinalized)
+		IncFinalization("success")
 	}
 
 	// Store block header, state, and live chain entry.

--- a/node/tick.go
+++ b/node/tick.go
@@ -135,6 +135,7 @@ func (e *Engine) updateHead(logTree bool) {
 			SetAttestationSignatures(e.Store.AttestationSignatures.Len())
 			SetNewAggregatedPayloads(e.Store.NewPayloads.Len())
 			SetKnownAggregatedPayloads(e.Store.KnownPayloads.Len())
+			SetPendingAttestationsTotal(e.PendingAttestations.Total())
 
 			if isReorg {
 				IncForkChoiceReorgs()

--- a/p2p/gossip.go
+++ b/p2p/gossip.go
@@ -26,6 +26,18 @@ var (
 	GossipAggregationSizeHook func(bytes int)
 )
 
+// Peer event metric hooks set by node package at startup. Nil-safe.
+// Direction is "inbound" or "outbound" per the libp2p connection stat.
+// Reason on disconnect is best-effort; libp2p doesn't always expose a
+// precise cause, so callers default to "remote_close" for ordinary
+// disconnects. PeerCountHook reports the aggregate connected peer count
+// after every connect/disconnect.
+var (
+	PeerConnectedHook    func(direction string)
+	PeerDisconnectedHook func(direction, reason string)
+	PeerCountHook        func(count int)
+)
+
 // StartGossipListeners starts goroutines that read from each subscribed topic
 // and dispatch decoded messages to the handler.
 func (h *Host) StartGossipListeners(handler MessageHandler) {

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -129,16 +129,34 @@ func NewHost(ctx context.Context, nodeKeyPath string, listenPort int, committeeC
 		ConnectedF: func(n network.Network, conn network.Conn) {
 			peerID := conn.RemotePeer()
 			p2pHost.peerStore.Add(peerID)
+			direction := directionLabel(conn.Stat().Direction)
+			count := p2pHost.peerStore.Count()
 			logger.Info(logger.Network, "peer connected peer_id=%s direction=%s peers=%d",
-				peerID, conn.Stat().Direction, p2pHost.peerStore.Count())
+				peerID, conn.Stat().Direction, count)
+			if PeerConnectedHook != nil {
+				PeerConnectedHook(direction)
+			}
+			if PeerCountHook != nil {
+				PeerCountHook(count)
+			}
 		},
 		DisconnectedF: func(n network.Network, conn network.Conn) {
 			peerID := conn.RemotePeer()
 			// Only remove if fully disconnected (no remaining connections).
 			if n.Connectedness(peerID) != network.Connected {
 				p2pHost.peerStore.Remove(peerID)
+				direction := directionLabel(conn.Stat().Direction)
+				count := p2pHost.peerStore.Count()
 				logger.Info(logger.Network, "peer disconnected peer_id=%s peers=%d",
-					peerID, p2pHost.peerStore.Count())
+					peerID, count)
+				if PeerDisconnectedHook != nil {
+					// libp2p doesn't expose a structured cause here;
+					// default to remote_close for ordinary peer churn.
+					PeerDisconnectedHook(direction, "remote_close")
+				}
+				if PeerCountHook != nil {
+					PeerCountHook(count)
+				}
 			}
 		},
 	})

--- a/p2p/peers.go
+++ b/p2p/peers.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
 
@@ -83,6 +84,15 @@ func (ps *PeerStore) AllPeers() []peer.ID {
 		ids = append(ids, id)
 	}
 	return ids
+}
+
+// directionLabel maps a libp2p connection direction to the spec's
+// "inbound"/"outbound" label values.
+func directionLabel(d network.Direction) string {
+	if d == network.DirOutbound {
+		return "outbound"
+	}
+	return "inbound"
 }
 
 // ConnectBootnodes connects to a list of bootnode multiaddrs.


### PR DESCRIPTION
Closes #219.

## Summary

Adds a buffer + fetch + replay loop for gossip attestations whose referenced head block isn't yet in the store. Mirrors Grandine's behavior; closes a liveness gap surfaced during devnet-4 interop where attestations arriving slightly before their block were permanently dropped.

## Motivation

Today, `node/store_validate.go` strict-rejects attestations on unknown head/source/target, and `onGossipAttestation` silently returns. In real p2p the aggregator's block can arrive after its own attestations (separate gossip topics, different propagation rates). Those attestations were unrecoverable. After this PR they are buffered keyed by the missing head root, a targeted `BlocksByRoot` fetch fires, and on block arrival the bucket is drained and each attestation replayed through the same gossip path (so XMSS verification runs against real state).

The infrastructure for this loop already existed for blocks — `PendingBlocks`, `FetchRootCh`, `collectPendingChildren`, `discardFinalizedPending`. This PR adds the symmetric attestation-side wiring.

## What changed

Four self-contained commits, each compiles and tests on its own:

| SHA | Phase | Change |
|---|---|---|
| `abe52e2` | 1 | New `PendingAttestationBuffer` (mutex-guarded, per-root FIFO eviction, hard total cap). 7 unit tests under `-race`. |
| `53270f0` | 2 | Threaded through `Engine`, constants `PendingAttestationsPerRootCap=8` / `TotalCap=512`, new `lean_pending_attestations_total` gauge. |
| `e60fdc4` | 3 | `replayPendingAttestations` placed inside `processOneBlock` so cascaded chain repairs drain per block. `discardFinalizedPending` extended to prune buffered attestations. 2 wiring tests. |
| `861ec84` | 4 | Activation: `onGossipAttestation` buffers on `ErrUnknownHeadBlock` + fires fetch. New counter `lean_attestations_buffer_evicted_total`. |

## Sampling and scope

- **Buffer trigger**: only `ErrUnknownHeadBlock`. Source/target unknowns remain strict-drop. Head is the dominant ordering race in practice; source/target races are rarer and can be added the same way later if metrics show it matters.
- **Replay placement**: inside the per-block success path in `processOneBlock`, not at the `onBlock` entry. A multi-block cascade (parent + N children) thus triggers N+1 drains, one per block in arrival order.
- **Replay concurrency**: one goroutine per buffered attestation, mirroring the existing live-gossip pattern in `Engine.Run()`. XMSS verify is ~500ms; serializing on the engine main loop is unacceptable.

## Known caveats (called out in commit messages)

- **Per-batch fetch dedup**: `runFetchBatcher`'s `seen` map is per-batch (50ms grace window), not across batches. In the common case N attestations for the same unknown head coalesce into one fetch. Under unusual gossip-dispersion timing we may issue 2-3 duplicate `BlocksByRoot` requests per root. `onBlock` idempotent-checks via `HasState` so double delivery is harmless. Engine-level in-flight set is a follow-up if metrics show this is common.
- **Bound on memory under attack**: per-root FIFO cap = 8, total cap = 512 → ~1.3 MB worst-case memory at ~2.5 KB per attestation. `lean_attestations_buffer_evicted_total` counter surfaces flooding.

## Backward compatibility

Purely additive. No public API changed, no existing metric renamed or removed, no wire-format / consensus changes, no new flags or config required. The gossip path adds one bool check per validation failure (only the `ErrUnknownHeadBlock` branch buffers).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l node/` clean
- [x] `go test ./node/` — 9 buffer + replay tests pass
- [x] `go test -race ./...` (excluding xmss FFI and spectests) — all packages clean under `-race`
- [ ] `make test-spec` — currently blocked by missing fixtures on disk (pre-existing, not a regression from this PR; same failure mode as before any commit on this branch)
- [ ] Devnet smoke: watch `lean_pending_attestations_total` over a multi-hour interop run. Healthy = spikes during reorgs/lag, drains on finalization. Persistent monotonic growth would indicate a prune-path bug; persistent non-zero `lean_attestations_buffer_evicted_total` would indicate flooding worth investigating.