### PR TITLE
chore(spectests): conformance coverage — 3 runners, XMSS adapters, fork-choice validations

### DIFF
--- a/spectests/forkchoice_test.go
+++ b/spectests/forkchoice_test.go
@@ -821,12 +821,56 @@ func validateChecks(t *testing.T, stepIdx int, checks *fcChecks, s *node.Consens
 		}
 	}
 
-	// AttestationChecks parses cleanly but per-validator attestation validation
-	// against gean's payload pools is a follow-up — needs Location ("known",
-	// "new", etc.) → store-pool routing logic that doesn't exist yet.
-	if len(checks.AttestationChecks) > 0 {
-		t.Logf("step %d: %d attestationChecks not yet validated (follow-up)",
-			stepIdx, len(checks.AttestationChecks))
+	for _, ac := range checks.AttestationChecks {
+		validateAttestationCheck(t, stepIdx, fc, ac)
+	}
+}
+
+// validateAttestationCheck asserts a per-validator attestation expectation
+// against fc.Votes. Location selects the pool: "new" reads LatestNew, "known"
+// reads LatestKnown. Slot fields not set on the check are skipped.
+func validateAttestationCheck(t *testing.T, stepIdx int, fc *forkchoice.ForkChoice, ac fcAttestationCheck) {
+	t.Helper()
+	tracker, ok := fc.Votes.Votes[ac.Validator]
+	if !ok {
+		t.Fatalf("step %d: attestationCheck v=%d location=%q: no vote tracker", stepIdx, ac.Validator, ac.Location)
+	}
+	var target *forkchoice.VoteTarget
+	switch ac.Location {
+	case "new":
+		target = tracker.LatestNew
+	case "known":
+		target = tracker.LatestKnown
+	default:
+		t.Fatalf("step %d: attestationCheck v=%d: unsupported location %q (want \"new\" or \"known\")",
+			stepIdx, ac.Validator, ac.Location)
+	}
+	if target == nil {
+		t.Fatalf("step %d: attestationCheck v=%d %s: no attestation present in pool",
+			stepIdx, ac.Validator, ac.Location)
+	}
+	if ac.AttestationSlot != nil && target.Slot != *ac.AttestationSlot {
+		t.Errorf("step %d: attestationCheck v=%d %s: attestationSlot got %d, want %d",
+			stepIdx, ac.Validator, ac.Location, target.Slot, *ac.AttestationSlot)
+	}
+	if target.Data == nil {
+		if ac.HeadSlot != nil || ac.SourceSlot != nil || ac.TargetSlot != nil {
+			t.Fatalf("step %d: attestationCheck v=%d %s: tracker has no AttestationData",
+				stepIdx, ac.Validator, ac.Location)
+		}
+		return
+	}
+	if ac.HeadSlot != nil && target.Data.Head != nil && target.Data.Head.Slot != *ac.HeadSlot {
+		t.Errorf("step %d: attestationCheck v=%d %s: headSlot got %d, want %d",
+			stepIdx, ac.Validator, ac.Location, target.Data.Head.Slot, *ac.HeadSlot)
+	}
+	if ac.SourceSlot != nil && target.Data.Source != nil && target.Data.Source.Slot != *ac.SourceSlot {
+		t.Errorf("step %d: attestationCheck v=%d %s: sourceSlot got %d, want %d",
+			stepIdx, ac.Validator, ac.Location, target.Data.Source.Slot, *ac.SourceSlot)
+	}
+	if ac.TargetSlot != nil && target.Data.Target != nil && target.Data.Target.Slot != *ac.TargetSlot {
+		t.Errorf("step %d: attestationCheck v=%d %s: targetSlot got %d, want %d",
+			stepIdx, ac.Validator, ac.Location, target.Data.Target.Slot, *ac.TargetSlot)
 	}
 }
 

--- a/spectests/forkchoice_test.go
+++ b/spectests/forkchoice_test.go
@@ -766,36 +766,36 @@ func validateChecks(t *testing.T, stepIdx int, checks *fcChecks, s *node.Consens
 		}
 	}
 
-	// SafeTarget validation requires the runner to simulate
-	// Engine.updateSafeTarget() at interval 3 (extract new-pool attestations,
-	// feed fork-choice votes, recompute the threshold-gated head). The runner
-	// doesn't do that yet, so SafeTarget stays at its anchor-init value.
-	// Parse + log for now; a follow-up wires the simulation.
+	// Simulate Engine.updateSafeTarget() before reading SafeTarget. Engine
+	// fires this at interval 3; the runner cannot model interval cadence
+	// directly, so it runs on demand whenever a safeTarget* check is set.
+	// fc.Votes still carries LatestNew entries from prior SetNew calls
+	// (the runner promotes the store pool but not the fc.Votes pool), so
+	// UpdateSafeTarget with fromKnown=false reads the right "new pool".
+	if checks.SafeTarget != nil || checks.SafeTargetSlot != nil || checks.SafeTargetRootLabel != nil {
+		simulateUpdateSafeTarget(s, fc)
+	}
 	st := s.SafeTarget()
