### PR TITLE
test(spectests): align fixture paths to lstar/ + wire networking SSZ types

### DIFF
--- a/spectests/api_test.go
+++ b/spectests/api_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Spec fixture directory for api endpoint tests.
-const apiFixturesRoot = "../leanSpec/fixtures/consensus/api_endpoint/devnet/api/test_api_endpoints"
+const apiFixturesRoot = "../leanSpec/fixtures/consensus/api_endpoint/lstar/api/test_api_endpoints"
 
 // leanSpec ships its deterministic test keys here. The fixture's leanEnv
 // ("prod"/"test") selects the subdirectory; each N.json has hex-encoded

--- a/spectests/fixture.go
+++ b/spectests/fixture.go
@@ -72,12 +72,9 @@ type TestDataList struct {
 }
 
 type TestValidator struct {
-	// Devnet-4 dual-key fields (camelCase per spec CamelModel).
 	AttestationPubkey string `json:"attestationPubkey"`
 	ProposalPubkey    string `json:"proposalPubkey"`
-	// Legacy devnet-3 single-key field (fallback).
-	Pubkey string `json:"pubkey"`
-	Index  uint64 `json:"index"`
+	Index             uint64 `json:"index"`
 }
 
 type TestValidatorList struct {
@@ -167,21 +164,10 @@ func (ts *TestState) ToState() *types.State {
 		},
 	}
 
-	// Validators — supports both devnet-4 dual-key and legacy single-key fixtures.
 	for _, v := range ts.Validators.Data {
-		var attPk, propPk [types.PubkeySize]byte
-		if v.AttestationPubkey != "" {
-			attPk = parseHexPubkey(v.AttestationPubkey)
-			propPk = parseHexPubkey(v.ProposalPubkey)
-		} else {
-			// Legacy single-key fallback.
-			pk := parseHexPubkey(v.Pubkey)
-			attPk = pk
-			propPk = pk
-		}
 		state.Validators = append(state.Validators, &types.Validator{
-			AttestationPubkey: attPk,
-			ProposalPubkey:    propPk,
+			AttestationPubkey: parseHexPubkey(v.AttestationPubkey),
+			ProposalPubkey:    parseHexPubkey(v.ProposalPubkey),
 			Index:             v.Index,
 		})
 	}

