### PR TITLE
fix(api): align /states/finalized embedded checkpoints with store view

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -75,6 +75,19 @@ func FinalizedStateHandler(s *node.ConsensusStore) http.HandlerFunc {
 
 		state.LatestBlockHeader.StateRoot = types.ZeroRoot
 
+		// Align embedded checkpoints with the store's current view. The stored
+		// post-state's latest_finalized reflects only what this block's own
+		// attestations finalized, so it lags behind the store once a descendant
+		// block causes this block to itself be finalized. Returning the store's
+		// current finalized checkpoint keeps the served state consistent with
+		// /lean/v0/fork_choice. Also lift latest_justified when it would fall
+		// behind the new finalized slot, preserving the latest_justified.slot
+		// >= latest_finalized.slot invariant.
+		state.LatestFinalized = finalized
+		if state.LatestJustified.Slot < finalized.Slot {
+			state.LatestJustified = s.LatestJustified()
+		}
+
 		data, err := state.MarshalSSZ()
 		if err != nil {
 			http.Error(w, "ssz marshal failed", http.StatusInternalServerError)

--- a/api/server.go
+++ b/api/server.go
@@ -83,6 +83,15 @@ func FinalizedStateHandler(s *node.ConsensusStore) http.HandlerFunc {
 		// /lean/v0/fork_choice. Also lift latest_justified when it would fall
 		// behind the new finalized slot, preserving the latest_justified.slot
 		// >= latest_finalized.slot invariant.
+		//
+		// Only these two checkpoint fields are projected onto the served blob.
+		// The historical arrays (HistoricalBlockHashes, JustifiedSlots,
+		// JustificationsRoots, JustificationsValidators) intentionally remain
+		// as-of-block-R — they are the input state to block R's STF, not a
+		// live view of the chain. Re-projecting them would require re-running
+		// finalization bookkeeping against the store's current view, which is
+		// out of scope for a read handler. Consumers that want live justification
+		// bookkeeping should use /lean/v0/fork_choice.
 		state.LatestFinalized = finalized
 		if state.LatestJustified.Slot < finalized.Slot {
 			state.LatestJustified = s.LatestJustified()

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -1,0 +1,171 @@
+package api
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/geanlabs/gean/node"
+	"github.com/geanlabs/gean/storage"
+	"github.com/geanlabs/gean/types"
+)
+
+// TestFinalizedStateHandlerAlignsCheckpoints reproduces the scenario where the
+// stored post-state's embedded checkpoints lag the store's live view: the state
+// at the finalized block root was computed during that block's own STF, so its
+// LatestFinalized reflects what block-R's own attestations finalized (an
+// ancestor), not the fact that R itself has since become finalized.
+//
+// The handler must project the store's current finalized checkpoint onto the
+// served blob so /lean/v0/states/finalized stays consistent with
+// /lean/v0/fork_choice. It must also preserve the
+// latest_justified.slot >= latest_finalized.slot invariant.
+func TestFinalizedStateHandlerAlignsCheckpoints(t *testing.T) {
+	s := node.NewConsensusStore(storage.NewInMemoryBackend())
+
+	// Block R at slot 11 — the block the store now considers finalized.
+	var finalizedRoot [32]byte
+	finalizedRoot[0] = 0xaa
+
+	header := &types.BlockHeader{
+		Slot:       11,
+		ParentRoot: [32]byte{0x01},
+		StateRoot:  [32]byte{0x02},
+	}
+
+	// Post-state at R: its own attestations finalized an ancestor at slot 8
+	// and justified one at slot 9, which is the lagging view we expect to see
+	// overwritten at serve time.
+	state := &types.State{
+		Config:                   &types.ChainConfig{GenesisTime: 1000},
+		Slot:                     11,
+		LatestBlockHeader:        header,
+		LatestJustified:          &types.Checkpoint{Root: [32]byte{0x03}, Slot: 9},
+		LatestFinalized:          &types.Checkpoint{Root: [32]byte{0x04}, Slot: 8},
+		HistoricalBlockHashes:    [][]byte{make([]byte, 32)},
+		JustifiedSlots:           types.NewBitlistSSZ(16),
+		Validators:               []*types.Validator{{AttestationPubkey: [52]byte{1}, Index: 0}},
+		JustificationsRoots:      [][]byte{make([]byte, 32)},
+		JustificationsValidators: types.NewBitlistSSZ(8),
+	}
+
+	s.InsertState(finalizedRoot, state)
+
+	// Store's live view: R is finalized at slot 11, and a later block has
+	// already justified slot 12.
+	storeFinalized := &types.Checkpoint{Root: finalizedRoot, Slot: 11}
+	storeJustified := &types.Checkpoint{Root: [32]byte{0x05}, Slot: 12}
+	s.SetLatestFinalized(storeFinalized)
+	s.SetLatestJustified(storeJustified)
+
+	req := httptest.NewRequest(http.MethodGet, "/lean/v0/states/finalized", nil)
+	rec := httptest.NewRecorder()
+	FinalizedStateHandler(s)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	body, err := io.ReadAll(rec.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	served := &types.State{}
+	if err := served.UnmarshalSSZ(body); err != nil {
+		t.Fatalf("unmarshal served state: %v", err)
+	}
+
+	if served.LatestFinalized.Slot != storeFinalized.Slot {
+		t.Fatalf("latest_finalized.slot: want %d (store), got %d (stale state)",
+			storeFinalized.Slot, served.LatestFinalized.Slot)
+	}
+	if served.LatestFinalized.Root != storeFinalized.Root {
+		t.Fatalf("latest_finalized.root mismatch with store")
+	}
+
+	if served.LatestJustified.Slot < served.LatestFinalized.Slot {
+		t.Fatalf("invariant violated: latest_justified.slot (%d) < latest_finalized.slot (%d)",
+			served.LatestJustified.Slot, served.LatestFinalized.Slot)
+	}
+	if served.LatestJustified.Slot != storeJustified.Slot {
+		t.Fatalf("latest_justified.slot: want %d (lifted from store), got %d",
+			storeJustified.Slot, served.LatestJustified.Slot)
+	}
+
+	// Canonical post-state form: state_root in latest_block_header is zeroed.
+	if served.LatestBlockHeader.StateRoot != types.ZeroRoot {
+		t.Fatalf("latest_block_header.state_root should be zeroed, got %x",
+			served.LatestBlockHeader.StateRoot)
+	}
+}
+
+// TestFinalizedStateHandlerJustifiedNotLoweredWhenAhead confirms that when the
+// state's embedded latest_justified is already at or ahead of the store's
+// finalized slot, we do not overwrite it — the invariant is already satisfied
+// and the embedded value is the correct one for block-R's era.
+func TestFinalizedStateHandlerJustifiedNotLoweredWhenAhead(t *testing.T) {
+	s := node.NewConsensusStore(storage.NewInMemoryBackend())
+
+	var finalizedRoot [32]byte
+	finalizedRoot[0] = 0xbb
+
+	embeddedJustified := &types.Checkpoint{Root: [32]byte{0x10}, Slot: 20}
+
+	state := &types.State{
+		Config:                   &types.ChainConfig{GenesisTime: 1000},
+		Slot:                     15,
+		LatestBlockHeader:        &types.BlockHeader{Slot: 15},
+		LatestJustified:          embeddedJustified,
+		LatestFinalized:          &types.Checkpoint{Root: [32]byte{0x11}, Slot: 10},
+		HistoricalBlockHashes:    [][]byte{make([]byte, 32)},
+		JustifiedSlots:           types.NewBitlistSSZ(16),
+		Validators:               []*types.Validator{{AttestationPubkey: [52]byte{1}, Index: 0}},
+		JustificationsRoots:      [][]byte{make([]byte, 32)},
+		JustificationsValidators: types.NewBitlistSSZ(8),
+	}
+
+	s.InsertState(finalizedRoot, state)
+	s.SetLatestFinalized(&types.Checkpoint{Root: finalizedRoot, Slot: 15})
+	// Store's justified is ahead of embedded, but embedded is already ahead of
+	// the new finalized slot, so the handler should leave embedded alone.
+	s.SetLatestJustified(&types.Checkpoint{Root: [32]byte{0x12}, Slot: 25})
+
+	req := httptest.NewRequest(http.MethodGet, "/lean/v0/states/finalized", nil)
+	rec := httptest.NewRecorder()
+	FinalizedStateHandler(s)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", rec.Code)
+	}
+
+	served := &types.State{}
+	if err := served.UnmarshalSSZ(rec.Body.Bytes()); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if served.LatestJustified.Slot != embeddedJustified.Slot ||
+		served.LatestJustified.Root != embeddedJustified.Root {
+		t.Fatalf("latest_justified should be preserved from state when already ahead: want slot=%d root=%x, got slot=%d root=%x",
+			embeddedJustified.Slot, embeddedJustified.Root,
+			served.LatestJustified.Slot, served.LatestJustified.Root)
+	}
+}
+
+// TestFinalizedStateHandlerMissingStateReturns503 ensures the handler fails
+// cleanly when the store has a finalized checkpoint but no corresponding state.
+func TestFinalizedStateHandlerMissingStateReturns503(t *testing.T) {
+	s := node.NewConsensusStore(storage.NewInMemoryBackend())
+	var root [32]byte
+	root[0] = 0xcc
+	s.SetLatestFinalized(&types.Checkpoint{Root: root, Slot: 5})
+
+	req := httptest.NewRequest(http.MethodGet, "/lean/v0/states/finalized", nil)
+	rec := httptest.NewRecorder()
+	FinalizedStateHandler(s)(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status: want 503, got %d", rec.Code)
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes hive `rpc_compat: state finalized endpoint tracks latest finalized slot` test (devnet4), which was failing with `state.latest_finalized.slot` lagging behind `fork_choice.finalized.slot` (e.g. 8 vs 11).
- In `FinalizedStateHandler`, overwrite `state.LatestFinalized` with the store's current finalized checkpoint before serializing; lift `state.LatestJustified` to the store's latest justified when it would otherwise fall behind the new finalized slot.

Closes #222 

## Why

The stored post-state at the finalized block root was computed during that block's own state transition, so its embedded `latest_finalized` only reflects what that block's own attestations finalized (a previous checkpoint). Once a descendant block causes this block to itself become finalized, the store's `LatestFinalized` advances but the stored state is never rewritten, leaving the served `/lean/v0/states/finalized` inconsistent with `/lean/v0/fork_choice`.

Aligning the embedded checkpoints at serving time keeps the two endpoints consistent without mutating stored state, and preserves the `latest_justified.slot >= latest_finalized.slot` invariant.

## Test plan

- [x] Built `ghcr.io/geanlabs/gean:devnet4` from this branch and ran `./hive --sim lean --client-file simulators/lean/clients/devnet4.yaml --client gean_devnet4` locally — **32/32 pass** (previously 31/32 with test-32 failing).