### PR TITLE
fix(runtime): p2p hygiene + restart clock recovery

### DIFF
--- a/cmd/gean/main.go
+++ b/cmd/gean/main.go
@@ -139,6 +139,13 @@ func main() {
 		initStoreFromState(s, genesisState)
 	}
 
+	// Rehydrate store.time from wall clock before any consumer reads it.
+	// On DB restore the persisted time is stale; on genesis/checkpoint init
+	// it is unset. A zero time makes the gossip validator (store_validate.go)
+	// reject every attestation as "too far in future" until the first onTick
+	// fires, opening an 800ms hole at every boot.
+	recoverStoreTime(s, genesisConfig.GenesisTime)
+
 	// --- Initialize fork choice ---
 
 	headRoot := s.Head()
@@ -302,7 +309,8 @@ func initStoreFromState(s *node.ConsensusStore, state *types.State) {
 	s.SetSafeTarget(blockRoot)
 	s.SetLatestJustified(anchor)
 	s.SetLatestFinalized(anchor)
-	s.SetTime(0)
+	// Store time is rehydrated from wall clock by recoverStoreTime after
+	// every init path; no need to seed it here.
 
 	// Store block header and state.
 	s.InsertBlockHeader(blockRoot, header)
@@ -311,4 +319,19 @@ func initStoreFromState(s *node.ConsensusStore, state *types.State) {
 
 	logger.Info(logger.Store, "store initialized from anchor: slot=%d head=%x parent_root=%x state_root=%x",
 		header.Slot, blockRoot, header.ParentRoot, stateRoot)
+}
+
+// recoverStoreTime sets store.time to the interval index corresponding to the
+// current wall clock relative to genesis. Stays at 0 before genesis.
+func recoverStoreTime(s *node.ConsensusStore, genesisTimeSec uint64) {
+	genesisMs := genesisTimeSec * 1000
+	nowMs := uint64(time.Now().UnixMilli())
+	if nowMs <= genesisMs {
+		s.SetTime(0)
+		return
+	}
+	intervals := (nowMs - genesisMs) / types.MillisecondsPerInterval
+	s.SetTime(intervals)
+	logger.Info(logger.Node, "store time rehydrated: intervals=%d genesis_time=%d now_ms=%d",
+		intervals, genesisTimeSec, nowMs)
 }

--- a/cmd/gean/main_test.go
+++ b/cmd/gean/main_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/geanlabs/gean/logger"
+	"github.com/geanlabs/gean/node"
+	"github.com/geanlabs/gean/storage"
+	"github.com/geanlabs/gean/types"
+)
+
+func TestMain(m *testing.M) {
+	logger.Quiet = true
+	m.Run()
+}
+
+func newTestStore() *node.ConsensusStore {
+	return node.NewConsensusStore(storage.NewInMemoryBackend())
+}
+
+func TestRecoverStoreTime_PostGenesis(t *testing.T) {
+	s := newTestStore()
+	nowMs := uint64(time.Now().UnixMilli())
+	genesisSec := (nowMs / 1000) - 10 // genesis 10 seconds ago
+
+	recoverStoreTime(s, genesisSec)
+
+	got := s.Time()
+	expectedMin := uint64(10*1000/types.MillisecondsPerInterval) - 1
+	expectedMax := uint64(10*1000/types.MillisecondsPerInterval) + 1
+	if got < expectedMin || got > expectedMax {
+		t.Fatalf("intervals: expected ~%d, got %d", (expectedMin+expectedMax)/2, got)
+	}
+}
+
+func TestRecoverStoreTime_PreGenesis(t *testing.T) {
+	s := newTestStore()
+	// Seed a non-zero time to verify the function overwrites it.
+	s.SetTime(999)
+
+	farFuture := uint64(time.Now().Unix()) + 86400
+	recoverStoreTime(s, farFuture)
+
+	if got := s.Time(); got != 0 {
+		t.Fatalf("expected time=0 for pre-genesis wall clock, got %d", got)
+	}
+}
+
+func TestRecoverStoreTime_OverwritesStaleValue(t *testing.T) {
+	s := newTestStore()
+	s.SetTime(1) // simulate a stale value persisted from a previous run
+
+	genesisSec := uint64(time.Now().Unix()) - 60 // 60s ago → 75 intervals
+	recoverStoreTime(s, genesisSec)
+
+	if got := s.Time(); got < 70 {
+		t.Fatalf("recovered time did not overwrite stale value: got %d, want >=70", got)
+	}
+}