--- a/spectests/networking_ssz_adapters_test.go
+++ b/spectests/networking_ssz_adapters_test.go
@@ -1,0 +1,105 @@
+//go:build spectests
+
+package spectests
+
+import (
+	ssz "github.com/ferranbt/fastssz"
+
+	"github.com/geanlabs/gean/p2p"
+	"github.com/geanlabs/gean/types"
+)
+
+// sszStatusAdapter wraps p2p.StatusMessage so the SSZ spec-test harness can
+// drive it through the same sszCodec interface as consensus containers.
+//
+// p2p.StatusMessage is hand-rolled SSZ in the networking layer (no
+// HashTreeRoot — req/resp messages aren't merkleized on the consensus hot
+// path). For the leanSpec networking SSZ fixtures we compose the hash here:
+// Status is a Container { finalized: Checkpoint, head: Checkpoint }, and
+// types.Checkpoint already exposes HashTreeRootWith via sszgen.
+type sszStatusAdapter struct {
+	Finalized types.Checkpoint
+	Head      types.Checkpoint
+}
+
+func (s *sszStatusAdapter) MarshalSSZ() ([]byte, error) {
+	msg := p2p.StatusMessage{
+		FinalizedRoot: s.Finalized.Root,
+		FinalizedSlot: s.Finalized.Slot,
+		HeadRoot:      s.Head.Root,
+		HeadSlot:      s.Head.Slot,
+	}
+	return msg.MarshalSSZ(), nil
+}
+
+func (s *sszStatusAdapter) UnmarshalSSZ(buf []byte) error {
+	var msg p2p.StatusMessage
+	if err := msg.UnmarshalSSZ(buf); err != nil {
+		return err
+	}
+	s.Finalized = types.Checkpoint{Root: msg.FinalizedRoot, Slot: msg.FinalizedSlot}
+	s.Head = types.Checkpoint{Root: msg.HeadRoot, Slot: msg.HeadSlot}
+	return nil
+}
+
+func (s *sszStatusAdapter) HashTreeRoot() ([32]byte, error) {
+	return ssz.HashWithDefaultHasher(s)
+}
+
+func (s *sszStatusAdapter) GetTree() (*ssz.Node, error) {
+	return ssz.ProofTree(s)
+}
+
+func (s *sszStatusAdapter) HashTreeRootWith(hh ssz.HashWalker) error {
+	indx := hh.Index()
+	if err := s.Finalized.HashTreeRootWith(hh); err != nil {
+		return err
+	}
+	if err := s.Head.HashTreeRootWith(hh); err != nil {
+		return err
+	}
+	hh.Merkleize(indx)
+	return nil
+}
+
+// sszBlocksByRootRequestAdapter wraps the standalone encode/decode functions
+// from p2p (gean models BlocksByRootRequest as a [][32]byte rather than a
+// struct) so they can flow through the sszCodec contract used by the SSZ
+// spec-test harness. Hash composition: Container { roots: List[Bytes32, MAX_REQUEST_BLOCKS] }.
+type sszBlocksByRootRequestAdapter struct {
+	Roots [][32]byte
+}
+
+func (b *sszBlocksByRootRequestAdapter) MarshalSSZ() ([]byte, error) {
+	return p2p.EncodeBlocksByRootRequest(b.Roots), nil
+}
+
+func (b *sszBlocksByRootRequestAdapter) UnmarshalSSZ(buf []byte) error {
+	roots, err := p2p.DecodeBlocksByRootRequest(buf)
+	if err != nil {
+		return err
+	}
+	b.Roots = roots
+	return nil
+}
+
+func (b *sszBlocksByRootRequestAdapter) HashTreeRoot() ([32]byte, error) {
+	return ssz.HashWithDefaultHasher(b)
+}
+
+func (b *sszBlocksByRootRequestAdapter) GetTree() (*ssz.Node, error) {
+	return ssz.ProofTree(b)
+}
+
+func (b *sszBlocksByRootRequestAdapter) HashTreeRootWith(hh ssz.HashWalker) error {
+	indx := hh.Index()
+	{
+		subIndx := hh.Index()
+		for i := range b.Roots {
+			hh.Append(b.Roots[i][:])
+		}
+		hh.MerkleizeWithMixin(subIndx, uint64(len(b.Roots)), uint64(types.MaxRequestBlocks))
+	}
+	hh.Merkleize(indx)
+	return nil
+}

--- a/spectests/networking_test.go
+++ b/spectests/networking_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Spec fixture directory root rs `leanSpec/fixtures/consensus/networking_codec`.
-const netCodecFixturesRoot = "../leanSpec/fixtures/consensus/networking_codec/devnet/networking"
+const netCodecFixturesRoot = "../leanSpec/fixtures/consensus/networking_codec/lstar/networking"
 
 // netFixtureOuter is the top-level JSON shape: one fixture file contains one
 // outer map whose single key is the pytest test ID and whose value is the fixture.

