### PR TITLE
feat(metrics): leanMetrics PR #34 + #35, rename signatures gauge

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -70,6 +70,9 @@ jobs:
           push: true
           tags: ${{ steps.prep.outputs.tags }}
           platforms: linux/${{ matrix.arch }}
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+            GIT_BRANCH=${{ github.ref_name }}
           cache-from: type=gha,scope=${{ matrix.arch }}
           cache-to: type=gha,scope=${{ matrix.arch }},mode=max
 

--- a/forkchoice/forkchoice.go
+++ b/forkchoice/forkchoice.go
@@ -115,6 +115,38 @@ func (fc *ForkChoice) GetCanonicalAnalysis(anchorRoot [32]byte) (canonical, nonC
 	return canonical, nonCanonical
 }
 
+// ReorgDepth returns the number of blocks abandoned from oldHead during a
+// reorg to newHead — i.e. the count of oldHead's ancestors (including oldHead
+// itself) that are not also ancestors of newHead. Returns 0 when oldHead and
+// newHead share a chain (no reorg, normal extension, or unknown root).
+func (fc *ForkChoice) ReorgDepth(oldHead, newHead [32]byte) uint64 {
+	if oldHead == newHead {
+		return 0
+	}
+	newIdx, ok := fc.Array.indices[newHead]
+	if !ok {
+		return 0
+	}
+	oldIdx, ok := fc.Array.indices[oldHead]
+	if !ok {
+		return 0
+	}
+
+	newAncestors := make(map[[32]byte]struct{})
+	for cur := newIdx; cur >= 0; cur = fc.Array.nodes[cur].Parent {
+		newAncestors[fc.Array.nodes[cur].Root] = struct{}{}
+	}
+
+	depth := uint64(0)
+	for cur := oldIdx; cur >= 0; cur = fc.Array.nodes[cur].Parent {
+		if _, hit := newAncestors[fc.Array.nodes[cur].Root]; hit {
+			return depth
+		}
+		depth++
+	}
+	return depth
+}
+
 // GetCanonicalAncestorAtDepth returns the canonical block at depth steps back from head.
 // Walks parent pointers from head backwards by depth steps.
 func (fc *ForkChoice) GetCanonicalAncestorAtDepth(depth int) (root [32]byte, slot uint64, ok bool) {

--- a/forkchoice/forkchoice_test.go
+++ b/forkchoice/forkchoice_test.go
@@ -324,3 +324,39 @@ func TestDebugOracleTiebreak(t *testing.T) {
 		t.Fatalf("ORACLE MISMATCH: spec=%x proto=%x", specHead[:4], protoHead[:4])
 	}
 }
+
+func TestReorgDepth(t *testing.T) {
+	// Anchor (slot 0) -> A (slot 1) -> A2 (slot 2) -> A3 (slot 3)
+	//                  \-> B (slot 1) -> B2 (slot 2)
+	anchor, a, a2, a3, b, b2 := root(1), root(2), root(3), root(4), root(5), root(6)
+	fc := New(0, anchor)
+	fc.OnBlock(1, a, anchor)
+	fc.OnBlock(2, a2, a)
+	fc.OnBlock(3, a3, a2)
+	fc.OnBlock(1, b, anchor)
+	fc.OnBlock(2, b2, b)
+
+	cases := []struct {
+		name      string
+		oldHead   [32]byte
+		newHead   [32]byte
+		wantDepth uint64
+	}{
+		{"same head no reorg", a3, a3, 0},
+		{"normal extension a → a2 (no reorg)", a, a2, 0},
+		{"1-block reorg a → b at slot 1", a, b, 1},
+		{"2-block reorg a2 → b2 at slot 2", a2, b2, 2},
+		{"3-block reorg a3 → b at slot 1", a3, b, 3},
+		{"unknown old root", root(99), a, 0},
+		{"unknown new root", a, root(99), 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fc.ReorgDepth(tc.oldHead, tc.newHead)
+			if got != tc.wantDepth {
+				t.Fatalf("ReorgDepth(old=%x, new=%x) = %d, want %d",
+					tc.oldHead[:1], tc.newHead[:1], got, tc.wantDepth)
+			}
+		})
+	}
+}

--- a/node/block.go
+++ b/node/block.go
@@ -372,6 +372,15 @@ func (e *Engine) onGossipAttestation(att *types.SignedAttestation) {
 		return
 	}
 
