### PR TITLE
Spec conformance bundle: divergence assert + anchor verification + harness richness

### DIFF
--- a/node/store_build.go
+++ b/node/store_build.go
@@ -199,10 +199,13 @@ func buildBlock(
 	stateRoot, _ := postState.HashTreeRoot()
 	finalBlock.StateRoot = stateRoot
 
-	// Spec assertion: the fixed-point loop must close any justified divergence.
+	// Spec invariant: the fixed-point loop must close any justified divergence.
 	// The produced block's post-state justified must be >= store justified.
+	// Without this, peers processing the block would never see the
+	// justification advance, degrading consensus liveness — only nodes that
+	// happened to receive the minority fork would know justification moved.
 	if postState.LatestJustified.Slot < storeJustified.Slot {
-		logger.Error(logger.Chain, "buildBlock: justified divergence not closed: block_justified=%d < store_justified=%d",
+		return nil, nil, errJustifiedDivergenceNotClosed(
 			postState.LatestJustified.Slot, storeJustified.Slot)
 	}
 

--- a/node/store_build_test.go
+++ b/node/store_build_test.go
@@ -177,3 +177,65 @@ func TestCountParticipants(t *testing.T) {
 		t.Errorf("countParticipants(empty): got %d, want 0", countParticipants(empty))
 	}
 }
+
+// TestBuildBlock_RejectsUnclosedDivergence pins the spec invariant: when the
+// fixed-point attestation loop cannot raise the produced block's post-state
+// justified to at least the store's justified, block production must fail.
+// Without this rejection, a non-converged proposal would ship and degrade
+// liveness — only nodes that received the minority fork would see
+// justification advance.
+func TestBuildBlock_RejectsUnclosedDivergence(t *testing.T) {
+	headState := &types.State{
+		Config:                   &types.ChainConfig{GenesisTime: 1000},
+		Slot:                     0,
+		LatestBlockHeader:        &types.BlockHeader{Slot: 0},
+		LatestJustified:          &types.Checkpoint{Slot: 0},
+		LatestFinalized:          &types.Checkpoint{Slot: 0},
+		JustifiedSlots:           types.NewBitlistSSZ(0),
+		JustificationsValidators: types.NewBitlistSSZ(0),
+		Validators:               []*types.Validator{{}},
+	}
+
+	// Pre-cache the state root in LatestBlockHeader, mirroring what
+	// ProcessSlots does on first call after genesis. Without this, buildBlock's
+	// trial ProcessSlots would mutate the header's StateRoot field, changing
+	// its HashTreeRoot — and the parent-root check inside ProcessBlock would
+	// fail with a mismatch unrelated to what we're testing here.
+	stateRoot, err := headState.HashTreeRoot()
+	if err != nil {
+		t.Fatalf("compute pre-cache state root: %v", err)
+	}
+	headState.LatestBlockHeader.StateRoot = stateRoot
+
+	parentRoot, err := headState.LatestBlockHeader.HashTreeRoot()
+	if err != nil {
+		t.Fatalf("compute parent root: %v", err)
+	}
+
+	// Store justified is artificially ahead of the head state — simulates a
+	// minority-fork advance that this proposer's chain cannot close because
+	// it has no attestations to apply.
+	storeJustified := &types.Checkpoint{Root: [32]byte{0x99}, Slot: 5}
+
+	block, sigs, err := buildBlock(
+		headState,
+		1, // slot (proposer index = 1 % 1 = 0)
+		0, // proposer index
+		parentRoot,
+		nil, // knownBlockRoots — unused with empty payloads
+		nil, // payloads — empty so the fixed-point loop is skipped, divergence stays open
+		storeJustified,
+		nil, // pkCache — unused with empty payloads
+	)
+
+	if block != nil || sigs != nil {
+		t.Fatalf("expected nil block/sigs on rejection, got block=%v sigs=%v", block, sigs)
+	}
+	if err == nil {
+		t.Fatal("expected error for unclosed divergence, got nil")
+	}
+	se, ok := err.(*StoreError)
+	if !ok || se.Kind != ErrJustifiedDivergenceNotClosed {
+		t.Fatalf("expected ErrJustifiedDivergenceNotClosed, got %v", err)
+	}
+}

--- a/node/store_errors.go
+++ b/node/store_errors.go
@@ -38,6 +38,7 @@ const (
 	ErrNotProposer
 	ErrDuplicateAttestationData
 	ErrTooManyAttestationData
+	ErrJustifiedDivergenceNotClosed
 )
 
 func errMissingParentState(parentRoot [32]byte, slot uint64) error {
@@ -86,4 +87,12 @@ func errNotProposer(vid, slot uint64) error {
 
 func errMissingTargetState(root [32]byte) error {
 	return &StoreError{ErrMissingTargetState, fmt.Sprintf("missing target state: %x", root[:4])}
+}
+
+func errJustifiedDivergenceNotClosed(blockJustifiedSlot, storeJustifiedSlot uint64) error {
+	return &StoreError{
+		ErrJustifiedDivergenceNotClosed,
+		fmt.Sprintf("produced block justified slot %d is behind store justified slot %d; fixed-point attestation loop did not converge",
+			blockJustifiedSlot, storeJustifiedSlot),
+	}
 }

--- a/spectests/forkchoice_test.go
+++ b/spectests/forkchoice_test.go
@@ -378,13 +378,39 @@ func runForkChoiceTest(t *testing.T, tt *fcTest) {
 		anchorHeader.BodyRoot = bodyRoot
 	}
 
-	// Cache state root in anchor state's latest block header.
-	anchorState.LatestBlockHeader.StateRoot = anchorBlock.StateRoot
+	// Verify the anchor pair is self-consistent: the anchor block's state_root
+	// must match hash_tree_root(anchor_state). Per leanSpec PR #678 — without
+	// this check, a malformed fixture (or attacker-served (state, block) pair
+	// in production) would be accepted after the runner silently rewrote
+	// state.LatestBlockHeader.StateRoot to match. Direct compare; the spec
+	// expects the input state to arrive with LatestBlockHeader.StateRoot
+	// already in the canonical form that makes the equality hold.
+	//
+	// Empty-steps fixtures with a mismatched pair are negative tests: the
+	// spec expected init to abort here. Treat the rejection as pass.
+	computedStateRoot, err := anchorState.HashTreeRoot()
+	if err != nil {
+		t.Fatalf("hashing anchor state: %v", err)
+	}
+	if computedStateRoot != anchorBlock.StateRoot {
+		if len(tt.Steps) == 0 {
+			t.Logf("anchor init rejected (expected): block=%x state=%x",
+				anchorBlock.StateRoot, computedStateRoot)
+			return
+		}
+		t.Fatalf("anchor state-root mismatch: block=%x state=%x",
+			anchorBlock.StateRoot, computedStateRoot)
+	}
 
 	s.InsertBlockHeader(anchorRoot, anchorHeader)
 	s.InsertState(anchorRoot, anchorState)
 	s.InsertLiveChainEntry(anchorBlock.Slot, anchorRoot, anchorBlock.ParentRoot)
 	s.SetHead(anchorRoot)
+	// Seed checkpoints from the anchor block itself, not from
+	// anchorState.LatestJustified/LatestFinalized. Per leanSpec PR #677, the
+	// store treats the anchor as the new genesis: justified/finalized point
+	// at the anchor block, and any pre-anchor history embedded in the state's
+	// checkpoints is intentionally ignored.
 	s.SetLatestJustified(&types.Checkpoint{Root: anchorRoot, Slot: anchorBlock.Slot})
 	s.SetLatestFinalized(&types.Checkpoint{Root: anchorRoot, Slot: anchorBlock.Slot})
 

--- a/spectests/forkchoice_test.go
+++ b/spectests/forkchoice_test.go
@@ -129,9 +129,34 @@ type fcAggregatedAttestation struct {
 }
 
 type fcChecks struct {
-	HeadSlot      *uint64 `json:"headSlot,omitempty"`
-	HeadRoot      *string `json:"headRoot,omitempty"`
-	HeadRootLabel *string `json:"headRootLabel,omitempty"`
+	Time                     *uint64              `json:"time,omitempty"`
+	HeadSlot                 *uint64              `json:"headSlot,omitempty"`
+	HeadRoot                 *string              `json:"headRoot,omitempty"`
+	HeadRootLabel            *string              `json:"headRootLabel,omitempty"`
+	LatestJustifiedSlot      *uint64              `json:"latestJustifiedSlot,omitempty"`
+	LatestJustifiedRoot      *string              `json:"latestJustifiedRoot,omitempty"`
+	LatestJustifiedRootLabel *string              `json:"latestJustifiedRootLabel,omitempty"`
+	LatestFinalizedSlot      *uint64              `json:"latestFinalizedSlot,omitempty"`
+	LatestFinalizedRoot      *string              `json:"latestFinalizedRoot,omitempty"`
+	LatestFinalizedRootLabel *string              `json:"latestFinalizedRootLabel,omitempty"`
+	SafeTarget               *string              `json:"safeTarget,omitempty"`
+	SafeTargetSlot           *uint64              `json:"safeTargetSlot,omitempty"`
+	SafeTargetRootLabel      *string              `json:"safeTargetRootLabel,omitempty"`
+	AttestationTargetSlot    *uint64              `json:"attestationTargetSlot,omitempty"`
+	AttestationChecks        []fcAttestationCheck `json:"attestationChecks,omitempty"`
+	LexicographicHeadAmong   []string             `json:"lexicographicHeadAmong,omitempty"`
+}
+
+// fcAttestationCheck mirrors leanSpec's per-validator attestation-state
+// expectations: each entry pins one validator's latest attestation slots
+// in a specific store location ("known", "new", etc).
+type fcAttestationCheck struct {
+	Validator       uint64  `json:"validator"`
+	AttestationSlot *uint64 `json:"attestationSlot,omitempty"`
+	HeadSlot        *uint64 `json:"headSlot,omitempty"`
+	SourceSlot      *uint64 `json:"sourceSlot,omitempty"`
+	TargetSlot      *uint64 `json:"targetSlot,omitempty"`
+	Location        string  `json:"location"`
 }
 
 // --- Parsing helpers ---
@@ -695,5 +720,112 @@ func validateChecks(t *testing.T, stepIdx int, checks *fcChecks, s *node.Consens
 					stepIdx, *checks.HeadRootLabel, headRoot, labelRoot)
 			}
 		}
+	}
+
+	if checks.Time != nil {
+		if got := s.Time(); got != *checks.Time {
+			t.Fatalf("step %d check: time got %d, want %d", stepIdx, got, *checks.Time)
+		}
+	}
+
+	lj := s.LatestJustified()
+	if checks.LatestJustifiedSlot != nil && lj.Slot != *checks.LatestJustifiedSlot {
+		t.Fatalf("step %d check: latestJustifiedSlot got %d, want %d",
+			stepIdx, lj.Slot, *checks.LatestJustifiedSlot)
+	}
+	if checks.LatestJustifiedRoot != nil {
+		want := fcParseHexRoot(*checks.LatestJustifiedRoot)
+		if lj.Root != want {
+			t.Fatalf("step %d check: latestJustifiedRoot got 0x%x, want 0x%x",
+				stepIdx, lj.Root, want)
+		}
+	}
+	if checks.LatestJustifiedRootLabel != nil {
+		if labelRoot, ok := labelRoots[*checks.LatestJustifiedRootLabel]; ok && lj.Root != labelRoot {
+			t.Fatalf("step %d check: latestJustifiedRootLabel %q got 0x%x, want 0x%x",
+				stepIdx, *checks.LatestJustifiedRootLabel, lj.Root, labelRoot)
+		}
+	}
+
+	lf := s.LatestFinalized()
+	if checks.LatestFinalizedSlot != nil && lf.Slot != *checks.LatestFinalizedSlot {
+		t.Fatalf("step %d check: latestFinalizedSlot got %d, want %d",
+			stepIdx, lf.Slot, *checks.LatestFinalizedSlot)
+	}
+	if checks.LatestFinalizedRoot != nil {
+		want := fcParseHexRoot(*checks.LatestFinalizedRoot)
+		if lf.Root != want {
+			t.Fatalf("step %d check: latestFinalizedRoot got 0x%x, want 0x%x",
+				stepIdx, lf.Root, want)
+		}
+	}
+	if checks.LatestFinalizedRootLabel != nil {
+		if labelRoot, ok := labelRoots[*checks.LatestFinalizedRootLabel]; ok && lf.Root != labelRoot {
+			t.Fatalf("step %d check: latestFinalizedRootLabel %q got 0x%x, want 0x%x",
+				stepIdx, *checks.LatestFinalizedRootLabel, lf.Root, labelRoot)
+		}
+	}
+
+	// SafeTarget validation requires the runner to simulate
+	// Engine.updateSafeTarget() at interval 3 (extract new-pool attestations,
+	// feed fork-choice votes, recompute the threshold-gated head). The runner
+	// doesn't do that yet, so SafeTarget stays at its anchor-init value.
+	// Parse + log for now; a follow-up wires the simulation.
+	st := s.SafeTarget()
+	if (checks.SafeTarget != nil || checks.SafeTargetSlot != nil || checks.SafeTargetRootLabel != nil) && st == [32]byte{} {
+		t.Logf("step %d: safeTarget assertions deferred — spec runner does not yet simulate updateSafeTarget", stepIdx)
+	} else {
+		if checks.SafeTarget != nil {
+			want := fcParseHexRoot(*checks.SafeTarget)
+			if st != want {
+				t.Fatalf("step %d check: safeTarget got 0x%x, want 0x%x", stepIdx, st, want)
+			}
+		}
+		if checks.SafeTargetRootLabel != nil {
+			if labelRoot, ok := labelRoots[*checks.SafeTargetRootLabel]; ok && st != labelRoot {
+				t.Fatalf("step %d check: safeTargetRootLabel %q got 0x%x, want 0x%x",
+					stepIdx, *checks.SafeTargetRootLabel, st, labelRoot)
+			}
+		}
+		if checks.SafeTargetSlot != nil {
+			stHeader := s.GetBlockHeader(st)
+			if stHeader == nil {
+				t.Fatalf("step %d check: safe target header not found for root 0x%x", stepIdx, st)
+			}
+			if stHeader.Slot != *checks.SafeTargetSlot {
+				t.Fatalf("step %d check: safeTargetSlot got %d, want %d",
+					stepIdx, stHeader.Slot, *checks.SafeTargetSlot)
+			}
+		}
+	}
+
+	if checks.AttestationTargetSlot != nil {
+		target := node.GetAttestationTarget(s)
+		if target.Slot != *checks.AttestationTargetSlot {
+			t.Fatalf("step %d check: attestationTargetSlot got %d, want %d",
+				stepIdx, target.Slot, *checks.AttestationTargetSlot)
+		}
+	}
+
+	if len(checks.LexicographicHeadAmong) > 0 {
+		found := false
+		for _, label := range checks.LexicographicHeadAmong {
+			if root, ok := labelRoots[label]; ok && root == headRoot {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("step %d check: head 0x%x not in lexicographicHeadAmong %v",
+				stepIdx, headRoot, checks.LexicographicHeadAmong)
+		}
+	}
+
+	// AttestationChecks parses cleanly but per-validator attestation validation
+	// against gean's payload pools is a follow-up — needs Location ("known",
+	// "new", etc.) → store-pool routing logic that doesn't exist yet.
+	if len(checks.AttestationChecks) > 0 {
+		t.Logf("step %d: %d attestationChecks not yet validated (follow-up)",
+			stepIdx, len(checks.AttestationChecks))
 	}
 }