-	if (checks.SafeTarget != nil || checks.SafeTargetSlot != nil || checks.SafeTargetRootLabel != nil) && st == [32]byte{} {
-		t.Logf("step %d: safeTarget assertions deferred — spec runner does not yet simulate updateSafeTarget", stepIdx)
-	} else {
-		if checks.SafeTarget != nil {
-			want := fcParseHexRoot(*checks.SafeTarget)
-			if st != want {
-				t.Fatalf("step %d check: safeTarget got 0x%x, want 0x%x", stepIdx, st, want)
-			}
+	if checks.SafeTarget != nil {
+		want := fcParseHexRoot(*checks.SafeTarget)
+		if st != want {
+			t.Fatalf("step %d check: safeTarget got 0x%x, want 0x%x", stepIdx, st, want)
 		}
-		if checks.SafeTargetRootLabel != nil {
-			if labelRoot, ok := labelRoots[*checks.SafeTargetRootLabel]; ok && st != labelRoot {
-				t.Fatalf("step %d check: safeTargetRootLabel %q got 0x%x, want 0x%x",
-					stepIdx, *checks.SafeTargetRootLabel, st, labelRoot)
-			}
+	}
+	if checks.SafeTargetRootLabel != nil {
+		if labelRoot, ok := labelRoots[*checks.SafeTargetRootLabel]; ok && st != labelRoot {
+			t.Fatalf("step %d check: safeTargetRootLabel %q got 0x%x, want 0x%x",
+				stepIdx, *checks.SafeTargetRootLabel, st, labelRoot)
 		}
-		if checks.SafeTargetSlot != nil {
-			stHeader := s.GetBlockHeader(st)
-			if stHeader == nil {
-				t.Fatalf("step %d check: safe target header not found for root 0x%x", stepIdx, st)
-			}
-			if stHeader.Slot != *checks.SafeTargetSlot {
-				t.Fatalf("step %d check: safeTargetSlot got %d, want %d",
-					stepIdx, stHeader.Slot, *checks.SafeTargetSlot)
-			}
+	}
+	if checks.SafeTargetSlot != nil {
+		stHeader := s.GetBlockHeader(st)
+		if stHeader == nil {
+			t.Fatalf("step %d check: safe target header not found for root 0x%x", stepIdx, st)
+		}
+		if stHeader.Slot != *checks.SafeTargetSlot {
+			t.Fatalf("step %d check: safeTargetSlot got %d, want %d",
+				stepIdx, stHeader.Slot, *checks.SafeTargetSlot)
 		}
 	}
 
@@ -828,4 +828,20 @@ func validateChecks(t *testing.T, stepIdx int, checks *fcChecks, s *node.Consens
 		t.Logf("step %d: %d attestationChecks not yet validated (follow-up)",
 			stepIdx, len(checks.AttestationChecks))
 	}
+}
+
+// simulateUpdateSafeTarget mirrors Engine.updateSafeTarget (node/tick.go) so
+// the spec runner can validate safeTarget assertions on demand. The runner
+// keeps fc.Votes "new" entries populated from prior SetNew calls (store-side
+// promotion does not clear fc.Votes), so UpdateSafeTarget reads the right
+// new pool.
+func simulateUpdateSafeTarget(s *node.ConsensusStore, fc *forkchoice.ForkChoice) {
+	headState := s.GetState(s.Head())
+	if headState == nil {
+		return
+	}
+	justifiedRoot := s.LatestJustified().Root
+	numValidators := uint64(len(headState.Validators))
+	safeTarget := fc.UpdateSafeTarget(justifiedRoot, numValidators)
+	s.SetSafeTarget(safeTarget)
 }

--- a/spectests/justifiability_test.go
+++ b/spectests/justifiability_test.go
@@ -1,0 +1,83 @@
+//go:build spectests
+
+package spectests
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geanlabs/gean/statetransition"
+)
+
+// Justifiability fixtures live under the lstar/state_transition path tree.
+// Each .json file carries one (slot, finalizedSlot) -> isJustifiable case.
+const justifiabilityFixturesRoot = "../leanSpec/fixtures/consensus/justifiability/lstar/state_transition/test_justifiability"
+
+type justifiabilityFixtureOuter map[string]justifiabilityFixture
+
+type justifiabilityFixture struct {
+	Network       string                 `json:"network"`
+	LeanEnv       string                 `json:"leanEnv"`
+	Slot          uint64                 `json:"slot"`
+	FinalizedSlot uint64                 `json:"finalizedSlot"`
+	Output        justifiabilityOutput   `json:"output"`
+	Info          map[string]interface{} `json:"_info"`
+}
+
+type justifiabilityOutput struct {
+	Delta         uint64 `json:"delta"`
+	IsJustifiable bool   `json:"isJustifiable"`
+}
+
+// TestSpecJustifiability walks the justifiability fixture directory and asserts
+// statetransition.SlotIsJustifiableAfter matches the spec-generated boolean for
+// every (slot, finalizedSlot) pair. Each fixture also carries the precomputed
+// delta = slot - finalizedSlot, which we cross-check for fixture integrity.
+func TestSpecJustifiability(t *testing.T) {
+	if _, err := os.Stat(justifiabilityFixturesRoot); os.IsNotExist(err) {
+		t.Skipf("fixtures not present at %s; run 'make leanSpec/fixtures'", justifiabilityFixturesRoot)
+	}
+
+	err := filepath.Walk(justifiabilityFixturesRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".json") {
+			return err
+		}
+
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("%s: read: %v", path, err)
+			return nil
+		}
+
+		var outer justifiabilityFixtureOuter
+		if err := json.Unmarshal(raw, &outer); err != nil {
+			t.Errorf("%s: parse: %v", path, err)
+			return nil
+		}
+
+		base := strings.TrimSuffix(filepath.Base(path), ".json")
+		for _, fx := range outer {
+			fx := fx
+			t.Run(base, func(t *testing.T) {
+				expectedDelta := fx.Slot - fx.FinalizedSlot
+				if fx.Output.Delta != expectedDelta {
+					t.Errorf("fixture delta inconsistent: slot=%d finalizedSlot=%d computedDelta=%d fixtureDelta=%d",
+						fx.Slot, fx.FinalizedSlot, expectedDelta, fx.Output.Delta)
+				}
+
+				got := statetransition.SlotIsJustifiableAfter(fx.Slot, fx.FinalizedSlot)
+				if got != fx.Output.IsJustifiable {
+					t.Errorf("SlotIsJustifiableAfter(slot=%d, finalizedSlot=%d) = %v, want %v (delta=%d)",
+						fx.Slot, fx.FinalizedSlot, got, fx.Output.IsJustifiable, expectedDelta)
+				}
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk fixtures: %v", err)
+	}
+}

--- a/spectests/slot_clock_test.go
+++ b/spectests/slot_clock_test.go
@@ -1,0 +1,149 @@
+//go:build spectests
+
+package spectests
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geanlabs/gean/types"
+)
+
+// Slot-clock fixtures cover the five derivations in
+// leanSpec subspecs/chain/clock.py:
+//   - current_slot, current_interval, total_intervals: f(genesis_time, now_ms)
+//   - from_slot:                                       f(slot)
+//   - from_unix_time:                                  f(unix_seconds, genesis_time)
+const slotClockFixturesRoot = "../leanSpec/fixtures/consensus/slot_clock/lstar/chain/test_slot_clock"
+
+type slotClockFixtureOuter map[string]slotClockFixture
+
+type slotClockFixture struct {
+	Network   string                 `json:"network"`
+	LeanEnv   string                 `json:"leanEnv"`
+	Operation string                 `json:"operation"`
+	Input     slotClockInput         `json:"input"`
+	Output    slotClockOutput        `json:"output"`
+	Info      map[string]interface{} `json:"_info"`
+}
+
+type slotClockInput struct {
+	GenesisTime   uint64 `json:"genesisTime"`
+	CurrentTimeMs uint64 `json:"currentTimeMs"`
+	UnixSeconds   uint64 `json:"unixSeconds"`
+	Slot          uint64 `json:"slot"`
+}
+
+type slotClockOutput struct {
+	Config         slotClockConfig `json:"config"`
+	Slot           uint64          `json:"slot"`
+	Interval       uint64          `json:"interval"`
+	TotalIntervals uint64          `json:"totalIntervals"`
+}
+
+type slotClockConfig struct {
+	SecondsPerSlot          uint64 `json:"secondsPerSlot"`
+	IntervalsPerSlot        uint64 `json:"intervalsPerSlot"`
+	MillisecondsPerInterval uint64 `json:"millisecondsPerInterval"`
+}
+
+// TestSpecSlotClock walks the slot_clock fixture directory and exercises
+// each of the five slot-clock derivations against the canonical
+// spec-generated inputs and outputs.
+//
+// Also pins the timing config (seconds/slot, intervals/slot, ms/interval)
+// from the fixture against gean's constants to catch drift in either
+// direction.
+func TestSpecSlotClock(t *testing.T) {
+	if _, err := os.Stat(slotClockFixturesRoot); os.IsNotExist(err) {
+		t.Skipf("fixtures not present at %s; run 'make leanSpec/fixtures'", slotClockFixturesRoot)
+	}
+
+	err := filepath.Walk(slotClockFixturesRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".json") {
+			return err
+		}
+
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("%s: read: %v", path, err)
+			return nil
+		}
+
+		var outer slotClockFixtureOuter
+		if err := json.Unmarshal(raw, &outer); err != nil {
+			t.Errorf("%s: parse: %v", path, err)
+			return nil
+		}
+
+		base := strings.TrimSuffix(filepath.Base(path), ".json")
+		for _, fx := range outer {
+			fx := fx
+			t.Run(base, func(t *testing.T) {
+				assertConstantsMatch(t, fx.Output.Config)
+
+				switch fx.Operation {
+				case "current_slot":
+					got := types.CurrentSlot(fx.Input.GenesisTime, fx.Input.CurrentTimeMs)
+					if got != fx.Output.Slot {
+						t.Errorf("CurrentSlot(gt=%d, now=%d) = %d, want %d",
+							fx.Input.GenesisTime, fx.Input.CurrentTimeMs, got, fx.Output.Slot)
+					}
+				case "current_interval":
+					got := types.CurrentInterval(fx.Input.GenesisTime, fx.Input.CurrentTimeMs)
+					if got != fx.Output.Interval {
+						t.Errorf("CurrentInterval(gt=%d, now=%d) = %d, want %d",
+							fx.Input.GenesisTime, fx.Input.CurrentTimeMs, got, fx.Output.Interval)
+					}
+				case "total_intervals":
+					got := types.TotalIntervals(fx.Input.GenesisTime, fx.Input.CurrentTimeMs)
+					if got != fx.Output.TotalIntervals {
+						t.Errorf("TotalIntervals(gt=%d, now=%d) = %d, want %d",
+							fx.Input.GenesisTime, fx.Input.CurrentTimeMs, got, fx.Output.TotalIntervals)
+					}
+				case "from_slot":
+					got := types.IntervalsFromSlot(fx.Input.Slot)
+					if got != fx.Output.Interval {
+						t.Errorf("IntervalsFromSlot(%d) = %d, want %d",
+							fx.Input.Slot, got, fx.Output.Interval)
+					}
+				case "from_unix_time":
+					got := types.IntervalsFromUnixTime(fx.Input.UnixSeconds, fx.Input.GenesisTime)
+					if got != fx.Output.Interval {
+						t.Errorf("IntervalsFromUnixTime(unix=%d, gt=%d) = %d, want %d",
+							fx.Input.UnixSeconds, fx.Input.GenesisTime, got, fx.Output.Interval)
+					}
+				default:
+					t.Skipf("unsupported slot_clock operation %q", fx.Operation)
+				}
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk fixtures: %v", err)
+	}
+}
+
+// assertConstantsMatch confirms that the fixture's declared timing config
+// matches gean's compiled-in constants. A mismatch here means the network
+// timing has drifted between spec and gean — every per-fixture assertion
+// below would still pass numerically but with the wrong physical meaning.
+func assertConstantsMatch(t *testing.T, cfg slotClockConfig) {
+	t.Helper()
+	if cfg.SecondsPerSlot != types.SecondsPerSlot {
+		t.Fatalf("fixture secondsPerSlot=%d, gean SecondsPerSlot=%d",
+			cfg.SecondsPerSlot, types.SecondsPerSlot)
+	}
+	if cfg.IntervalsPerSlot != types.IntervalsPerSlot {
+		t.Fatalf("fixture intervalsPerSlot=%d, gean IntervalsPerSlot=%d",
+			cfg.IntervalsPerSlot, types.IntervalsPerSlot)
+	}
+	if cfg.MillisecondsPerInterval != types.MillisecondsPerInterval {
+		t.Fatalf("fixture millisecondsPerInterval=%d, gean MillisecondsPerInterval=%d",
+			cfg.MillisecondsPerInterval, types.MillisecondsPerInterval)
+	}
+}

--- a/spectests/ssz_test.go
+++ b/spectests/ssz_test.go
@@ -63,15 +63,17 @@ var hashSkipTypes = map[string]bool{
 	"SignedBlock":       true,
 }
 
-// sszFactories maps the spec typeName to a zero-value gean struct. Only types
-// whose gean implementation already satisfies sszCodec are registered here;
-// fixtures for other types (Signature, PublicKey, HashTreeLayer, HashTreeOpening)
-// are skipped at runtime with a clear reason.
+// sszFactories maps the spec typeName to a zero-value gean struct.
 //
 // Networking req/resp types (Status, BlocksByRootRequest) are registered via
 // thin adapters in networking_ssz_adapters_test.go because their gean
 // implementations live in p2p/ with hand-rolled SSZ that doesn't match the
 // fastssz-generated sszCodec contract.
+//
+// XMSS containers (PublicKey, Signature, HashTreeLayer, HashTreeOpening) are
+// registered via xmss_ssz_adapters_test.go. Gean stores XMSS payloads as
+// opaque byte arrays — the inner spec structure exists only in the Rust FFI
+// — so the adapters reconstruct the field layout for hash_tree_root.
 var sszFactories = map[string]func() sszCodec{
 	"Checkpoint":                  func() sszCodec { return new(types.Checkpoint) },
 	"Config":                      func() sszCodec { return new(types.ChainConfig) },
@@ -90,6 +92,10 @@ var sszFactories = map[string]func() sszCodec{
 	"State":                       func() sszCodec { return new(types.State) },
 	"Status":                      func() sszCodec { return new(sszStatusAdapter) },
 	"BlocksByRootRequest":         func() sszCodec { return new(sszBlocksByRootRequestAdapter) },
+	"PublicKey":                   func() sszCodec { return new(sszPublicKeyAdapter) },
+	"Signature":                   func() sszCodec { return new(sszSignatureAdapter) },
+	"HashTreeLayer":               func() sszCodec { return new(sszHashTreeLayerAdapter) },
+	"HashTreeOpening":             func() sszCodec { return new(sszHashTreeOpeningAdapter) },
 }
 
 // sszDecodeFailureFactories provides decode-only entry points for fixtures

--- a/spectests/sync_test.go
+++ b/spectests/sync_test.go
@@ -1,0 +1,144 @@
+//go:build spectests
+
+package spectests
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geanlabs/gean/types"
+)
+
+// Sync fixtures cover the spec's verify_checkpoint_state operation
+// (leanSpec subspecs/sync/checkpoint_sync.py:106). Each .json carries one
+// SSZ-encoded State plus a boolean indicating whether the structural
+// rules accept it.
+const syncFixturesRoot = "../leanSpec/fixtures/consensus/sync/lstar/sync"
+
+type syncFixtureOuter map[string]syncFixture
+
+type syncFixture struct {
+	Network   string                 `json:"network"`
+	LeanEnv   string                 `json:"leanEnv"`
+	Operation string                 `json:"operation"`
+	Input     syncInput              `json:"input"`
+	Output    syncOutput             `json:"output"`
+	Info      map[string]interface{} `json:"_info"`
+}
+
+type syncInput struct {
+	NumValidators uint64 `json:"numValidators"`
+	AnchorSlot    uint64 `json:"anchorSlot"`
+}
+
+type syncOutput struct {
+	Valid          bool   `json:"valid"`
+	StateBytes     string `json:"stateBytes"`
+	ValidatorCount uint64 `json:"validatorCount"`
+	AnchorSlot     uint64 `json:"anchorSlot"`
+}
+
+// verifyCheckpointStructural mirrors the spec's verify_checkpoint_state
+// (leanSpec subspecs/sync/checkpoint_sync.py:106): a state passes if it has
+// at least one validator, the count stays inside VALIDATOR_REGISTRY_LIMIT,
+// and its SSZ tree root can be computed (covers structural decode sanity).
+//
+// Production gean uses checkpoint.VerifyCheckpointState, which additionally
+// cross-checks genesis time and the expected validator set against the
+// caller-supplied configuration and rejects slot 0 outright. That broader
+// policy is stricter than the spec's structural-only definition, so the
+// spec test exercises the narrower contract here.
+func verifyCheckpointStructural(state *types.State) bool {
+	if len(state.Validators) == 0 {
+		return false
+	}
+	if uint64(len(state.Validators)) > types.ValidatorRegistryLimit {
+		return false
+	}
+	if _, err := state.HashTreeRoot(); err != nil {
+		return false
+	}
+	return true
+}
+
+// TestSpecSync walks the sync fixture directory and, for each verify_checkpoint
+// case, decodes the canonical stateBytes via gean's SSZ and asserts the
+// structural verdict matches the spec-generated boolean. Also pins the
+// extracted validator count and anchor slot.
+func TestSpecSync(t *testing.T) {
+	if _, err := os.Stat(syncFixturesRoot); os.IsNotExist(err) {
+		t.Skipf("fixtures not present at %s; run 'make leanSpec/fixtures'", syncFixturesRoot)
+	}
+
+	err := filepath.Walk(syncFixturesRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".json") {
+			return err
+		}
+
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("%s: read: %v", path, err)
+			return nil
+		}
+
+		var outer syncFixtureOuter
+		if err := json.Unmarshal(raw, &outer); err != nil {
+			t.Errorf("%s: parse: %v", path, err)
+			return nil
+		}
+
+		base := strings.TrimSuffix(filepath.Base(path), ".json")
+		for _, fx := range outer {
+			fx := fx
+			t.Run(base, func(t *testing.T) {
+				if fx.Operation != "verify_checkpoint" {
+					t.Skipf("unsupported sync operation %q", fx.Operation)
+				}
+
+				stateBytes, err := hex.DecodeString(strings.TrimPrefix(fx.Output.StateBytes, "0x"))
+				if err != nil {
+					t.Fatalf("decode stateBytes hex: %v", err)
+				}
+
+				state := &types.State{}
+				ssz_err := state.UnmarshalSSZ(stateBytes)
+				// A successful decode is a prerequisite for any structural check;
+				// if the spec said valid=true, decode must succeed.
+				if fx.Output.Valid && ssz_err != nil {
+					t.Fatalf("expected SSZ decode to succeed for valid=true case: %v", ssz_err)
+				}
+				if ssz_err != nil {
+					// Decode failure is itself a structural rejection; nothing
+					// further to assert beyond the expected valid=false.
+					if fx.Output.Valid {
+						t.Fatalf("decode failed but spec marks valid=true: %v", ssz_err)
+					}
+					return
+				}
+
+				got := verifyCheckpointStructural(state)
+				if got != fx.Output.Valid {
+					t.Errorf("verifyCheckpointStructural = %v, want %v (validators=%d anchor_slot=%d)",
+						got, fx.Output.Valid, len(state.Validators), state.Slot)
+				}
+
+				if uint64(len(state.Validators)) != fx.Output.ValidatorCount {
+					t.Errorf("validator count from SSZ = %d, fixture says %d",
+						len(state.Validators), fx.Output.ValidatorCount)
+				}
+				if state.Slot != fx.Output.AnchorSlot {
+					t.Errorf("anchor slot from SSZ = %d, fixture says %d",
+						state.Slot, fx.Output.AnchorSlot)
+				}
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk fixtures: %v", err)
+	}
+}

--- a/spectests/xmss_ssz_adapters_test.go
+++ b/spectests/xmss_ssz_adapters_test.go
@@ -1,0 +1,302 @@
+//go:build spectests
+
+package spectests
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	ssz "github.com/ferranbt/fastssz"
+)
+
+// XMSS container constants pulled from leanSpec subspecs/xmss/constants.py
+// (prod TARGET_CONFIG). Gean stores XMSS payloads as opaque byte arrays
+// ([PubkeySize]byte, [SignatureSize]byte) because all real work lives in
+// the Rust FFI; these adapters reconstruct the spec-defined inner structure
+// solely to drive hash_tree_root for the spec SSZ conformance test.
+const (
+	xmssHashLenFE       = 8       // Vector[Fp, 8] — 32 bytes
+	xmssParameterLen    = 5       // Vector[Fp, 5] — 20 bytes
+	xmssRandLenFE       = 7       // Vector[Fp, 7] — 28 bytes
+	xmssFpBytes         = 4       // KoalaBear Fp serialized width
+	xmssHashDigestBytes = xmssHashLenFE * xmssFpBytes // 32
+
+	// NODE_LIST_LIMIT = 1 << (LOG_LIFETIME/2 + 1) = 1 << 17 = 131072 for
+	// LOG_LIFETIME = 32 (prod). Drives the SSZ list mix-in depth.
+	xmssNodeListLimit uint64 = 1 << 17
+)
+
+// --- PublicKey -------------------------------------------------------------
+//
+// SSZ Container { root: Vector[Fp, 8], parameter: Vector[Fp, 5] }
+// Both fields are fixed-size, so the wire form is plain concatenation:
+//   32 bytes root + 20 bytes parameter = 52 bytes total.
+// hash_tree_root: merkleize([root_chunk, parameter_chunk]) where each chunk
+// is the bytes padded to 32.
+
+type sszPublicKeyAdapter struct {
+	Root      [xmssHashDigestBytes]byte
+	Parameter [xmssParameterLen * xmssFpBytes]byte
+}
+
+const xmssPublicKeyBytes = xmssHashDigestBytes + xmssParameterLen*xmssFpBytes
+
+func (p *sszPublicKeyAdapter) MarshalSSZ() ([]byte, error) {
+	out := make([]byte, xmssPublicKeyBytes)
+	copy(out[:xmssHashDigestBytes], p.Root[:])
+	copy(out[xmssHashDigestBytes:], p.Parameter[:])
+	return out, nil
+}
+
+func (p *sszPublicKeyAdapter) UnmarshalSSZ(buf []byte) error {
+	if len(buf) != xmssPublicKeyBytes {
+		return fmt.Errorf("PublicKey: want %d bytes, got %d", xmssPublicKeyBytes, len(buf))
+	}
+	copy(p.Root[:], buf[:xmssHashDigestBytes])
+	copy(p.Parameter[:], buf[xmssHashDigestBytes:])
+	return nil
+}
+
+func (p *sszPublicKeyAdapter) HashTreeRoot() ([32]byte, error) {
+	return ssz.HashWithDefaultHasher(p)
+}
+
+func (p *sszPublicKeyAdapter) GetTree() (*ssz.Node, error) {
+	return ssz.ProofTree(p)
+}
+
+func (p *sszPublicKeyAdapter) HashTreeRootWith(hh ssz.HashWalker) error {
+	indx := hh.Index()
+	hh.PutBytes(p.Root[:])      // 32 bytes — one chunk
+	hh.PutBytes(p.Parameter[:]) // 20 bytes — zero-padded by hasher to one chunk
+	hh.Merkleize(indx)
+	return nil
+}
+
+// --- HashTreeOpening -------------------------------------------------------
+//
+// SSZ Container { siblings: List[Vector[Fp, 8], NODE_LIST_LIMIT] }
+// Wire form: 4-byte offset (= 4) then concatenated 32-byte digests.
+// hash_tree_root: merkleize([list_root]) where list_root mixes in the
+// element count over NODE_LIST_LIMIT.
+
+type sszHashTreeOpeningAdapter struct {
+	Siblings [][xmssHashDigestBytes]byte
+}
+
+func (h *sszHashTreeOpeningAdapter) MarshalSSZ() ([]byte, error) {
+	out := make([]byte, 4+len(h.Siblings)*xmssHashDigestBytes)
+	binary.LittleEndian.PutUint32(out[:4], 4)
+	for i, s := range h.Siblings {
+		copy(out[4+i*xmssHashDigestBytes:], s[:])
+	}
+	return out, nil
+}
+
+func (h *sszHashTreeOpeningAdapter) UnmarshalSSZ(buf []byte) error {
+	if len(buf) < 4 {
+		return fmt.Errorf("HashTreeOpening: buffer too short for offset")
+	}
+	off := binary.LittleEndian.Uint32(buf[:4])
+	if off != 4 {
+		return fmt.Errorf("HashTreeOpening: unexpected offset %d", off)
+	}
+	rest := buf[4:]
+	if len(rest)%xmssHashDigestBytes != 0 {
+		return fmt.Errorf("HashTreeOpening: siblings tail %d not divisible by digest size %d",
+			len(rest), xmssHashDigestBytes)
+	}
+	n := len(rest) / xmssHashDigestBytes
+	h.Siblings = make([][xmssHashDigestBytes]byte, n)
+	for i := 0; i < n; i++ {
+		copy(h.Siblings[i][:], rest[i*xmssHashDigestBytes:(i+1)*xmssHashDigestBytes])
+	}
+	return nil
+}
+
+func (h *sszHashTreeOpeningAdapter) HashTreeRoot() ([32]byte, error) {
+	return ssz.HashWithDefaultHasher(h)
+}
+
+func (h *sszHashTreeOpeningAdapter) GetTree() (*ssz.Node, error) {
+	return ssz.ProofTree(h)
+}
+
+func (h *sszHashTreeOpeningAdapter) HashTreeRootWith(hh ssz.HashWalker) error {
+	indx := hh.Index()
+	{
+		subIndx := hh.Index()
+		for i := range h.Siblings {
+			hh.PutBytes(h.Siblings[i][:])
+		}
+		hh.MerkleizeWithMixin(subIndx, uint64(len(h.Siblings)), xmssNodeListLimit)
+	}
+	hh.Merkleize(indx)
+	return nil
+}
+
+// --- HashTreeLayer ---------------------------------------------------------
+//
+// SSZ Container { start_index: uint64, nodes: List[Vector[Fp, 8], NODE_LIST_LIMIT] }
+// Wire form: 8-byte start_index + 4-byte offset (=12) + concatenated nodes.
+// hash_tree_root: merkleize([start_index_chunk, list_root]).
+
+type sszHashTreeLayerAdapter struct {
+	StartIndex uint64
+	Nodes      [][xmssHashDigestBytes]byte
+}
+
+const xmssHashTreeLayerHeader = 8 + 4 // start_index + offset
+
+func (h *sszHashTreeLayerAdapter) MarshalSSZ() ([]byte, error) {
+	out := make([]byte, xmssHashTreeLayerHeader+len(h.Nodes)*xmssHashDigestBytes)
+	binary.LittleEndian.PutUint64(out[:8], h.StartIndex)
+	binary.LittleEndian.PutUint32(out[8:12], xmssHashTreeLayerHeader)
+	for i, n := range h.Nodes {
+		copy(out[xmssHashTreeLayerHeader+i*xmssHashDigestBytes:], n[:])
+	}
+	return out, nil
+}
+
+func (h *sszHashTreeLayerAdapter) UnmarshalSSZ(buf []byte) error {
+	if len(buf) < xmssHashTreeLayerHeader {
+		return fmt.Errorf("HashTreeLayer: buffer too short for header")
+	}
+	h.StartIndex = binary.LittleEndian.Uint64(buf[:8])
+	off := binary.LittleEndian.Uint32(buf[8:12])
+	if uint64(off) != uint64(xmssHashTreeLayerHeader) {
+		return fmt.Errorf("HashTreeLayer: unexpected nodes offset %d", off)
+	}
+	rest := buf[xmssHashTreeLayerHeader:]
+	if len(rest)%xmssHashDigestBytes != 0 {
+		return fmt.Errorf("HashTreeLayer: nodes tail %d not divisible by digest size %d",
+			len(rest), xmssHashDigestBytes)
+	}
+	n := len(rest) / xmssHashDigestBytes
+	h.Nodes = make([][xmssHashDigestBytes]byte, n)
+	for i := 0; i < n; i++ {
+		copy(h.Nodes[i][:], rest[i*xmssHashDigestBytes:(i+1)*xmssHashDigestBytes])
+	}
+	return nil
+}
+
+func (h *sszHashTreeLayerAdapter) HashTreeRoot() ([32]byte, error) {
+	return ssz.HashWithDefaultHasher(h)
+}
+
+func (h *sszHashTreeLayerAdapter) GetTree() (*ssz.Node, error) {
+	return ssz.ProofTree(h)
+}
+
+func (h *sszHashTreeLayerAdapter) HashTreeRootWith(hh ssz.HashWalker) error {
+	indx := hh.Index()
+	hh.PutUint64(h.StartIndex)
+	{
+		subIndx := hh.Index()
+		for i := range h.Nodes {
+			hh.PutBytes(h.Nodes[i][:])
+		}
+		hh.MerkleizeWithMixin(subIndx, uint64(len(h.Nodes)), xmssNodeListLimit)
+	}
+	hh.Merkleize(indx)
+	return nil
+}
+
+// --- Signature -------------------------------------------------------------
+//
+// SSZ Container { path: HashTreeOpening, rho: Vector[Fp, 7], hashes: HashDigestList }
+// path and hashes are variable-size, so the wire form is the standard
+// offsets-first layout: off_path (4) + rho (28) + off_hashes (4) + path body
+// + hashes body. The spec overrides is_fixed_size to true and reports
+// SIGNATURE_LEN_BYTES = 2536, so parent containers inline the bytes; the
+// wire format is still the SSZ offset/body layout above.
+// hash_tree_root: merkleize([htr(path), rho_chunk, htr(hashes)]).
+
+type sszSignatureAdapter struct {
+	Path   sszHashTreeOpeningAdapter
+	Rho    [xmssRandLenFE * xmssFpBytes]byte
+	Hashes [][xmssHashDigestBytes]byte
+}
+
+func (s *sszSignatureAdapter) MarshalSSZ() ([]byte, error) {
+	pathBytes, err := s.Path.MarshalSSZ()
+	if err != nil {
+		return nil, err
+	}
+	hashesBody := make([]byte, len(s.Hashes)*xmssHashDigestBytes)
+	for i, h := range s.Hashes {
+		copy(hashesBody[i*xmssHashDigestBytes:], h[:])
+	}
+
+	fixedHeader := 4 + len(s.Rho) + 4
+	offPath := uint32(fixedHeader)
+	offHashes := uint32(fixedHeader + len(pathBytes))
+
+	out := make([]byte, fixedHeader+len(pathBytes)+len(hashesBody))
+	binary.LittleEndian.PutUint32(out[:4], offPath)
+	copy(out[4:4+len(s.Rho)], s.Rho[:])
+	binary.LittleEndian.PutUint32(out[4+len(s.Rho):fixedHeader], offHashes)
+	copy(out[fixedHeader:fixedHeader+len(pathBytes)], pathBytes)
+	copy(out[fixedHeader+len(pathBytes):], hashesBody)
+	return out, nil
+}
+
+func (s *sszSignatureAdapter) UnmarshalSSZ(buf []byte) error {
+	fixedHeader := 4 + len(s.Rho) + 4
+	if len(buf) < fixedHeader {
+		return fmt.Errorf("Signature: buffer too short for header")
+	}
+	offPath := binary.LittleEndian.Uint32(buf[:4])
+	copy(s.Rho[:], buf[4:4+len(s.Rho)])
+	offHashes := binary.LittleEndian.Uint32(buf[4+len(s.Rho) : fixedHeader])
+
+	if uint64(offPath) != uint64(fixedHeader) {
+		return fmt.Errorf("Signature: unexpected path offset %d", offPath)
+	}
+	if offHashes < offPath || uint64(offHashes) > uint64(len(buf)) {
+		return fmt.Errorf("Signature: invalid hashes offset %d (path=%d, total=%d)",
+			offHashes, offPath, len(buf))
+	}
+
+	pathBytes := buf[offPath:offHashes]
+	if err := s.Path.UnmarshalSSZ(pathBytes); err != nil {
+		return fmt.Errorf("Signature.path: %w", err)
+	}
+
+	hashesBytes := buf[offHashes:]
+	if len(hashesBytes)%xmssHashDigestBytes != 0 {
+		return fmt.Errorf("Signature.hashes tail %d not divisible by digest size %d",
+			len(hashesBytes), xmssHashDigestBytes)
+	}
+	n := len(hashesBytes) / xmssHashDigestBytes
+	s.Hashes = make([][xmssHashDigestBytes]byte, n)
+	for i := 0; i < n; i++ {
+		copy(s.Hashes[i][:], hashesBytes[i*xmssHashDigestBytes:(i+1)*xmssHashDigestBytes])
+	}
+	return nil
+}
+
+func (s *sszSignatureAdapter) HashTreeRoot() ([32]byte, error) {
+	return ssz.HashWithDefaultHasher(s)
+}
+
+func (s *sszSignatureAdapter) GetTree() (*ssz.Node, error) {
+	return ssz.ProofTree(s)
+}
+
+func (s *sszSignatureAdapter) HashTreeRootWith(hh ssz.HashWalker) error {
+	indx := hh.Index()
+	if err := s.Path.HashTreeRootWith(hh); err != nil {
+		return err
+	}
+	hh.PutBytes(s.Rho[:]) // 28 bytes — zero-padded by hasher to one 32-byte chunk
+	{
+		subIndx := hh.Index()
+		for i := range s.Hashes {
+			hh.PutBytes(s.Hashes[i][:])
+		}
+		hh.MerkleizeWithMixin(subIndx, uint64(len(s.Hashes)), xmssNodeListLimit)
+	}
+	hh.Merkleize(indx)
+	return nil
+}

--- a/statetransition/justifiable.go
+++ b/statetransition/justifiable.go
@@ -4,8 +4,10 @@ import "math"
 
 // SlotIsJustifiableAfter returns true if slot can be justified given the finalized slot.
 // 3SF-mini rules: distance must be <= 5, a perfect square, or a pronic number.
+// The finalized slot itself (delta = 0) is justifiable per spec
+// (leanSpec types/slot.py:54 asserts self >= finalized_slot, then delta = 0 satisfies delta <= 5).
 func SlotIsJustifiableAfter(slot, finalizedSlot uint64) bool {
-	if slot <= finalizedSlot {
+	if slot < finalizedSlot {
 		return false
 	}
 	delta := slot - finalizedSlot

--- a/statetransition/justifiable_test.go
+++ b/statetransition/justifiable_test.go
@@ -39,8 +39,11 @@ func TestSlotIsJustifiableAfter(t *testing.T) {
 		{19, 0, false}, // 19
 		{21, 0, false}, // 21
 
-		// Edge: slot <= finalized
-		{0, 0, false},
+		// Edge: finalized slot itself is justifiable (delta = 0 falls in delta <= 5).
+		{0, 0, true},
+		{10, 10, true},
+
+		// Edge: slot strictly before finalized.
 		{5, 10, false},
 	}
 

--- a/types/clock.go
+++ b/types/clock.go
@@ -1,0 +1,52 @@
+package types
+
+// Pure slot-clock derivations matching leanSpec subspecs/chain/clock.py.
+// Engine methods (node/tick.go) carry the runtime state; these stateless
+// equivalents are used by spec conformance tests and by anyone needing the
+// derivation without an Engine handle.
+
+// CurrentSlot returns the slot number at currentTimeMs given genesisTime
+// (seconds since Unix epoch). Returns 0 before genesis.
+func CurrentSlot(genesisTime, currentTimeMs uint64) uint64 {
+	genesisMs := genesisTime * 1000
+	if currentTimeMs < genesisMs {
+		return 0
+	}
+	return (currentTimeMs - genesisMs) / MillisecondsPerSlot
+}
+
+// CurrentInterval returns the interval index within the current slot
+// (0..IntervalsPerSlot-1). Returns 0 before genesis.
+func CurrentInterval(genesisTime, currentTimeMs uint64) uint64 {
+	genesisMs := genesisTime * 1000
+	if currentTimeMs < genesisMs {
+		return 0
+	}
+	msIntoSlot := (currentTimeMs - genesisMs) % MillisecondsPerSlot
+	return msIntoSlot / MillisecondsPerInterval
+}
+
+// TotalIntervals returns the total interval count since genesis (matches
+// Store.time). Returns 0 before genesis.
+func TotalIntervals(genesisTime, currentTimeMs uint64) uint64 {
+	genesisMs := genesisTime * 1000
+	if currentTimeMs < genesisMs {
+		return 0
+	}
+	return (currentTimeMs - genesisMs) / MillisecondsPerInterval
+}
+
+// IntervalsFromSlot returns the interval count at the start of the given slot.
+func IntervalsFromSlot(slot uint64) uint64 {
+	return slot * IntervalsPerSlot
+}
+
+// IntervalsFromUnixTime returns the total interval count at the given Unix
+// timestamp (seconds) relative to genesisTime. Returns 0 if the timestamp
+// precedes genesis.
+func IntervalsFromUnixTime(unixSeconds, genesisTime uint64) uint64 {
+	if unixSeconds < genesisTime {
+		return 0
+	}
+	return (unixSeconds - genesisTime) * 1000 / MillisecondsPerInterval
+}

--- a/types/clock_test.go
+++ b/types/clock_test.go
@@ -1,0 +1,103 @@
+package types
+
+import "testing"
+
+func TestCurrentSlot(t *testing.T) {
+	const gt = 1700000000
+	const gtMs = gt * 1000
+	tests := []struct {
+		name        string
+		currentMs   uint64
+		expectedSlot uint64
+	}{
+		{"before_genesis", gtMs - 5000, 0},
+		{"at_genesis", gtMs, 0},
+		{"mid_slot_0", gtMs + 1500, 0},
+		{"at_slot_1", gtMs + uint64(MillisecondsPerSlot), 1},
+		{"slot_10", gtMs + 10*uint64(MillisecondsPerSlot), 10},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CurrentSlot(gt, tt.currentMs); got != tt.expectedSlot {
+				t.Fatalf("CurrentSlot(%d, %d) = %d, want %d", gt, tt.currentMs, got, tt.expectedSlot)
+			}
+		})
+	}
+}
+
+func TestCurrentInterval(t *testing.T) {
+	const gt = 1700000000
+	const gtMs = gt * 1000
+	tests := []struct {
+		name             string
+		currentMs        uint64
+		expectedInterval uint64
+	}{
+		{"before_genesis", gtMs - 5000, 0},
+		{"at_slot_start", gtMs, 0},
+		{"800ms_in", gtMs + 800, 1},
+		{"1600ms_in", gtMs + 1600, 2},
+		{"3200ms_in", gtMs + 3200, 4},
+		{"wraps_at_next_slot", gtMs + uint64(MillisecondsPerSlot), 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CurrentInterval(gt, tt.currentMs); got != tt.expectedInterval {
+				t.Fatalf("CurrentInterval(%d, %d) = %d, want %d", gt, tt.currentMs, got, tt.expectedInterval)
+			}
+		})
+	}
+}
+
+func TestTotalIntervals(t *testing.T) {
+	const gt = 1700000000
+	const gtMs = gt * 1000
+	tests := []struct {
+		name      string
+		currentMs uint64
+		want      uint64
+	}{
+		{"before_genesis", gtMs - 1000, 0},
+		{"at_genesis", gtMs, 0},
+		{"one_interval", gtMs + 800, 1},
+		{"one_slot", gtMs + uint64(MillisecondsPerSlot), IntervalsPerSlot},
+		{"two_slots_plus_2_intervals", gtMs + 2*uint64(MillisecondsPerSlot) + 1600, 2*IntervalsPerSlot + 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TotalIntervals(gt, tt.currentMs); got != tt.want {
+				t.Fatalf("TotalIntervals(%d, %d) = %d, want %d", gt, tt.currentMs, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIntervalsFromSlot(t *testing.T) {
+	if IntervalsFromSlot(0) != 0 {
+		t.Fatal("slot 0 should map to interval 0")
+	}
+	if IntervalsFromSlot(1) != IntervalsPerSlot {
+		t.Fatalf("slot 1 should map to %d, got %d", IntervalsPerSlot, IntervalsFromSlot(1))
+	}
+	if IntervalsFromSlot(100) != 100*IntervalsPerSlot {
+		t.Fatalf("slot 100 should map to %d", 100*IntervalsPerSlot)
+	}
+}
+
+func TestIntervalsFromUnixTime(t *testing.T) {
+	const gt = 1700000000
+	if got := IntervalsFromUnixTime(gt-5, gt); got != 0 {
+		t.Fatalf("pre-genesis should be 0, got %d", got)
+	}
+	if got := IntervalsFromUnixTime(gt, gt); got != 0 {
+		t.Fatalf("at genesis should be 0, got %d", got)
+	}
+	// 1 second = 1000ms / 800ms-per-interval = 1 (integer div).
+	if got := IntervalsFromUnixTime(gt+1, gt); got != 1 {
+		t.Fatalf("+1 second should be 1 interval, got %d", got)
+	}
+	// 4 seconds = 1 slot = IntervalsPerSlot intervals.
+	if got := IntervalsFromUnixTime(gt+SecondsPerSlot, gt); got != IntervalsPerSlot {
+		t.Fatalf("+1 slot should be %d intervals, got %d", IntervalsPerSlot, got)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #248. Closes six spec-conformance gaps from the devnet-4 audit plus one behavioral bug surfaced by the new test runners:

- 3 new top-level spec test runners (`TestSpecJustifiability`, `TestSpecSync`, `TestSpecSlotClock`)
- 4 XMSS container SSZ adapters (`PublicKey`, `Signature`, `HashTreeLayer`, `HashTreeOpening`)
- Real assertions for the two deferred `t.Logf` branches in the existing fork-choice spec runner (`safeTarget`, `attestationChecks`)
- One bug fix: `SlotIsJustifiableAfter(slot=finalized, finalized)` was returning `false`; spec says `true`. Found by the new justifiability runner.

All eight commits are atomic, single-scope.

## Items

### `#21` `chore(spectests): wire TestSpecJustifiability runner` (`265ba41`)

**Where:** new `spectests/justifiability_test.go`.

**Coverage:** 33 fixtures from `leanSpec/fixtures/consensus/justifiability/lstar/state_transition/test_justifiability/`. Rule-1 (`delta <= 5`), rule-2 (perfect squares), rule-3 (pronic numbers), the boundary at `delta = 0`, non-zero finalized slot variants, and non-justifiable distances.

The runner cross-validates the precomputed `delta = slot - finalizedSlot` field carried in each fixture for fixture integrity, then exercises `statetransition.SlotIsJustifiableAfter` against `output.isJustifiable`.

---

### `#22` `chore(spectests): wire TestSpecSync runner` (`26bfe26`)

**Where:** new `spectests/sync_test.go`.

**Coverage:** 6 fixtures from `leanSpec/fixtures/consensus/sync/lstar/sync/` covering `verify_checkpoint_state`. Hex-decodes the canonical `output.stateBytes`, deserializes via gean's SSZ, and asserts the structural verdict via a local `verifyCheckpointStructural` matching the spec rule set (`subspecs/sync/checkpoint_sync.py:106`): validator count > 0, count <= `ValidatorRegistryLimit`, `HashTreeRoot` non-error.

The spec test exercises the narrower structural contract because production gean's `checkpoint.VerifyCheckpointState` adds genesis-time and expected-validator cross-checks and rejects slot 0 — stricter than the spec's structural-only definition.

---

### `#23` `chore(spectests): wire TestSpecSlotClock runner` (`c9894eb`)

**Where:** new `spectests/slot_clock_test.go` plus new `types/clock.go` + `types/clock_test.go` from `feat(types): add stateless slot-clock derivations` (`854fbf5`).

**Coverage:** 25 fixtures from `leanSpec/fixtures/consensus/slot_clock/lstar/chain/test_slot_clock/`. Exercises all five derivations (`current_slot`, `current_interval`, `total_intervals`, `from_slot`, `from_unix_time`) plus before-genesis, slot boundary, mid-slot, multi-slot, and one-day edges.

Gean's `Engine` carried slot-clock methods bound to its `Store`; the new pure functions in `types/clock.go` mirror them statelessly so the spec runner (and any future caller) can run the derivations without an Engine handle.

The runner also pins the timing config (`secondsPerSlot`, `intervalsPerSlot`, `millisecondsPerInterval`) carried in every fixture against gean's compiled-in constants to catch drift in either direction.

---

### `#20` `chore(spectests): register XMSS container SSZ adapters` (`a91b4c0`)

**Where:** new `spectests/xmss_ssz_adapters_test.go`; `spectests/ssz_test.go` adds four entries to `sszFactories`.

**Coverage:** 8 fixtures (`test_xmss_containers/test_{public_key,signature,hash_tree_layer,hash_tree_opening}_{zero,typical,actual,empty}.json`). All previously skipped with \"type not wired into ssz harness\".

Gean stores XMSS payloads as opaque byte arrays (`[PubkeySize]byte`, `[SignatureSize]byte`) because production signing / verification flows through the Rust FFI. The adapters reconstruct the spec-defined inner field layout solely to drive encode/decode roundtrip and `hash_tree_root` for conformance:

- `PublicKey` — fixed 52-byte `Container { root: Vector[Fp, 8], parameter: Vector[Fp, 5] }`.
- `HashTreeOpening` — `Container { siblings: List[Vector[Fp, 8], NODE_LIST_LIMIT] }`, full list-with-mixin merkleization.
- `HashTreeLayer` — `Container { start_index: uint64, nodes: List[Vector[Fp, 8], NODE_LIST_LIMIT] }`.
- `Signature` — decomposes the wire layout into `path` / `rho` / `hashes` to compute the same `hash_tree_root` the spec expects despite the `is_fixed_size` override that makes the wire form opaque to parent containers.

---

### `#24` `feat(spectests): simulate updateSafeTarget in fork-choice runner` (`34d8f96`)

**Where:** `spectests/forkchoice_test.go`.

**Before:** the runner parsed `safeTarget*` expectations but short-circuited the assertion with a `t.Logf`. Engine fires `updateSafeTarget` at interval 3, and the runner cannot model interval cadence directly.

**After:** new `simulateUpdateSafeTarget` invoked from `validateChecks` whenever any `safeTarget*` field is set. Pulls `headState`, computes `numValidators`, calls `fc.UpdateSafeTarget(latestJustifiedRoot, numValidators)`, stores the result.

**Why this works:** `fc.Votes` keeps `LatestNew` entries populated from prior `SetNew` calls during attestation steps — the runner promotes the store-side new pool but does not touch `fc.Votes`, so `UpdateSafeTarget` with `fromKnown=false` reads the right new-pool snapshot.

All 6 `test_safe_target` fixtures now exercise real assertions: `advances_incrementally_along_the_chain`, `does_not_advance_below_supermajority` (two_of_six + three_of_six), `follows_heavier_fork_on_split`, `ignores_known_pool_at_interval_3`, `is_conservative_relative_to_lmd_ghost_head`.

---

### `#25` `feat(spectests): validate attestationChecks per-step in fork-choice runner` (`51fab02`)

**Where:** `spectests/forkchoice_test.go`.

**Before:** the runner parsed the per-validator `attestationChecks` list but short-circuited with `t.Logf`.

**After:** new `validateAttestationCheck` per entry. Looks up `fc.Votes.Votes[validator]`, picks `LatestNew` or `LatestKnown` based on the `location` field, asserts `AttestationSlot` / `HeadSlot` / `SourceSlot` / `TargetSlot` when set.

All `test_safe_target` and `test_signature_aggregation` fixtures carrying `attestationChecks` now exercise the assertions.

---

### `fix(statetransition): include delta=0 in justifiable slots per spec` (`236f206`)

**Surfaced by:** running the new `TestSpecJustifiability` runner.

**Before:** `SlotIsJustifiableAfter(slot, finalizedSlot)` guarded with `if slot <= finalizedSlot { return false }`. Returned `false` for `slot == finalizedSlot`.

**After:** strict `slot < finalizedSlot` guard, matching:

- leanSpec `types/slot.py:54` — `assert self >= finalized_slot` (allows equality), then `delta <= 5` (delta = 0 satisfies).
- zeam `pkgs/types/src/utils.zig:67` — `if (candidate < finalized) return error`, then `delta <= 5`.
- ethlambda `state_transition/lib.rs:499` — `checked_sub` returns `Some(0)`, then `delta <= 5`.

**Behavior change:** attestations whose target slot equals the finalized slot are now accepted by gean's state transition rather than silently dropped. Aligns gean with the rest of the client ecosystem.

## Stats

- 8 commits on `feat/spectest-conformance-expansion` off `origin/devnet-4` at `5dfbd7f`
- +944 / −40 across 9 files
- `go vet ./...` clean
- `go test -count=1 -tags spectests ./spectests/` green
- `go test -count=1 ./...` green (verified on the prior commit set)

## Commit format

All 8 commits follow `type(scope): subject` with single scope per commit. No `Co-authored-by` trailer.

## Test plan

- [ ] CI: `go vet ./...` + `go test -count=1 ./...` + `go test -count=1 -tags spectests ./spectests/` green
- [ ] Spot-check: `go test -tags spectests ./spectests/ -run TestSpecJustifiability -v` shows 33 PASS, 0 FAIL
- [ ] Spot-check: `go test -tags spectests ./spectests/ -run TestSpecSync -v` shows 6 PASS, 0 FAIL
- [ ] Spot-check: `go test -tags spectests ./spectests/ -run TestSpecSlotClock -v` shows 25 PASS, 0 FAIL
- [ ] Spot-check: `go test -tags spectests ./spectests/ -run TestSpecSSZ -v` shows 8 new XMSS subtests PASS (previously skipped)
- [ ] Spot-check: `go test -tags spectests ./spectests/ -run TestSpecForkChoice -v` shows all `test_safe_target/*` PASS without the deferred `t.Logf` lines
- [ ] No devnet co-test required — every change is in `spectests/`, `types/`, or `statetransition/` and validates against canonical fixtures