+	// Match leanMetrics observe_on_attestation: emit on clean success only.
+	start := time.Now()
+	success := false
+	defer func() {
+		if success {
+			ObserveAttestationValidationTime(time.Since(start).Seconds())
+		}
+	}()
+
 	// Validate attestation data. If the attestation references a head block
 	// we don't yet know about, buffer it under that head root and fire a
 	// targeted BlocksByRoot fetch — when the block arrives, the block import
@@ -431,6 +440,7 @@ func (e *Engine) onGossipAttestation(att *types.SignedAttestation) {
 	// Store for aggregation.
 	logger.Info(logger.Gossip, "attestation verified: validator=%d slot=%d dataRoot=%x", att.ValidatorID, att.Data.Slot, dataRoot)
 	e.Store.AttestationSignatures.InsertWithHandle(dataRoot, att.Data, att.ValidatorID, att.Signature, sigHandle, parseErr)
+	success = true
 }
 
 // onGossipAggregatedAttestation validates and stores an aggregated attestation.

--- a/node/metrics.go
+++ b/node/metrics.go
@@ -34,6 +34,12 @@ var (
 	metricAttestationCommitteeCount = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "lean_attestation_committee_count", Help: "Number of attestation committees/subnets",
 	})
+	// lean_gossip_signatures is the leanMetrics-standard name (data-source
+	// flavored). It tracks the same pool that leanSpec PR #680-era renamed
+	// from gossip_signatures → attestation_signatures on the spec side; the
+	// metric and field names move in opposite directions on purpose — the
+	// metric is named for where the data comes from (gossip), the field for
+	// what it contains (attestation signatures).
 	metricGossipSignatures = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "lean_gossip_signatures", Help: "Number of gossip signatures in fork-choice store",
 	})

--- a/node/metrics.go
+++ b/node/metrics.go
@@ -61,6 +61,9 @@ var (
 	metricAttestationCommitteeSubnet = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "lean_attestation_committee_subnet", Help: "Node's attestation committee subnet",
 	})
+	metricGossipMeshPeers = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "lean_gossip_mesh_peers", Help: "Number of peers in the gossipsub mesh",
+	})
 )
 
 // --- Counters ---
@@ -272,6 +275,7 @@ func SetConnectedPeers(client string, n int) {
 	metricConnectedPeers.WithLabelValues(client).Set(float64(n))
 }
 func SetAttestationCommitteeSubnet(n uint64) { metricAttestationCommitteeSubnet.Set(float64(n)) }
+func SetGossipMeshPeers(n int)               { metricGossipMeshPeers.Set(float64(n)) }
 
 func IncAttestationsValid(n uint64)          { metricAttestationsValid.Add(float64(n)) }
 func IncAttestationsInvalid()                { metricAttestationsInvalid.Inc() }

--- a/node/metrics.go
+++ b/node/metrics.go
@@ -34,8 +34,8 @@ var (
 	metricAttestationCommitteeCount = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "lean_attestation_committee_count", Help: "Number of attestation committees/subnets",
 	})
-	metricAttestationSignatures = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "lean_attestation_signatures", Help: "Number of attestation signature entries",
+	metricGossipSignatures = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "lean_gossip_signatures", Help: "Number of gossip signatures in fork-choice store",
 	})
 	metricLatestNewAggregatedPayloads = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "lean_latest_new_aggregated_payloads", Help: "Number of new (pending) aggregated payloads",
@@ -256,7 +256,7 @@ func SetIsAggregator(b bool) {
 	}
 }
 func SetAttestationCommitteeCount(n uint64) { metricAttestationCommitteeCount.Set(float64(n)) }
-func SetAttestationSignatures(n int)        { metricAttestationSignatures.Set(float64(n)) }
+func SetGossipSignatures(n int)             { metricGossipSignatures.Set(float64(n)) }
 func SetNewAggregatedPayloads(n int)        { metricLatestNewAggregatedPayloads.Set(float64(n)) }
 func SetKnownAggregatedPayloads(n int)      { metricLatestKnownAggregatedPayloads.Set(float64(n)) }
 func SetPendingAttestationsTotal(n int)     { metricPendingAttestationsTotal.Set(float64(n)) }

--- a/node/metrics.go
+++ b/node/metrics.go
@@ -35,8 +35,8 @@ var (
 		Name: "lean_attestation_committee_count", Help: "Number of attestation committees/subnets",
 	})
 	// lean_gossip_signatures is the leanMetrics-standard name (data-source
-	// flavored). It tracks the same pool that leanSpec PR #680-era renamed
-	// from gossip_signatures → attestation_signatures on the spec side; the
+	// flavored). It tracks the same pool that leanSpec renamed from
+	// gossip_signatures → attestation_signatures on the spec side; the
 	// metric and field names move in opposite directions on purpose — the
 	// metric is named for where the data comes from (gossip), the field for
 	// what it contains (attestation signatures).

