### PR TITLE
fix(ci): pass git commit and branch as docker build-args (#225)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -70,6 +70,9 @@ jobs:
           push: true
           tags: ${{ steps.prep.outputs.tags }}
           platforms: linux/${{ matrix.arch }}
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+            GIT_BRANCH=${{ github.ref_name }}
           cache-from: type=gha,scope=${{ matrix.arch }}
           cache-to: type=gha,scope=${{ matrix.arch }},mode=max
 


### PR DESCRIPTION
Closes #225.

## Problem

The published `ghcr.io/geanlabs/gean:*` images carry `org.opencontainers.image.revision=unknown` and `org.opencontainers.image.ref.name=unknown` instead of the actual commit/branch.

```
$ docker inspect ghcr.io/geanlabs/gean:devnet4 --format '{{json .Config.Labels}}'
{
  "org.opencontainers.image.revision": "unknown",
  "org.opencontainers.image.ref.name": "unknown",
  ...
}
```

## Root cause

The Dockerfile declares `ARG GIT_COMMIT=unknown` / `ARG GIT_BRANCH=unknown` and writes them into the OCI labels. The workflow's `docker/build-push-action@v6` step did not pass these as `build-args`, so the defaults took effect on every CI build.

`make docker-build` (Makefile:119-124) already passes both via `--build-arg`, which is why the bug only surfaced for consumers of the published GHCR images, not for local builds.

## Fix

Add `build-args` to the action invocation:

```yaml
build-args: |
  GIT_COMMIT=${{ github.sha }}
  GIT_BRANCH=${{ github.ref_name }}
```

`github.sha` is the full commit SHA of the workflow trigger; `github.ref_name` is the branch or tag name.

## Test plan
- [ ] CI passes
- [ ] After merge, pull the next published `:devnet4` (or any new tag) and confirm:
  ```
  docker inspect ghcr.io/geanlabs/gean:<tag> --format '{{json .Config.Labels}}' | jq '.["org.opencontainers.image.revision"], .["org.opencontainers.image.ref.name"]'
  ```
  returns the actual commit SHA and branch name (not `unknown`).