### PR TITLE
fix(node): align migration ordering with leanSpec PR #680

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ run-node2: build ## Run node2 on port 9002
 
 # --- leanSpec fixtures ---
 
-LEAN_SPEC_COMMIT_HASH := 9b89651
+LEAN_SPEC_COMMIT_HASH := e845240
 
 leanSpec: ## Clone leanSpec at pinned main commit (contains devnet-4 changes)
 	git clone https://github.com/leanEthereum/leanSpec.git --single-branch

--- a/forkchoice/forkchoice.go
+++ b/forkchoice/forkchoice.go
@@ -28,8 +28,10 @@ func (fc *ForkChoice) UpdateHead(justifiedRoot [32]byte) [32]byte {
 }
 
 // UpdateSafeTarget computes the head using a 2/3 supermajority threshold.
-// Uses all attestations (both known and new merged) — fromKnown=false reads LatestNew
-// which at call time should contain the merged pool.
+// Reads votes from VoteTracker.LatestNew (fromKnown=false). The caller is
+// responsible for populating LatestNew from the new pool only — per leanSpec
+// PR #680, safe target is an availability signal derived strictly from
+// freshly received votes, not historical knowledge from the known pool.
 func (fc *ForkChoice) UpdateSafeTarget(justifiedRoot [32]byte, numValidators uint64) [32]byte {
 	minScore := int64((2*numValidators + 2) / 3) // ceil(2n/3)
 	deltas := ComputeDeltas(fc.Array.Len(), fc.Votes, false)

--- a/node/consensus_store.go
+++ b/node/consensus_store.go
@@ -264,19 +264,12 @@ func (s *ConsensusStore) ExtractLatestKnownAttestations() map[uint64]*types.Atte
 	return s.KnownPayloads.ExtractLatestAttestations()
 }
 
-// ExtractLatestAllAttestations returns per-validator latest from known+new merged.
-// Used by updateSafeTarget. rs extract_latest_all_attestations (L104).
-func (s *ConsensusStore) ExtractLatestAllAttestations() map[uint64]*types.AttestationData {
-	known := s.KnownPayloads.ExtractLatestAttestations()
-	newAtts := s.NewPayloads.ExtractLatestAttestations()
-	// Merge: new overwrites known if newer.
-	for vid, data := range newAtts {
-		existing, ok := known[vid]
-		if !ok || existing.Slot < data.Slot {
-			known[vid] = data
-		}
-	}
-	return known
+// ExtractLatestNewAttestations returns per-validator latest from new pool only.
+// Used by updateSafeTarget. Per leanSpec PR #680, safe target is an availability
+// signal computed strictly from the new pool — votes already migrated into
+// known are historical and intentionally excluded.
+func (s *ConsensusStore) ExtractLatestNewAttestations() map[uint64]*types.AttestationData {
+	return s.NewPayloads.ExtractLatestAttestations()
 }
 
 // --- Internal metadata helpers ---

--- a/node/consensus_store_test.go
+++ b/node/consensus_store_test.go
@@ -174,26 +174,31 @@ func TestPromoteNewToKnown(t *testing.T) {
 	}
 }
 