--- a/node/metrics.go
+++ b/node/metrics.go
@@ -219,6 +219,11 @@ var (
 		Help:    "Bytes size of a gossip aggregated attestation message",
 		Buckets: []float64{1024, 4096, 16384, 65536, 131072, 262144, 524288, 1048576},
 	})
+	metricTickIntervalDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "lean_tick_interval_duration_seconds",
+		Help:    "Elapsed time between clock ticks in seconds (nominal 0.8s = 4s slot / 5 intervals)",
+		Buckets: []float64{0.4, 0.6, 0.75, 0.8, 0.805, 0.81, 0.815, 0.82, 0.825, 0.85, 0.9, 1.0, 1.2, 1.6},
+	})
 )
 
 // --- Counters for block production ---
@@ -310,10 +315,11 @@ func IncPeerConnection(direction, result string) {
 func IncPeerDisconnection(direction, reason string) {
 	metricPeerDisconnectionEvents.WithLabelValues(direction, reason).Inc()
 }
-func ObserveSTFTime(seconds float64)             { metricSTFTime.Observe(seconds) }
-func ObserveSTFSlotsTime(seconds float64)        { metricSTFSlotsTime.Observe(seconds) }
-func ObserveSTFBlockTime(seconds float64)        { metricSTFBlockTime.Observe(seconds) }
-func ObserveSTFAttestationsTime(seconds float64) { metricSTFAttestationsTime.Observe(seconds) }
+func ObserveTickIntervalDuration(seconds float64) { metricTickIntervalDuration.Observe(seconds) }
+func ObserveSTFTime(seconds float64)              { metricSTFTime.Observe(seconds) }
+func ObserveSTFSlotsTime(seconds float64)         { metricSTFSlotsTime.Observe(seconds) }
+func ObserveSTFBlockTime(seconds float64)         { metricSTFBlockTime.Observe(seconds) }
+func ObserveSTFAttestationsTime(seconds float64)  { metricSTFAttestationsTime.Observe(seconds) }
 
 // Block production observers/counters.
 func ObserveBlockBuildingTime(seconds float64) { metricBlockBuildingTime.Observe(seconds) }

--- a/node/node.go
+++ b/node/node.go
@@ -48,6 +48,11 @@ type Engine struct {
 	AggregationCh chan *types.SignedAggregatedAttestation
 	FailedRootCh  chan [32]byte // roots that exhausted all fetch retries — triggers subtree cleanup
 	FetchRootCh   chan [32]byte // roots to fetch — coalesced into batches by the fetch batcher
+
+	// lastTick holds the wall time of the previous onTick invocation. Zero
+	// means no prior tick — the very first tick records no observation
+	// (would otherwise pollute the histogram with a process-startup delta).
+	lastTick time.Time
 }
 
 // New creates a new Engine.

--- a/node/store_block.go
+++ b/node/store_block.go
@@ -93,9 +93,11 @@ func onBlockCore(
 	postState.UnmarshalSSZ(stateBytes)
 
 	// Execute state transition.
+	stfStart := time.Now()
 	if err := statetransition.StateTransition(postState, block); err != nil {
 		return &StoreError{ErrStateTransitionFailed, fmt.Sprintf("state transition: %v", err)}
 	}
+	ObserveSTFTime(time.Since(stfStart).Seconds())
 
 	// Cache state root in latest block header.
 	postState.LatestBlockHeader.StateRoot = block.StateRoot

--- a/node/tick.go
+++ b/node/tick.go
@@ -11,7 +11,13 @@ import (
 
 // onTick processes an 800ms tick event.
 func (e *Engine) onTick() {
-	timestampMs := uint64(time.Now().UnixMilli())
+	now := time.Now()
+	if !e.lastTick.IsZero() {
+		ObserveTickIntervalDuration(now.Sub(e.lastTick).Seconds())
+	}
+	e.lastTick = now
+
+	timestampMs := uint64(now.UnixMilli())
 
 	currentSlot := e.currentSlot(timestampMs)
 	currentInterval := e.currentInterval(timestampMs)

--- a/node/tick.go
+++ b/node/tick.go
@@ -146,8 +146,10 @@ func (e *Engine) updateHead(logTree bool) {
 
 			if isReorg {
 				IncForkChoiceReorgs()
-				logger.Warn(logger.Forkchoice, "REORG slot=%d head_root=0x%x parent_root=0x%x (was 0x%x) justified_slot=%d justified_root=0x%x finalized_slot=%d finalized_root=0x%x",
-					newHeader.Slot, newHead, newHeader.ParentRoot, oldHead,
+				depth := e.FC.ReorgDepth(oldHead, newHead)
+				ObserveForkChoiceReorgDepth(float64(depth))
+				logger.Warn(logger.Forkchoice, "REORG depth=%d slot=%d head_root=0x%x parent_root=0x%x (was 0x%x) justified_slot=%d justified_root=0x%x finalized_slot=%d finalized_root=0x%x",
+					depth, newHeader.Slot, newHead, newHeader.ParentRoot, oldHead,
 					justified.Slot, justified.Root,
 					finalized.Slot, finalized.Root)
 			} else {

--- a/node/tick.go
+++ b/node/tick.go
@@ -132,7 +132,7 @@ func (e *Engine) updateHead(logTree bool) {
 			SetHeadSlot(newHeader.Slot)
 			SetLatestJustifiedSlot(justified.Slot)
 			SetLatestFinalizedSlot(finalized.Slot)
-			SetAttestationSignatures(e.Store.AttestationSignatures.Len())
+			SetGossipSignatures(e.Store.AttestationSignatures.Len())
 			SetNewAggregatedPayloads(e.Store.NewPayloads.Len())
 			SetKnownAggregatedPayloads(e.Store.KnownPayloads.Len())
 			SetPendingAttestationsTotal(e.PendingAttestations.Total())

--- a/node/tick.go
+++ b/node/tick.go
@@ -24,6 +24,7 @@ func (e *Engine) onTick() {
 
 	SetCurrentSlot(currentSlot)
 	e.updateSyncStatus(currentSlot)
+	e.refreshGossipMeshPeers()
 
 	// Snapshot the aggregator role once per tick. A mid-tick toggle must
 	// not cause OnTick below and the interval-2 branch to observe different
@@ -280,6 +281,13 @@ func (e *Engine) getOurProposer(slot uint64) (uint64, bool) {
 		}
 	}
 	return 0, false
+}
+
+func (e *Engine) refreshGossipMeshPeers() {
+	if e.P2P == nil {
+		return
+	}
+	SetGossipMeshPeers(e.P2P.MeshPeerCount())
 }
 
 // SyncLagSlots is the threshold beyond which the node is considered "syncing"

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -251,6 +251,19 @@ func (h *Host) TopicMeshSizes() map[string]int {
 	return sizes
 }
 
+// MeshPeerCount returns the number of distinct remote peers across all
+// subscribed gossipsub mesh topics. A peer in N meshes is counted once,
+// matching rust-libp2p's all_mesh_peers().count() semantic.
+func (h *Host) MeshPeerCount() int {
+	seen := make(map[peer.ID]struct{})
+	for _, topic := range h.topics {
+		for _, p := range topic.ListPeers() {
+			seen[p] = struct{}{}
+		}
+	}
+	return len(seen)
+}
+
 // LibP2PHost returns the underlying libp2p host for req-resp stream handlers.
 func (h *Host) LibP2PHost() host.Host {
 	return h.host


### PR DESCRIPTION
## Summary
- Add `lean_tick_interval_duration_seconds` histogram ([leanMetrics #34](https://github.com/leanEthereum/leanMetrics/pull/34)) — observed at top of `Engine.onTick()` with skip-first-tick logic
- Add `lean_gossip_mesh_peers` gauge ([leanMetrics #35](https://github.com/leanEthereum/leanMetrics/pull/35)) — distinct-peer semantics via new `Host.MeshPeerCount()`, matching zeam's `all_mesh_peers().count()`
- Rename `lean_attestation_signatures` → `lean_gossip_signatures` to match the standardized name in `metrics.md`

## Notes
- `lean_gossip_mesh_peers` ships as an unlabeled scalar (matches zeam's `Gauge(u64)` shape). The per-peer `client=<name>_<N>` labelling described in `metrics.md` is deferred — sensible to ship once cross-client conventions converge rather than diverge.
- Tick-interval first observation is intentionally skipped to avoid recording a multi-decade delta against the zero `time.Time`.
- Three atomic commits — easy to revert any single piece.

## Test plan
- [x] `go build ./...` green
- [x] `go test ./node ./p2p` passing
- [ ] Multi-client devnet — confirm `lean_tick_interval_duration_seconds` bucket fills around 0.8s, `lean_gossip_mesh_peers` matches connected-peer count, no orphaned `lean_attestation_signatures` references in dashboards