--- a/node/block.go
+++ b/node/block.go
@@ -40,6 +40,15 @@ func (e *Engine) processOneBlock(signedBlock *types.SignedBlock, queue *[]*types
 		return
 	}
 
+	// Reject blocks strictly below the finalized slot: their parent state has
+	// been pruned and they cannot extend the canonical chain.
+	finalizedSlot := e.Store.LatestFinalized().Slot
+	if block.Slot < finalizedSlot {
+		logger.Warn(logger.Chain, "rejecting pre-finalized block slot=%d block_root=0x%x finalized_slot=%d",
+			block.Slot, blockRoot, finalizedSlot)
+		return
+	}
+
 	hasParent := e.Store.HasState(parentRoot)
 	logger.Info(logger.Chain, "processing block slot=%d block_root=0x%x has_parent=%t", block.Slot, blockRoot, hasParent)
 

--- a/node/node.go
+++ b/node/node.go
@@ -151,6 +151,11 @@ func (e *Engine) Run(ctx context.Context) {
 		}
 	}()
 
+	// Initial-tick catch-up: run onTick once before the ticker fires so the
+	// store, head, and sync status reflect wall-clock time immediately
+	// instead of sitting at boot state for up to one tick interval (800ms).
+	e.onTick()
+
 	for {
 		select {
 		case <-ctx.Done():

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1,8 +1,10 @@
 package node
 
 import (
+	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/geanlabs/gean/forkchoice"
 	"github.com/geanlabs/gean/logger"
@@ -174,6 +176,45 @@ func TestEnginePendingBlocks(t *testing.T) {
 	if len(e.PendingBlockParents) != 1 {
 		t.Fatalf("expected 1 pending block, got %d", len(e.PendingBlockParents))
 	}
+}
+
+// Engine.Run must invoke onTick once before the for-select loop accepts
+// ticker fires. Without the bootstrap call there is up to one tick interval
+// (800ms) of dead time after start where store.time stays at its boot value.
+// The polling check below trips well inside that window.
+func TestEngineRun_InvokesInitialOnTick(t *testing.T) {
+	e := makeTestEngine()
+
+	if got := e.Store.Time(); got != 0 {
+		t.Fatalf("precondition: expected store.time=0 at start, got %d", got)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		e.Run(ctx)
+		close(done)
+	}()
+	defer func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(500 * time.Millisecond):
+			t.Error("Engine.Run did not exit after context cancel")
+		}
+	}()
+
+	// The ticker fires every MillisecondsPerInterval (800ms). Anything
+	// observed before that came from the bootstrap call.
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if e.Store.Time() > 0 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	t.Fatalf("Engine.Run did not invoke initial onTick within 200ms; store.time=%d", e.Store.Time())
 }
 
 func TestProcessOneBlock_RejectsPreFinalized(t *testing.T) {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -176,6 +176,65 @@ func TestEnginePendingBlocks(t *testing.T) {
 	}
 }
 
+func TestProcessOneBlock_RejectsPreFinalized(t *testing.T) {
+	e := makeTestEngine()
+
+	var finalizedRoot, parentRoot [32]byte
+	finalizedRoot[0] = 0x05
+	parentRoot[0] = 0xBB
+	e.Store.SetLatestFinalized(&types.Checkpoint{Root: finalizedRoot, Slot: 10})
+
+	signedBlock := &types.SignedBlock{
+		Block: &types.Block{
+			Slot:       5,
+			ParentRoot: parentRoot,
+			Body:       &types.BlockBody{},
+		},
+		Signature: &types.BlockSignatures{},
+	}
+
+	var queue []*types.SignedBlock
+	e.processOneBlock(signedBlock, &queue)
+
+	if len(e.PendingBlocks) != 0 {
+		t.Fatalf("pre-finalized block was buffered as pending; PendingBlocks=%d", len(e.PendingBlocks))
+	}
+	if len(e.PendingBlockParents) != 0 {
+		t.Fatalf("pre-finalized block recorded a missing-parent entry; PendingBlockParents=%d", len(e.PendingBlockParents))
+	}
+	if len(queue) != 0 {
+		t.Fatalf("pre-finalized block produced cascade work; queue=%d", len(queue))
+	}
+}
+
+func TestProcessOneBlock_AdmitsAtFinalizedSlot(t *testing.T) {
+	e := makeTestEngine()
+
+	var finalizedRoot, parentRoot [32]byte
+	finalizedRoot[0] = 0x05
+	parentRoot[0] = 0xBB
+	e.Store.SetLatestFinalized(&types.Checkpoint{Root: finalizedRoot, Slot: 10})
+
+	// Block AT the finalized slot must pass the guard (strict less-than). With
+	// no parent state available it gets buffered as pending; that's the proof
+	// the new guard didn't drop it.
+	signedBlock := &types.SignedBlock{
+		Block: &types.Block{
+			Slot:       10,
+			ParentRoot: parentRoot,
+			Body:       &types.BlockBody{},
+		},
+		Signature: &types.BlockSignatures{},
+	}
+
+	var queue []*types.SignedBlock
+	e.processOneBlock(signedBlock, &queue)
+
+	if len(e.PendingBlockParents) == 0 {
+		t.Fatal("block at finalized slot was rejected by the strict-less-than guard")
+	}
+}
+
 func TestEngineCascadePending(t *testing.T) {
 	e := makeTestEngine()
 

--- a/p2p/encoding.go
+++ b/p2p/encoding.go
@@ -74,22 +74,17 @@ func EncodeReqRespPayload(data []byte) []byte {
 }
 
 // DecodeReqRespPayload decodes a payload: varint(uncompressed_len) + snappy_framed(data).
-// Uses snappy FRAMED format (not block) for req-resp cross-client compatibility.
+// Uses snappy FRAMED format only, per Ethereum ssz_snappy req/resp spec.
 func DecodeReqRespPayload(buf []byte) ([]byte, error) {
 	declaredLen, rest, err := DecodeVarint(buf)
 	if err != nil {
 		return nil, fmt.Errorf("decode varint: %w", err)
 	}
 
-	// Try framed format first (cross-client), fall back to block format (self-to-self).
 	r := snappy.NewReader(bytes.NewReader(rest))
 	decoded, err := io.ReadAll(r)
 	if err != nil {
-		// Fallback: try block format (for self-to-self communication).
-		decoded, err = snappy.Decode(nil, rest)
-		if err != nil {
-			return nil, fmt.Errorf("snappy decode: %w", err)
-		}
+		return nil, fmt.Errorf("snappy framed decode: %w", err)
 	}
 
 	if declaredLen > 0 && uint32(len(decoded)) != declaredLen {

--- a/p2p/encoding.go
+++ b/p2p/encoding.go
@@ -13,6 +13,7 @@ import (
 const (
 	MaxPayloadSize           = 10 * 1024 * 1024                              // 10 MiB uncompressed
 	MaxCompressedPayloadSize = 32 + MaxPayloadSize + MaxPayloadSize/6 + 1024 // ~12 MiB
+	MaxErrorMessageSize      = 256                                           // ErrorMessage: List[byte, 256]
 )
 
 // --- Gossipsub encoding: raw snappy ---
@@ -106,7 +107,12 @@ const (
 )
 
 // EncodeResponse encodes a response chunk: code + varint(len) + snappy(data).
+// Error response bodies are truncated to MaxErrorMessageSize before encoding
+// per the ErrorMessage: List[byte, 256] wire limit.
 func EncodeResponse(code byte, data []byte) []byte {
+	if code != RespSuccess && len(data) > MaxErrorMessageSize {
+		data = data[:MaxErrorMessageSize]
+	}
 	payload := EncodeReqRespPayload(data)
 	result := make([]byte, 1+len(payload))
 	result[0] = code
@@ -137,6 +143,10 @@ func DecodeResponse(r io.Reader) (byte, []byte, error) {
 	decoded, err := DecodeReqRespPayload(rest)
 	if err != nil {
 		return code, nil, fmt.Errorf("decode response payload: %w", err)
+	}
+
+	if code != RespSuccess && len(decoded) > MaxErrorMessageSize {
+		return code, nil, fmt.Errorf("error message %d bytes exceeds MaxErrorMessageSize %d", len(decoded), MaxErrorMessageSize)
 	}
 
 	return code, decoded, nil

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/golang/snappy"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
@@ -112,6 +113,18 @@ func TestErrorMessageOversizedRejectedOnDecode(t *testing.T) {
 	_, _, err := DecodeResponse(bytes.NewReader(encoded))
 	if err == nil {
 		t.Fatal("expected error for oversize error-body decode, got nil")
+	}
+}
+
+// Rejects block-format snappy data (the historic self-to-self fallback path).
+// Spec requires framed-only on req/resp.
+func TestReqRespPayloadRejectsBlockFormatSnappy(t *testing.T) {
+	raw := []byte("hello world")
+	blockFormat := snappy.Encode(nil, raw)
+	chunk := append(EncodeVarint(uint32(len(raw))), blockFormat...)
+	_, err := DecodeReqRespPayload(chunk)
+	if err == nil {
+		t.Fatal("expected error decoding block-format snappy as framed, got nil")
 	}
 }
 

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -71,6 +71,65 @@ func TestResponseEncoding(t *testing.T) {
 	}
 }
 
+func TestErrorMessageTruncatedOnEncode(t *testing.T) {
+	oversized := bytes.Repeat([]byte("A"), MaxErrorMessageSize+100)
+	encoded := EncodeResponse(RespInvalidRequest, oversized)
+	code, decoded, err := DecodeResponse(bytes.NewReader(encoded))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if code != RespInvalidRequest {
+		t.Fatalf("code: expected %d, got %d", RespInvalidRequest, code)
+	}
+	if len(decoded) != MaxErrorMessageSize {
+		t.Fatalf("decoded length: expected %d, got %d", MaxErrorMessageSize, len(decoded))
+	}
+}
+
+func TestErrorMessageAtBoundaryRoundtrips(t *testing.T) {
+	data := bytes.Repeat([]byte("B"), MaxErrorMessageSize)
+	encoded := EncodeResponse(RespServerError, data)
+	code, decoded, err := DecodeResponse(bytes.NewReader(encoded))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if code != RespServerError {
+		t.Fatalf("code: expected %d, got %d", RespServerError, code)
+	}
+	if !bytes.Equal(data, decoded) {
+		t.Fatal("boundary-size error message roundtrip mismatch")
+	}
+}
+
+// Verifies that a hand-crafted error chunk whose body exceeds
+// MaxErrorMessageSize is rejected by DecodeResponse. Constructed by
+// encoding a >256-byte payload as if for SUCCESS (no truncation) and
+// then rewriting byte 0 to an error code.
+func TestErrorMessageOversizedRejectedOnDecode(t *testing.T) {
+	oversized := bytes.Repeat([]byte("C"), MaxErrorMessageSize+1)
+	encoded := EncodeResponse(RespSuccess, oversized)
+	encoded[0] = RespServerError
+	_, _, err := DecodeResponse(bytes.NewReader(encoded))
+	if err == nil {
+		t.Fatal("expected error for oversize error-body decode, got nil")
+	}
+}
+
+func TestSuccessUntouchedByErrorMessageCap(t *testing.T) {
+	large := bytes.Repeat([]byte("D"), MaxErrorMessageSize+1024)
+	encoded := EncodeResponse(RespSuccess, large)
+	code, decoded, err := DecodeResponse(bytes.NewReader(encoded))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if code != RespSuccess {
+		t.Fatalf("code: expected %d, got %d", RespSuccess, code)
+	}
+	if !bytes.Equal(large, decoded) {
+		t.Fatal("success payload should not be truncated")
+	}
+}
+
 // --- Topic tests ---
 
 func TestTopicStrings(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #247.
## Items

### `#14` `fix(p2p): cap reqresp error body at MAX_ERROR_MESSAGE_SIZE` (`54bd06e`)

**Where:** `p2p/encoding.go` `EncodeResponse` / `DecodeResponse`.

**Before:** outgoing error payloads were sent verbatim through `EncodeReqRespPayload`. Incoming error chunks were decoded up to `MaxCompressedPayloadSize` (~12 MiB). The spec wire limit `ErrorMessage: List[byte, 256]` was respected only by convention at each call site — gean's six current error sites are all under 40 bytes, but the discipline was implicit.

**After:** new `MaxErrorMessageSize = 256` constant. `EncodeResponse` truncates `data` to 256 bytes when `code != RespSuccess`. `DecodeResponse` rejects decoded error bodies exceeding the cap. SUCCESS-coded chunks are untouched, so block / status / range payloads keep their full 10 MiB ceiling.

**Why now:** defense-in-depth against a misbehaving peer flooding us with a multi-MB body labeled \"error\"; the SUCCESS-only carve-out keeps the change zero-risk for legitimate response paths. Tests cover the truncate-on-encode, boundary-roundtrip, oversize-reject-on-decode, and success-untouched cases.

---

### `#15` `fix(p2p): drop snappy block-format fallback in reqresp decoder` (`265daa2`)

**Where:** `p2p/encoding.go` `DecodeReqRespPayload`.

**Before:** the decoder tried framed snappy first and fell back to block-format snappy on framed failure, with a comment claiming the fallback was \"for self-to-self communication.\" In practice no caller in gean emits block-format on req/resp — `EncodeReqRespPayload` only uses `snappy.NewBufferedWriter` (framed). The fallback existed solely as latent tolerance for malformed peers.

**After:** the framed decode failure now returns directly. Block-format snappy on the ssz_snappy req/resp protocol family is rejected per the Ethereum P2P spec.

**Why now:** running gean against zeam / ethlambda in devnet-4 means we want the decoder to fail loud against any client that drifts off the framed-only mandate, not silently accept it. A new test crafts a block-format chunk and asserts rejection.

---

### `#13` `fix(node): reject pre-finalized blocks in processOneBlock` (`373d6b8`)

**Where:** `node/block.go` `processOneBlock`.

**Before:** a block whose `slot < latest_finalized.slot` flowed through to the parent-state check, failed it (parent state is pruned), and got buffered as \"pending parent\" until the depth-discard threshold kicked in. Wasted bookkeeping and inflated the pending buffer with blocks that can never become canonical.

**After:** strict less-than guard immediately after the duplicate-block check. Pre-finalized blocks are dropped with a warning log naming the block, slot, and finalized slot. The canonical finalized block itself is at the boundary (`slot == finalized.slot`) and continues to be handled by the upstream `HasState` duplicate check.

**Cross-client check:**
- zeam `pkgs/node/src/forkchoice.zig:1651` — `if (slot < self.fcStore.latest_finalized.slot) return ForkChoiceError.PreFinalizedSlot;` (strict `<`). Gean mirrors this verbatim.
- ethlambda `crates/blockchain/src/store.rs:430` `on_block_core` — no explicit guard; relies on the parent-state lookup to fail naturally. Less efficient (wastes a state lookup) but spec-conformant. We chose zeam's pattern for the friendlier error path and reduced pending-buffer churn.

Two tests cover the new behavior: a block at `slot = finalized − 5` is rejected without entering `PendingBlocks`; a block at `slot = finalized` (boundary case) passes the guard and proceeds to the parent check (proving the strict `<` is respected).

---

### `#16` `fix(node): recover store time from wall clock on restart` (`c706204`)

**Where:** `cmd/gean/main.go` (init plumbing), `cmd/gean/main_test.go` (new).

**Before:** `initStoreFromState` always called `s.SetTime(0)`. Three init paths share that function: DB restore, checkpoint sync, and genesis. After init, the gossip validator at `node/store_validate.go:53` compares each incoming attestation slot against `s.Time()` (intervals since genesis) to detect future-slot attestations:

```go
if data.Slot*types.IntervalsPerSlot > s.Time()+types.GossipDisparityIntervals {
    return errAttestationTooFarInFuture(data.Slot, s.Time())
}
```

With `s.Time() == 0`, every legitimate attestation received between boot and the first ticker fire (up to 800 ms) is rejected as \"too far in future\" — visible on every gean restart as a transient burst of `attestation too far in future` log lines and a corresponding accept-rate dip on dashboards.

**After:** new `recoverStoreTime(s, genesisTime)` helper:

```go
genesisMs := genesisTimeSec * 1000
nowMs := uint64(time.Now().UnixMilli())
if nowMs <= genesisMs {
    s.SetTime(0)
    return
}
intervals := (nowMs - genesisMs) / types.MillisecondsPerInterval
s.SetTime(intervals)
```

Called once in `main.go` after the DB-restore / checkpoint / genesis branch. Three unit tests cover the post-genesis case, the pre-genesis case (returns 0), and the overwrite-stale-DB-value case.

**Why move it out of `initStoreFromState`?** DB restore doesn't call that function — only checkpoint sync and genesis do. Putting the recovery at the outer call site means the persisted (stale) `time` on DB restore also gets overwritten, closing the hole on all three paths uniformly.

---

### `#37` `fix(node): run onTick once at engine boot` (`9bb5876`) + `test(node):` (`122a2fb`)

**Where:** `node/node.go` `Engine.Run`, `node/node_test.go` (smoke test).

**Before:** `Run` set up the goroutines for the fetch batcher and attestation handlers, then entered the `for-select` loop. The ticker fires every 800 ms (`MillisecondsPerInterval`), so the first `onTick` executed up to one full tick after boot. Until then `lean_current_slot`, `lean_node_sync_status`, head, and safe-target gauges all sat at their boot defaults.

**After:** explicit `e.onTick()` call right before the `for-select` loop. The boot-time tick now sees the wall-clock-correct `store.time` from `#16` and runs the same interval dispatch as any ticker-fired tick.

**Smoke test** (`TestEngineRun_InvokesInitialOnTick`):
1. Boot a test engine with `store.time == 0`.
2. Start `Engine.Run` in a goroutine.
3. Poll up to 200 ms for `store.time` to advance.
4. The 200 ms ceiling is well inside the 800 ms ticker interval — anything observed earlier must have come from the bootstrap call.

The test runs 3× with `-count=3` to verify stability (no flake observed).

**Why `#16` and `#37` together?** They cover the same boot-window in complementary ways. `#16` ensures store time is correct *before* the first tick; `#37` ensures the first tick happens *immediately* rather than 800 ms later. Either alone leaves part of the hole open.

---

## Cross-client baseline

| Item | zeam | ethlambda | grandine | Action taken |
|---|---|---|---|---|
| #14 | enforced | enforced (`crates/net/p2p/.../error.rs` size cap) | n/a (not yet on devnet-4) | Match: defensive cap on both encode + decode |
| #15 | framed-only | framed-only | n/a | Match: drop fallback |
| #13 | strict `<` (`forkchoice.zig:1651`) | implicit via parent-state | n/a | Match zeam's explicit `<` |
| #16 | uses slot-clock recovery on boot | uses wall-clock recovery on boot | n/a | Match the wall-clock approach |
| #37 | initial tick runs at start | initial tick runs at start | n/a | Match |

## Commit format

All six commits follow the saved repo conventions:

- `type(scope): subject` with single scope per commit (no compound scopes)
- 5 `fix(...)` commits for behavior changes + 1 `test(...)` commit for the follow-up smoke test
- No `Co-authored-by` trailer

## Stats

- **6 commits** on `feat/runtime-hygiene-devnet4` off `origin/devnet-4` at `5dfbd7f`
- **+274 / −8** across 7 files
- **10 behavioral tests** added (4 error-size + 1 snappy-framed + 2 pre-finalized + 3 wall-clock recovery)
- **1 smoke test** for engine-boot tick catch-up
- `go vet ./...` clean
- `go test -count=1 ./...` green on a fresh build (verified post-rebase)

## Behavior change for operators

After this merges, on the next gean restart:

- Log volume around boot drops noticeably — no more burst of `attestation too far in future` warnings.
- Grafana panels (`lean_current_slot`, `lean_node_sync_status`, `lean_head_slot`, mesh sizes) leave their boot defaults within ~tens of milliseconds rather than ~800 ms.
- No spurious `pre-finalized block` warnings during normal operation; the log only fires if a peer actually gossips a stale block.
- Peers that send oversized error bodies or block-format snappy on req/resp will see closed streams with a tighter error message; this should not affect spec-conformant peers.

## Spec references

- leanSpec `src/lean_spec/subspecs/networking/config.py:65`
  ```python
  MAX_ERROR_MESSAGE_SIZE: Final[int] = 256
  ```
- leanSpec `src/lean_spec/subspecs/networking/reqresp/handler.py:118`
  ```python
  encoded = code.encode(message.encode(\"utf-8\")[:MAX_ERROR_MESSAGE_SIZE])
  ```
- zeam `pkgs/node/src/forkchoice.zig:1651`
  ```zig
  } else if (slot < self.fcStore.latest_finalized.slot) {
      return ForkChoiceError.PreFinalizedSlot;
  }
  ```

## Test plan

- [ ] CI: `go vet ./...` + `go test -count=1 ./...` green
- [ ] Devnet co-test on the multi-client devnet-4 (gean + zeam + ethlambda + grandine):
  - [ ] Cold-start gean and capture `lean_node_sync_status`, `lean_current_slot`, attestation-accept-rate panels for the first 5 slots after boot
  - [ ] Confirm absence of `attestation too far in future` burst immediately after restart
  - [ ] Confirm head / sync gauges leave boot values within one tick interval
  - [ ] Watch peer-side req/resp protocol errors for 1 slot-clock hour after the snappy-framed-only change is live
  - [ ] Confirm no spurious `pre-finalized block` log entries during normal operation
  - [ ] Restart gean mid-epoch and verify the previously-persisted `store.time` is correctly overwritten on DB restore
- [ ] Hold open for one slot-clock day of devnet observation before merge

## Out of scope (intentional)

- `#243` orphan metric helpers — landed in PR #241 (already merged on `devnet-4`)
- leanSpec PR #708 sync-lag duty gate — bundled into the upcoming PR-D
- leanSpec PR #713 `/lean/v0/blocks/finalized` endpoint — bundled into the upcoming PR-C
- The 49 remaining items from the 60-item compliance audit — tracked in subsequent cycles