-func TestExtractLatestAllAttestations(t *testing.T) {
+// TestExtractLatestNewAttestations verifies the new-pool-only accessor used by
+// updateSafeTarget. Per leanSpec PR #680, safe target must ignore the known pool.
+func TestExtractLatestNewAttestations(t *testing.T) {
 	s := makeTestStore()
 
-	// Validator 0 in known at slot 5.
+	// Validator 0 lives only in the known pool — must be ignored.
 	var dr1 [32]byte
 	dr1[0] = 1
-	bits1 := types.NewBitlistSSZ(1)
+	bits1 := types.NewBitlistSSZ(2)
 	types.BitlistSet(bits1, 0)
 	s.KnownPayloads.Push(dr1, &types.AttestationData{Slot: 5}, &types.AggregatedSignatureProof{Participants: bits1})
 
-	// Validator 0 in new at slot 8 (newer).
+	// Validator 1 lives only in the new pool — must be returned.
 	var dr2 [32]byte
 	dr2[0] = 2
-	bits2 := types.NewBitlistSSZ(1)
-	types.BitlistSet(bits2, 0)
+	bits2 := types.NewBitlistSSZ(2)
+	types.BitlistSet(bits2, 1)
 	s.NewPayloads.Push(dr2, &types.AttestationData{Slot: 8}, &types.AggregatedSignatureProof{Participants: bits2})
 
-	all := s.ExtractLatestAllAttestations()
-	if all[0].Slot != 8 {
-		t.Fatalf("expected slot 8 (newer), got %d", all[0].Slot)
+	got := s.ExtractLatestNewAttestations()
+	if _, found := got[0]; found {
+		t.Fatal("validator 0 lives only in known pool — must not appear")
+	}
+	if got[1] == nil || got[1].Slot != 8 {
+		t.Fatalf("validator 1 should appear at slot 8, got %v", got[1])
 	}
 }
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -75,6 +75,86 @@ func TestEngineUpdateSafeTarget(t *testing.T) {
 	}
 }
 
+// makeSafeTargetEngine builds an engine with a 3-block chain and N validators
+// in head state. Returns the engine and the slot-2 block root used as the
+// safe-target candidate by the regression test below.
+func makeSafeTargetEngine(t *testing.T, numValidators int) (*Engine, [32]byte) {
+	t.Helper()
+	e := makeTestEngine()
+
+	genesis := e.Store.Head()
+	var block1, block2 [32]byte
+	block1[0] = 0x11
+	block2[0] = 0x22
+
+	e.Store.InsertBlockHeader(block1, &types.BlockHeader{Slot: 1, ParentRoot: genesis})
+	e.Store.InsertBlockHeader(block2, &types.BlockHeader{Slot: 2, ParentRoot: block1})
+	e.FC.OnBlock(1, block1, genesis)
+	e.FC.OnBlock(2, block2, block1)
+
+	headState := e.Store.GetState(genesis)
+	headState.Validators = make([]*types.Validator, numValidators)
+	for i := range headState.Validators {
+		headState.Validators[i] = &types.Validator{}
+	}
+	e.Store.InsertState(genesis, headState)
+
+	return e, block2
+}
+
+// planAggregatedVoteForBlock returns an attestation-data payload + proof where
+// the first `numVoters` validators vote for the given head/target block.
+func planAggregatedVoteForBlock(targetRoot [32]byte, targetSlot, numValidators, numVoters uint64) ([32]byte, *types.AttestationData, *types.AggregatedSignatureProof) {
+	bits := types.NewBitlistSSZ(numValidators)
+	for i := uint64(0); i < numVoters; i++ {
+		types.BitlistSet(bits, i)
+	}
+	data := &types.AttestationData{
+		Slot:   targetSlot,
+		Head:   &types.Checkpoint{Root: targetRoot, Slot: targetSlot},
+		Target: &types.Checkpoint{Root: targetRoot, Slot: targetSlot},
+		Source: &types.Checkpoint{},
+	}
+	dataRoot, _ := data.HashTreeRoot()
+	return dataRoot, data, &types.AggregatedSignatureProof{Participants: bits}
+}
+
+// TestUpdateSafeTarget_IgnoresKnownPool reproduces the leanSpec PR #680
+// scenario: votes living only in the known pool must not advance safe target.
+// The same votes via the new pool must advance it.
+func TestUpdateSafeTarget_IgnoresKnownPool(t *testing.T) {
+	const numValidators = 6 // threshold = ceil(2*6/3) = 4
+
+	t.Run("known_pool_only_does_not_advance", func(t *testing.T) {
+		e, block2 := makeSafeTargetEngine(t, numValidators)
+		genesis := e.Store.Head()
+
+		dataRoot, data, proof := planAggregatedVoteForBlock(block2, 2, numValidators, 4)
+		e.Store.KnownPayloads.Push(dataRoot, data, proof)
+
+		e.updateSafeTarget()
+
+		if e.Store.SafeTarget() != genesis {
+			t.Fatalf("safe target advanced past genesis from known-pool-only votes (root=0x%x); leanSpec #680 forbids this",
+				e.Store.SafeTarget())
+		}
+	})
+
+	t.Run("new_pool_advances", func(t *testing.T) {
+		e, block2 := makeSafeTargetEngine(t, numValidators)
+
+		dataRoot, data, proof := planAggregatedVoteForBlock(block2, 2, numValidators, 4)
+		e.Store.NewPayloads.Push(dataRoot, data, proof)
+
+		e.updateSafeTarget()
+
+		if e.Store.SafeTarget() != block2 {
+			t.Fatalf("safe target did not advance to block_2 with 4-of-6 new-pool votes; got 0x%x",
+				e.Store.SafeTarget())
+		}
+	})
+}
+
 func TestEnginePendingBlocks(t *testing.T) {
 	e := makeTestEngine()
 

--- a/node/store_tick.go
+++ b/node/store_tick.go
@@ -42,10 +42,12 @@ func OnTick(
 
 		switch interval {
 		case 0:
-			// Start of slot — promote attestations if proposal exists.
+			// Start of slot — promote attestations if a proposal exists.
+			// When this node will propose, migrate new→known so the head
+			// update + block-builder both read fresh known. Non-proposer
+			// nodes do nothing here; their migration runs at interval 4.
 			if shouldSignalProposal {
 				s.PromoteNewToKnown()
-				// Head update happens in Engine.
 			}
 		case 1:
 			// Vote propagation — no store action.

--- a/node/tick.go
+++ b/node/tick.go
@@ -153,12 +153,15 @@ func (e *Engine) updateHead(logTree bool) {
 	}
 }
 
-// updateSafeTarget runs LMD GHOST with 2/3 threshold using all attestations.
+// updateSafeTarget runs LMD GHOST with 2/3 threshold using only the new pool.
+// Per leanSpec PR #680, safe target is an availability signal: it must reflect
+// only freshly received votes from the current slot, not historical knowledge
+// migrated into the known pool.
 func (e *Engine) updateSafeTarget() {
-	attestations := e.Store.ExtractLatestAllAttestations()
+	attestations := e.Store.ExtractLatestNewAttestations()
 	justifiedRoot := e.Store.LatestJustified().Root
 
-	// Feed merged attestations to vote store as "new" for safe target.
+	// Feed new-pool attestations to vote store as "new" for safe target.
 	for vid, data := range attestations {
 		idx := e.FC.NodeIndex(data.Head.Root)
 		if idx >= 0 {


### PR DESCRIPTION
Closes #229.

## Summary

Brings gean's interval-3 safe-target computation in line with leanSpec PR #680 (https://github.com/leanEthereum/leanSpec/pull/680).

zeam was the reference implementation the spec was aligned to (see https://github.com/blockblaz/zeam/pull/779). gean now mirrors zeam's pattern line-for-line: `updateSafeTarget` reads from the new pool only, and the interval-0 conditional `PromoteNewToKnown` (gated on `hasProposal`) is preserved exactly as in zeam's `tickIntervalUnlocked`. lean (Rust) and nlean (C#) follow the same pattern.

Per the new spec, safe target is an availability signal computed strictly from `latest_new_aggregated_payloads`. Counting the known pool at interval 3 lets safe target advance on stale evidence from earlier slots.

Bumps `LEAN_SPEC_COMMIT_HASH` to `e845240` (PR #680 merge commit). Spec fixtures regenerate cleanly at the new pin.

## Cross-client status (audit at PR time)

| Client | Safe-target pool |
|---|---|
| zeam (reference) | new-only ✅ |
| lean (Rust) | new-only ✅ |
| nlean (C#) | new-only ✅ |
| **gean** (this PR) | new-only ✅ |
| ethlambda | merged — open PR in flight |
| lantern | merged |

## Test plan
- [x] `go build ./... && go vet ./... && gofmt -l` — clean.
- [x] `go test -race -count=1 ./node/ ./forkchoice/` — green, including the new regression test `TestUpdateSafeTarget_IgnoresKnownPool` (mirrors leanSpec `test_safe_target_ignores_known_pool_at_interval_3`).
- [x] `go test -tags spectests -count=1 ./spectests/` — green at the new pin, including `test_justified_divergence_self_heals_in_next_block` (the PR #595 invariant exercising gean's existing fixed-point loop in `buildBlock`).
- [ ] Multi-client devnet soak — to be observed after merge.