### PR TITLE
feat(metrics): wire unwired metric setters (STF, aggregate verify, attestation validation)

### DIFF
--- a/node/metrics.go
+++ b/node/metrics.go
@@ -172,7 +172,7 @@ var (
 	metricSTFTime = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "lean_state_transition_time_seconds",
 		Help:    "Time to process full state transition",
-		Buckets: []float64{0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 4},
+		Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1},
 	})
 	metricSTFSlotsTime = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "lean_state_transition_slots_processing_time_seconds",

--- a/node/node.go
+++ b/node/node.go
@@ -8,6 +8,7 @@ import (
 	"github.com/geanlabs/gean/forkchoice"
 	"github.com/geanlabs/gean/logger"
 	"github.com/geanlabs/gean/p2p"
+	"github.com/geanlabs/gean/statetransition"
 	"github.com/geanlabs/gean/types"
 	"github.com/geanlabs/gean/xmss"
 )
@@ -95,6 +96,14 @@ func (e *Engine) Run(ctx context.Context) {
 	p2p.GossipBlockSizeHook = ObserveGossipBlockSize
 	p2p.GossipAttestationSizeHook = ObserveGossipAttestationSize
 	p2p.GossipAggregationSizeHook = ObserveGossipAggregationSize
+
+	// Wire state-transition observability hooks.
+	statetransition.ObserveTotalTimeHook = ObserveSTFTime
+	statetransition.ObserveSlotsTimeHook = ObserveSTFSlotsTime
+	statetransition.ObserveBlockTimeHook = ObserveSTFBlockTime
+	statetransition.ObserveAttestationsTimeHook = ObserveSTFAttestationsTime
+	statetransition.IncSlotsProcessedHook = IncSTFSlotsProcessed
+	statetransition.IncAttestationsProcessedHook = IncSTFAttestationsProcessed
 
 	// Wire peer event hooks. Client label is "unknown" until libp2p
 	// identify-based client detection is added (follow-up); spec result

--- a/node/store_block.go
+++ b/node/store_block.go
@@ -265,9 +265,14 @@ func verifyBlockSignatures(
 	for _, job := range jobs {
 		job := job
 		g.Go(func() error {
-			if err := xmss.VerifyAggregatedSignature(job.proofData, job.pubkeys, job.dataRoot, job.slot); err != nil {
+			verifyStart := time.Now()
+			err := xmss.VerifyAggregatedSignature(job.proofData, job.pubkeys, job.dataRoot, job.slot)
+			ObservePqSigAggVerificationTime(time.Since(verifyStart).Seconds())
+			if err != nil {
+				IncPqSigAggregatedInvalid()
 				return &StoreError{ErrAggregateVerificationFailed, fmt.Sprintf("attestation %d proof: %v", job.attIdx, err)}
 			}
+			IncPqSigAggregatedValid()
 			return nil
 		})
 	}

--- a/node/store_validate.go
+++ b/node/store_validate.go
@@ -1,11 +1,16 @@
 package node
 
 import (
+	"time"
+
 	"github.com/geanlabs/gean/types"
 )
 
 // ValidateAttestationData checks 9 validation branches for incoming attestations.
 func ValidateAttestationData(s *ConsensusStore, data *types.AttestationData) error {
+	start := time.Now()
+	defer func() { ObserveAttestationValidationTime(time.Since(start).Seconds()) }()
+
 	// 1-3. Availability: source, target, head blocks must exist.
 	sourceHeader := s.GetBlockHeader(data.Source.Root)
 	if sourceHeader == nil {

--- a/node/verify.go
+++ b/node/verify.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/geanlabs/gean/types"
 	"github.com/geanlabs/gean/xmss"
@@ -49,5 +50,13 @@ func verifyAggregatedProof(
 	}
 
 	slot := uint32(data.Slot)
-	return xmss.VerifyAggregatedSignature(proofData, parsedPubkeys, dataRoot, slot)
+	verifyStart := time.Now()
+	err = xmss.VerifyAggregatedSignature(proofData, parsedPubkeys, dataRoot, slot)
+	ObservePqSigAggVerificationTime(time.Since(verifyStart).Seconds())
+	if err != nil {
+		IncPqSigAggregatedInvalid()
+		return err
+	}
+	IncPqSigAggregatedValid()
+	return nil
 }

--- a/statetransition/attestations.go
+++ b/statetransition/attestations.go
@@ -2,6 +2,7 @@ package statetransition
 
 import (
 	"sort"
+	"time"
 
 	"github.com/geanlabs/gean/types"
 )
@@ -9,6 +10,7 @@ import (
 // ProcessAttestations processes all aggregated attestations in a block body,
 // updating justification and finalization state.
 func ProcessAttestations(state *types.State, attestations []*types.AggregatedAttestation) error {
+	start := time.Now()
 	validatorCount := int(state.NumValidators())
 	if validatorCount == 0 {
 		return nil
@@ -30,6 +32,7 @@ func ProcessAttestations(state *types.State, attestations []*types.AggregatedAtt
 	// Build root → slot lookup for finalization pruning.
 	rootToSlot := buildRootToSlot(state)
 
+	var processed uint64
 	for _, agg := range attestations {
 		source := agg.Data.Source
 		target := agg.Data.Target
@@ -71,11 +74,19 @@ func ProcessAttestations(state *types.State, attestations []*types.AggregatedAtt
 			// Try to finalize source.
 			tryFinalize(state, source, target, &justifications, rootToSlot)
 		}
+
+		processed++
 	}
 
 	// Serialize back to flat SSZ storage (sorted for determinism).
 	serializeJustifications(state, justifications, validatorCount)
 
+	if IncAttestationsProcessedHook != nil && processed > 0 {
+		IncAttestationsProcessedHook(processed)
+	}
+	if ObserveAttestationsTimeHook != nil {
+		ObserveAttestationsTimeHook(time.Since(start).Seconds())
+	}
 	return nil
 }
 

--- a/statetransition/block.go
+++ b/statetransition/block.go
@@ -1,15 +1,24 @@
 package statetransition
 
 import (
+	"time"
+
 	"github.com/geanlabs/gean/types"
 )
 
 // ProcessBlock validates a block and applies it to the state.
 func ProcessBlock(state *types.State, block *types.Block) error {
+	start := time.Now()
 	if err := ProcessBlockHeader(state, block); err != nil {
 		return err
 	}
-	return ProcessAttestations(state, block.Body.Attestations)
+	if err := ProcessAttestations(state, block.Body.Attestations); err != nil {
+		return err
+	}
+	if ObserveBlockTimeHook != nil {
+		ObserveBlockTimeHook(time.Since(start).Seconds())
+	}
+	return nil
 }
 
 // ProcessBlockHeader validates the block header and updates the state.

--- a/statetransition/hooks.go
+++ b/statetransition/hooks.go
@@ -1,0 +1,16 @@
+package statetransition
+
+// Observability hooks, assigned by the node package at engine start. Nil-safe.
+// Mirrors the pattern used by p2p.GossipBlockSizeHook for cross-package metric
+// emission without a circular import (statetransition must not import node).
+//
+// Hooks are assigned once before any state transition runs; reads never race
+// with writes.
+var (
+	ObserveTotalTimeHook         func(seconds float64)
+	ObserveSlotsTimeHook         func(seconds float64)
+	ObserveBlockTimeHook         func(seconds float64)
+	ObserveAttestationsTimeHook  func(seconds float64)
+	IncSlotsProcessedHook        func(n uint64)
+	IncAttestationsProcessedHook func(n uint64)
+)

--- a/statetransition/slots.go
+++ b/statetransition/slots.go
@@ -1,12 +1,17 @@
 package statetransition
 
 import (
+	"time"
+
 	"github.com/geanlabs/gean/types"
 )
 
 // ProcessSlots advances the state to targetSlot, caching the state root in the
 // block header if it hasn't been set yet.
 func ProcessSlots(state *types.State, targetSlot uint64) error {
+	start := time.Now()
+	initialSlot := state.Slot
+
 	if state.Slot >= targetSlot {
 		return &StateSlotIsNewerError{TargetSlot: targetSlot, CurrentSlot: state.Slot}
 	}
@@ -22,5 +27,12 @@ func ProcessSlots(state *types.State, targetSlot uint64) error {
 
 	// Advance directly to target slot.
 	state.Slot = targetSlot
+
+	if IncSlotsProcessedHook != nil {
+		IncSlotsProcessedHook(targetSlot - initialSlot)
+	}
+	if ObserveSlotsTimeHook != nil {
+		ObserveSlotsTimeHook(time.Since(start).Seconds())
+	}
 	return nil
 }

--- a/statetransition/transition.go
+++ b/statetransition/transition.go
@@ -1,12 +1,16 @@
 package statetransition
 
 import (
+	"time"
+
 	"github.com/geanlabs/gean/types"
 )
 
 // StateTransition applies a block to a state, producing the post-block state.
 // Steps: process_slots → process_block → verify state_root.
 func StateTransition(state *types.State, block *types.Block) error {
+	start := time.Now()
+
 	// 1. Advance through empty slots to the block's slot.
 	if err := ProcessSlots(state, block.Slot); err != nil {
 		return err
@@ -29,5 +33,8 @@ func StateTransition(state *types.State, block *types.Block) error {
 		}
 	}
 
+	if ObserveTotalTimeHook != nil {
+		ObserveTotalTimeHook(time.Since(start).Seconds())
+	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Wires 10 of the 12 previously-unwired metric setters, lighting up 7+ Grafana panels that were showing zero on gean. Also corrects the bucket range for `lean_state_transition_time_seconds` (previously started at 250 ms; realistic STF is sub-ms to tens-of-ms).

## What's wired

| Metric | Phase |
|---|---|
| `lean_state_transition_time_seconds` | 1 |
| `lean_state_transition_slots_processing_time_seconds` | 1 |
| `lean_state_transition_block_processing_time_seconds` | 1 |
| `lean_state_transition_attestations_processing_time_seconds` | 1 |
| `lean_state_transition_slots_processed_total` | 1 |
| `lean_state_transition_attestations_processed_total` | 1 |
| `lean_pq_sig_aggregated_signatures_verification_time_seconds` | 2 |
| `lean_pq_sig_aggregated_signatures_valid_total` | 2 |
| `lean_pq_sig_aggregated_signatures_invalid_total` | 2 |
| `lean_attestation_validation_time_seconds` | 3 |

## Approach

Phase 1 uses the same hook-var pattern as the existing `p2p.GossipBlockSizeHook` — `statetransition` cannot import `node` without a circular dependency, so observability hooks live in `statetransition/hooks.go` as nil-safe package vars, assigned once in `node.Run()` alongside the existing gossip hooks. Phases 2 and 3 call the setters directly (both live in `node`).

## Semantics

- **STF total time** reported on successful return only. A transition that fails state-root verification is rolled back by the caller; reporting its elapsed time would misrepresent committed work.
- **Slot count** reported on successful return only (same reasoning as above).
- **Attestation count** incremented per-attestation after the validity and bit-size gates — not by batch at function entry. Counts work applied, not submitted.
- **Aggregate verify** records time unconditionally, then increments `valid` or `invalid` based on outcome.

## Deferred to follow-up

Two metrics explicitly **not** in this PR, tracked as a separate follow-up:
- `lean_fork_choice_reorg_depth` — needs a common-ancestor walk against the fork-choice tree
- `lean_table_bytes` — needs a periodic pebble-metrics polling goroutine

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean
- [x] `go test -race ./node/ ./statetransition/` passing
- [ ] Post-rebuild smoke: `curl /metrics | grep lean_state_transition` returns populated histogram buckets