--- a/spectests/ssz_test.go
+++ b/spectests/ssz_test.go
@@ -17,20 +17,22 @@ import (
 // Spec fixture roots for SSZ conformance tests. Each directory holds fixtures
 // that carry typeName / serialized (SSZ hex) / root (hash_tree_root hex).
 var sszFixtureRoots = []string{
-	"../leanSpec/fixtures/consensus/ssz/devnet/ssz/test_consensus_containers",
-	"../leanSpec/fixtures/consensus/ssz/devnet/ssz/test_networking_containers",
-	"../leanSpec/fixtures/consensus/ssz/devnet/ssz/test_xmss_containers",
+	"../leanSpec/fixtures/consensus/ssz/lstar/ssz/test_consensus_containers",
+	"../leanSpec/fixtures/consensus/ssz/lstar/ssz/test_networking_containers",
+	"../leanSpec/fixtures/consensus/ssz/lstar/ssz/test_xmss_containers",
 }
 
 type sszFixtureOuter map[string]sszFixture
 
 type sszFixture struct {
-	Network    string          `json:"network"`
-	LeanEnv    string          `json:"leanEnv"`
-	TypeName   string          `json:"typeName"`
-	Value      json.RawMessage `json:"value"`
-	Serialized string          `json:"serialized"`
-	Root       string          `json:"root"`
+	Network         string          `json:"network"`
+	LeanEnv         string          `json:"leanEnv"`
+	TypeName        string          `json:"typeName"`
+	Value           json.RawMessage `json:"value"`
+	Serialized      string          `json:"serialized"`
+	Root            string          `json:"root"`
+	ExpectException string          `json:"expectException"`
+	RawBytes        string          `json:"rawBytes"`
 }
 
 // sszCodec is the uniform contract every gean SSZ type satisfies (sszgen
@@ -63,8 +65,13 @@ var hashSkipTypes = map[string]bool{
 
 // sszFactories maps the spec typeName to a zero-value gean struct. Only types
 // whose gean implementation already satisfies sszCodec are registered here;
-// fixtures for other types (Signature, PublicKey, HashTreeLayer, HashTreeOpening,
-// Status, BlocksByRootRequest) are skipped at runtime with a clear reason.
+// fixtures for other types (Signature, PublicKey, HashTreeLayer, HashTreeOpening)
+// are skipped at runtime with a clear reason.
+//
+// Networking req/resp types (Status, BlocksByRootRequest) are registered via
+// thin adapters in networking_ssz_adapters_test.go because their gean
+// implementations live in p2p/ with hand-rolled SSZ that doesn't match the
+// fastssz-generated sszCodec contract.
 var sszFactories = map[string]func() sszCodec{
 	"Checkpoint":                  func() sszCodec { return new(types.Checkpoint) },
 	"Config":                      func() sszCodec { return new(types.ChainConfig) },
@@ -81,7 +88,20 @@ var sszFactories = map[string]func() sszCodec{
 	"SignedAggregatedAttestation": func() sszCodec { return new(types.SignedAggregatedAttestation) },
 	"AggregatedSignatureProof":    func() sszCodec { return new(types.AggregatedSignatureProof) },
 	"State":                       func() sszCodec { return new(types.State) },
+	"Status":                      func() sszCodec { return new(sszStatusAdapter) },
+	"BlocksByRootRequest":         func() sszCodec { return new(sszBlocksByRootRequestAdapter) },
 }
+
+// sszDecodeFailureFactories provides decode-only entry points for fixtures
+// from leanSpec PR #649 that carry expectException + rawBytes and assert the
+// decoder rejects malformed input. Empty for now: the rejection fixtures
+// currently target spec-internal parameterized type wrappers (DecodeBitlist8,
+// DecodeBitvector16) plus basic types (Bytes4, Uint32) that gean never
+// exposes as standalone decoders. The harness skips with a clear reason
+// when typeName isn't registered, so future fixtures targeting types gean
+// does decode (e.g. via UnmarshalSSZ on a registered struct) auto-work
+// once added here.
+var sszDecodeFailureFactories = map[string]func([]byte) error{}
 
 // TestSpecSSZ walks the ssz container fixture directories and, for each
 // fixture, exercises the gean codec end-to-end:
@@ -139,6 +159,11 @@ func TestSpecSSZ(t *testing.T) {
 func runSSZFixture(t *testing.T, fx sszFixture) {
 	t.Helper()
 
+	if fx.ExpectException != "" {
+		runSSZDecodeFailure(t, fx)
+		return
+	}
+
 	factory, ok := sszFactories[fx.TypeName]
 	if !ok {
 		t.Skipf("type %q not wired into ssz harness", fx.TypeName)
@@ -182,5 +207,29 @@ func runSSZFixture(t *testing.T, fx sszFixture) {
 	}
 	if gotRoot != wantRoot {
 		t.Errorf("hash_tree_root mismatch:\n got:  %s\n want: %s", gotRoot, wantRoot)
+	}
+}
+
+// runSSZDecodeFailure handles fixtures with expectException set: the rawBytes
+// payload is decoded against the registered decoder for typeName, and the
+// decode MUST fail. Skips cleanly when typeName isn't registered so future
+// fixtures auto-work as types are wired in.
+func runSSZDecodeFailure(t *testing.T, fx sszFixture) {
+	t.Helper()
+
+	decoder, ok := sszDecodeFailureFactories[fx.TypeName]
+	if !ok {
+		t.Skipf("decode-failure type %q not wired into ssz harness", fx.TypeName)
+		return
+	}
+
+	raw, err := hex.DecodeString(strings.TrimPrefix(fx.RawBytes, "0x"))
+	if err != nil {
+		t.Fatalf("decode rawBytes hex: %v", err)
+	}
+
+	if err := decoder(raw); err == nil {
+		t.Errorf("expected decode of typeName=%q to fail with %s, but it succeeded",
+			fx.TypeName, fx.ExpectException)
 	}
 }


### PR DESCRIPTION
Closes #244.

## Problem

leanSpec moved test fixture output from `tests/consensus/devnet/` → `tests/consensus/lstar/` during the multi-fork refactor (around `ecca01b`/`4d1816d`). gean's spectests still hardcoded the old `devnet/` segment in 4 path constants, so `TestSpecAPI` / `TestSpecSSZ` / `TestSpecNetworkingCodec` all silently `t.Skipf`'d against the missing directories.

Three suites were passing CI with **zero fixtures executed** — a false-positive green.

## Fix

### Path rename (4 places)

| File:line | Before | After |
|---|---|---|
| `spectests/api_test.go:28` | `.../api_endpoint/devnet/api/test_api_endpoints` | `.../api_endpoint/lstar/api/test_api_endpoints` |
| `spectests/networking_test.go:22` | `.../networking_codec/devnet/networking` | `.../networking_codec/lstar/networking` |
| `spectests/ssz_test.go:20-22` | three roots under `consensus/ssz/devnet/ssz/...` | `consensus/ssz/lstar/ssz/...` |

### Dead code removal

`spectests/fixture.go` — drop the legacy single-key `Pubkey` fallback in `TestValidator` (struct field) and `ToState` (consumer `else` branch). No HEAD fixture emits the single-key validator format; dual-key landed in leanSpec PR #449 (`ad9a322`) for Devnet 4.

### SSZ harness expansion

The path fix surfaces fixtures the SSZ runner couldn't consume:

- **Decode-failure fixtures** (leanSpec PR #649): `sszFixture` gains `ExpectException` + `RawBytes` JSON fields. `runSSZFixture` branches on `ExpectException` → new `runSSZDecodeFailure` asserts `UnmarshalSSZ(rawBytes)` errors. `sszDecodeFailureFactories` map empty for now (current rejection fixtures target spec-internal parameterized types `DecodeBitlist8`/`DecodeBitvector16` and basic types `Bytes4`/`Uint32` that gean doesn't expose as standalone decoders); framework auto-handles future fixtures targeting registered types.
- **Networking req/resp types** (`Status`, `BlocksByRootRequest`): new `spectests/networking_ssz_adapters_test.go` wraps `p2p.StatusMessage` and `p2p.EncodeBlocksByRootRequest`/`DecodeBlocksByRootRequest` as `sszCodec`. `HashTreeRoot` composed manually — Status reuses `Checkpoint.HashTreeRootWith`; `BlocksByRootRequest` merkleizes `List[Bytes32, MaxRequestBlocks]` via `ssz.MerkleizeWithMixin`.

## Test results

| Suite | Pass | Skip | Fail | Note |
|---|---|---|---|---|
| SSZ | 43 | 8 | 0 | +6 newly wired (Status×2, BlocksByRootRequest×4); 8 skips are XMSS internals (`Signature`, `PublicKey`, `HashTreeLayer`, `HashTreeOpening` — gean uses opaque cgo handles) |
| API | 12 | 0 | 0 | All paths gean wires (health, finalized state, justified checkpoint 4v/8v, fork_choice 4v/8v, aggregator status×2, aggregator toggle×4) |
| Networking codec | 51 | 115 | 0 | 51 codecs gean wires (varint, gossip topic/message id, ENR happy-path, discv5 ping/pong/findnode); 115 skip with clear "codec %q not yet wired" reasons (gossipsub_rpc, reqresp_*, peer_id, discv5_packet, snappy_*, xor/log2 distance, decode_failure modes) |
| Forkchoice / STF / Signatures | — | — | — | No regression |

## Out of scope (separate follow-ups)

The path fix surfaces three categories of unwired test types that each warrant their own focused PR:

1. XMSS-internal SSZ types (`Signature`, `PublicKey`, `HashTreeLayer`, `HashTreeOpening`).
2. Networking codec coverage (gossipsub RPC protobuf, reqresp wire codec, peer-id derivation, discv5 packet, snappy frame, xor/log2 distance, decode_failure modes).
3. SSZ basic-types (PR #606 — Boolean, Uint*, Bitlist, Bitvector, Bytes*, Union, Fp) and decode-rejection types.

These were silently passing before the path fix; now they're cleanly skipped with clear `t.Skipf` reasons that show up in test output — the right "known unwired" state.

## Test plan
- [x] `go build -tags spectests ./...` clean
- [x] `go test -tags spectests ./spectests/ -count=1` green across all suites (no failures)
- [x] No regression in forkchoice / STF / signatures suites
- [ ] Reviewer confirms the surfaced failure categories are tracked separately before merging