### PR DESCRIPTION
Closes #234.

## Summary

Three small spec-conformance fixes bundled as separate commits so each can be reviewed in isolation. All originate from a third-party audit of gean's leanSpec compliance posture.

### Commit 1 — `fix(node): reject divergent block production per spec invariant`

Files: `node/store_errors.go`, `node/store_build.go`, `node/store_build_test.go` (+76 / −2)

leanSpec's `produce_block_with_signatures` asserts the produced block's post-state justified slot is at least the store's justified slot. Gean's `buildBlock` was only logging that condition with `logger.Error` and still returning the block — meaning a non-converged proposal could ship and degrade liveness. Replace the log with a typed `ErrJustifiedDivergenceNotClosed` return. New regression test `TestBuildBlock_RejectsUnclosedDivergence` exercises the rejection path.

Cross-client: ethlambda has the same typed-error pattern. zeam and ream both lack the assertion (worse than gean's prior behavior).

### Commit 2 — `fix(spectests): verify anchor state-root match per leanSpec PR #678`

Files: `spectests/forkchoice_test.go` (+28 / −2)

The spec test runner was silently rewriting `anchorState.LatestBlockHeader.StateRoot = anchorBlock.StateRoot`, defeating the leanSpec PR #678 assertion. Replace the mutation with `hash_tree_root(state) == anchor_block.state_root` verification. Empty-steps fixtures with mismatched pairs are now treated as expected rejections (the new `test_store_from_anchor_rejects_mismatched_state_root` fixture passes).

Note: production checkpoint-sync at `cmd/gean/main.go` was originally suspected of having the same gap, but `checkpoint/checkpoint.go::VerifyCheckpointState` already runs 12 structural checks at parity with ethlambda's verification.

### Commit 3 — `fix(spectests): broaden fork-choice harness check coverage`

Files: `spectests/forkchoice_test.go` (+135 / −3)

`fcChecks` previously parsed only 3 fields (head slot/root/rootLabel). Extended to 16 fields plus a new `fcAttestationCheck` struct, mirroring ethlambda's `StoreChecks`. Now validates: `time`, `latestJustified{Slot,Root,RootLabel}`, `latestFinalized{Slot,Root,RootLabel}`, `attestationTargetSlot`, `lexicographicHeadAmong`.

Two paths honestly deferred with `t.Logf` rather than silent-pass:
- **safeTarget** assertions — the runner doesn't yet simulate `Engine.updateSafeTarget()` at interval 3, so SafeTarget stays at anchor-init zero. Tracked as a follow-up.
- **attestationChecks** — needs Location → store-pool routing layer that doesn't exist yet. Tracked as a follow-up.

Coverage status: 12 of 20 distinct check fields emitted by current fixtures are validated; 8 remain silently ignored by Go's JSON unmarshaller (`reorgDepth`, `latestKnown/NewAggregatedTargetSlots`, `blockAttestationCount`, `blockAttestations`, `attestationSignatureTargetSlots`, `filledBlockRootLabel`, `labelsInStore`). Tracked as a follow-up.

## Test plan
- [x] `go build ./... && go vet ./... && gofmt -l` clean.
- [x] `go test -race -count=1 ./node/ ./forkchoice/` green, including `TestBuildBlock_RejectsUnclosedDivergence`.
- [x] `go test -tags spectests -count=1 ./spectests/` green at the bumped pin (`a5a05f93`), including the new `test_store_from_anchor_rejects_mismatched_state_root` rejection fixture.
- [ ] Multi-client devnet soak after merge.

## Follow-ups (will be filed as separate issues)

- **Spec runner: safe-target wiring** — seed `SetSafeTarget(anchorRoot)` at anchor init + extract `Engine.updateSafeTarget` body into `node.UpdateSafeTarget(s, fc)` and call from spec runner at interval-3 tick steps.
- **Spec runner: validate the 8 silently-ignored check fields** — `reorgDepth`, `latestKnown/NewAggregatedTargetSlots`, `blockAttestationCount`, etc.