### PR TITLE
docs(readme): update Current status to devnet-4

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ A consensus client should be something a developer can read, understand, and ver
 
 ## Current status
 
-gean targets **Lean Consensus devnet-3** (single attestation committee).
+gean targets **Lean Consensus devnet-4**.
 
 | Network | Status | Spec pin |
 |---------|--------|----------|
-| devnet-3 | Active | `leanSpec@be85318` |
+| devnet-4 | Active | `leanSpec@e845240` |
+| devnet-3 | Superseded | `leanSpec@be85318` |
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

- Update `README.md` "Current status" to reflect that gean now targets **Lean Consensus devnet-4**.
- Update the spec pin row to `leanSpec@e845240` (current `LEAN_SPEC_COMMIT_HASH` in `Makefile`).
- Keep devnet-3 in the table as `Superseded` for historical context.

## Why

The `devnet-4` branch already contains 73 commits of devnet-4 work (dual-key validators, recursive XMSS aggregation, block envelope redesign, etc.) but the README still advertised devnet-3 as Active. The "single attestation committee" qualifier was also dropped because devnet-4 introduces per-validator subnet subscriptions.

## Test plan

- [x] `README.md` renders correctly (Markdown table, headings unchanged).
- [x] No code changes; nothing else to test.

Closes #231