### PR TITLE
fix(node): bump leanSpec to a5a05f93 + tighten attestation future-slot bound

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,14 +102,14 @@ run-node2: build ## Run node2 on port 9002
 
 # --- leanSpec fixtures ---
 
-LEAN_SPEC_COMMIT_HASH := e845240
+LEAN_SPEC_COMMIT_HASH := a5a05f93
 
 leanSpec: ## Clone leanSpec at pinned main commit (contains devnet-4 changes)
 	git clone https://github.com/leanEthereum/leanSpec.git --single-branch
 	cd leanSpec && git checkout $(LEAN_SPEC_COMMIT_HASH)
 
 leanSpec/fixtures: leanSpec ## Generate consensus test fixtures from leanSpec
-	cd leanSpec && uv run fill --fork devnet --scheme=prod -o fixtures
+	cd leanSpec && uv run fill --fork lstar --scheme=prod -o fixtures
 
 # --- Docker ---
 

--- a/node/store_errors.go
+++ b/node/store_errors.go
@@ -76,8 +76,8 @@ func errHeadSlotMismatch(cpSlot, blockSlot uint64) error {
 	return &StoreError{ErrHeadSlotMismatch, fmt.Sprintf("head checkpoint slot %d != block slot %d", cpSlot, blockSlot)}
 }
 
-func errAttestationTooFarInFuture(attSlot, currentSlot uint64) error {
-	return &StoreError{ErrAttestationTooFarInFuture, fmt.Sprintf("attestation slot %d too far in future (current %d)", attSlot, currentSlot)}
+func errAttestationTooFarInFuture(attSlot, storeTime uint64) error {
+	return &StoreError{ErrAttestationTooFarInFuture, fmt.Sprintf("attestation slot %d too far in future (store time %d intervals)", attSlot, storeTime)}
 }
 
 func errNotProposer(vid, slot uint64) error {

--- a/node/store_validate.go
+++ b/node/store_validate.go
@@ -1,6 +1,8 @@
 package node
 
 import (
+	"math"
+
 	"github.com/geanlabs/gean/types"
 )
 
@@ -41,10 +43,15 @@ func ValidateAttestationData(s *ConsensusStore, data *types.AttestationData) err
 		return errHeadSlotMismatch(data.Head.Slot, headHeader.Slot)
 	}
 
-	// 9. Time: attestation not > 1 slot in future.
-	currentSlot := s.Time() / types.IntervalsPerSlot
-	if data.Slot > currentSlot+1 {
-		return errAttestationTooFarInFuture(data.Slot, currentSlot)
+	// 9. Time: attestation's start interval must not exceed store time by
+	// more than GossipDisparityIntervals (clock-skew tolerance, ~800ms).
+	// Per leanSpec PR #682, the bound is in intervals, not slots — a whole-slot
+	// margin would let an adversary pre-publish next-slot aggregates ahead of
+	// any honest validator. The first conjunct guards against uint64 overflow
+	// for malicious slot values near MaxUint64.
+	if data.Slot > math.MaxUint64/types.IntervalsPerSlot ||
+		data.Slot*types.IntervalsPerSlot > s.Time()+types.GossipDisparityIntervals {
+		return errAttestationTooFarInFuture(data.Slot, s.Time())
 	}
 
 	return nil

--- a/spectests/stf_test.go
+++ b/spectests/stf_test.go
@@ -69,6 +69,14 @@ func runStateTransitionTest(t *testing.T, tt *StateTransitionTest) {
 
 	expectError := tt.ExpectException != "" || tt.Post == nil
 
+	// Empty blocks list with an expected exception means the spec filler
+	// raised the assertion internally (e.g., process_slots target == state.slot
+	// rejected before any block was constructed). The spec framework's verdict
+	// stands; nothing for us to replay.
+	if len(tt.Blocks) == 0 && tt.ExpectException != "" {
+		return
+	}
+
 	state := tt.Pre.ToState()
 
 	var lastErr error

--- a/types/constants.go
+++ b/types/constants.go
@@ -25,4 +25,10 @@ const (
 
 	// Sync
 	SyncToleranceSlots = 2
+
+	// GossipDisparityIntervals bounds the clock skew the time check is willing
+	// to absorb when admitting a vote whose slot has not yet started locally.
+	// One interval is roughly 800ms, the lean analogue of mainnet's
+	// MAXIMUM_GOSSIP_CLOCK_DISPARITY. Per leanSpec PR #682.
+	GossipDisparityIntervals = 1
 )


### PR DESCRIPTION
Closes #233.

## Summary

Brings gean current with leanSpec main (`a5a05f93`, May 6) and adopts leanSpec PR #682 (https://github.com/leanEthereum/leanSpec/pull/682), which tightens `validate_attestation`'s future-slot bound from slot precision (~4s tolerance) to interval precision (~800ms tolerance).

Previously gean accepted attestations up to almost a full slot before they should have been emitted, which left a pre-publish window an adversary could exploit to gossip next-slot aggregates ahead of any honest validator. The new bound is `data.slot * IntervalsPerSlot <= store.time + GossipDisparityIntervals`.

Bundled with the pin bump because:

- The new fixtures from PR #682 fail against gean's current loose check, so the pin can't be bumped without the fix.
- leanSpec PR #710 dropped the `devnet` fork-name alias, so the filler invocation needs `--fork lstar`.


## Changes

- `Makefile` — `LEAN_SPEC_COMMIT_HASH` `e845240` → `a5a05f93`; filler `--fork devnet` → `--fork lstar`.
- `types/constants.go` — added `GossipDisparityIntervals = 1`.
- `node/store_validate.go` — replaced slot-truncated time check with interval-precision check + explicit overflow guard (Go has no `saturating_mul`).
- `node/store_errors.go` — `errAttestationTooFarInFuture` reports `store_time` (intervals) instead of `current_slot`.
- `spectests/stf_test.go` — empty-blocks guard for negative-test fixtures the spec filler raised internally.


## Test plan
- [x] `go build ./... && go vet ./... && gofmt -l` clean.
- [x] `go test -race -count=1 ./node/` green.
- [x] `make leanSpec/fixtures` regenerates cleanly at the new pin.
- [x] `go test -tags spectests -count=1 ./spectests/` green, including the four new PR #682 disparity-boundary fixtures (`test_attestation_at_disparity_boundary_allowed`, `test_attestation_just_beyond_disparity_boundary_rejected`, plus aggregated counterparts).
- [ ] Multi-client devnet soak — to be observed after merge.