### PR TITLE
feat(api): /lean/v0/blocks/finalized endpoint + checkpoint anchor pairing

### DIFF
--- a/api/handlers_blocks_test.go
+++ b/api/handlers_blocks_test.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/geanlabs/gean/node"
+	"github.com/geanlabs/gean/storage"
+	"github.com/geanlabs/gean/types"
+)
+
+func newTestStoreForBlocks() *node.ConsensusStore {
+	return node.NewConsensusStore(storage.NewInMemoryBackend())
+}
+
+// emptyChainConfig is needed because the SignedBlock SSZ schema reaches through
+// types/block.go down to fields that need to round-trip.
+func makeSignedBlockForTest(slot, proposer uint64) *types.SignedBlock {
+	return &types.SignedBlock{
+		Block: &types.Block{
+			Slot:          slot,
+			ProposerIndex: proposer,
+			Body:          &types.BlockBody{},
+		},
+		Signature: &types.BlockSignatures{},
+	}
+}
+
+func TestFinalizedBlockHandler_NotFound_WhenNoFinalized(t *testing.T) {
+	s := newTestStoreForBlocks()
+	// LatestFinalized().Root == ZeroRoot when nothing has been set.
+
+	rec := httptest.NewRecorder()
+	FinalizedBlockHandler(s)(rec, httptest.NewRequest("GET", "/lean/v0/blocks/finalized", nil))
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d, want 404", rec.Code)
+	}
+}
+
+func TestFinalizedBlockHandler_NotFound_WhenSignedBlockMissing(t *testing.T) {
+	s := newTestStoreForBlocks()
+	// Set finalized to a non-zero root but never store a SignedBlock for it.
+	var root [32]byte
+	root[0] = 0xab
+	s.SetLatestFinalized(&types.Checkpoint{Root: root, Slot: 5})
+
+	rec := httptest.NewRecorder()
+	FinalizedBlockHandler(s)(rec, httptest.NewRequest("GET", "/lean/v0/blocks/finalized", nil))
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d, want 404", rec.Code)
+	}
+}
+
+func TestFinalizedBlockHandler_ReturnsSSZ_WhenPresent(t *testing.T) {
+	s := newTestStoreForBlocks()
+
+	signed := makeSignedBlockForTest(7, 3)
+	root, err := signed.Block.HashTreeRoot()
+	if err != nil {
+		t.Fatalf("hash_tree_root: %v", err)
+	}
+	s.StorePendingBlock(root, signed)
+	s.SetLatestFinalized(&types.Checkpoint{Root: root, Slot: 7})
+
+	rec := httptest.NewRecorder()
+	FinalizedBlockHandler(s)(rec, httptest.NewRequest("GET", "/lean/v0/blocks/finalized", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/octet-stream" {
+		t.Fatalf("Content-Type=%q, want application/octet-stream", got)
+	}
+
+	want, err := signed.MarshalSSZ()
+	if err != nil {
+		t.Fatalf("expected MarshalSSZ: %v", err)
+	}
+	if !bytes.Equal(rec.Body.Bytes(), want) {
+		t.Fatalf("body mismatch:\n got len=%d\n want len=%d", rec.Body.Len(), len(want))
+	}
+
+	// Sanity: the served bytes deserialize back into the same block via SSZ.
+	roundtrip := &types.SignedBlock{}
+	if err := roundtrip.UnmarshalSSZ(rec.Body.Bytes()); err != nil {
+		t.Fatalf("served bytes do not roundtrip: %v", err)
+	}
+	if roundtrip.Block.Slot != signed.Block.Slot || roundtrip.Block.ProposerIndex != signed.Block.ProposerIndex {
+		t.Fatalf("roundtrip mismatch: slot=%d proposer=%d, want slot=%d proposer=%d",
+			roundtrip.Block.Slot, roundtrip.Block.ProposerIndex,
+			signed.Block.Slot, signed.Block.ProposerIndex)
+	}
+}

--- a/api/server.go
+++ b/api/server.go
@@ -20,6 +20,7 @@ func StartAPIServer(address string, s *node.ConsensusStore, fc *forkchoice.ForkC
 
 	mux.HandleFunc("GET /lean/v0/health", HealthHandler)
 	mux.HandleFunc("GET /lean/v0/states/finalized", FinalizedStateHandler(s))
+	mux.HandleFunc("GET /lean/v0/blocks/finalized", FinalizedBlockHandler(s))
 	mux.HandleFunc("GET /lean/v0/checkpoints/justified", JustifiedCheckpointHandler(s))
 	mux.HandleFunc("GET /lean/v0/fork_choice", ForkChoiceHandler(s, fc))
 	mux.HandleFunc("GET /lean/v0/admin/aggregator", AggregatorStatusHandler(aggCtl))
@@ -60,6 +61,34 @@ func StartMetricsServer(address string) error {
 func HealthHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Write([]byte(`{"status":"healthy","service":"lean-rpc-api"}`))
+}
+
+// FinalizedBlockHandler returns the SignedBlock at the latest finalized root
+// as SSZ bytes. Per leanSpec PR #713, checkpoint-sync clients pair this with
+// /lean/v0/states/finalized and verify state_root == hash_tree_root(state) to
+// detect synthetic-block fabrication: peers that respond to BlocksByRoot for
+// the anchor root will reject a synthetic body whose hash_tree_root does not
+// match what the state claims.
+func FinalizedBlockHandler(s *node.ConsensusStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		finalized := s.LatestFinalized()
+		if finalized.Root == types.ZeroRoot {
+			http.Error(w, "no finalized block yet", http.StatusNotFound)
+			return
+		}
+		signedBlock := s.GetSignedBlock(finalized.Root)
+		if signedBlock == nil {
+			http.Error(w, "finalized block not available", http.StatusNotFound)
+			return
+		}
+		data, err := signedBlock.MarshalSSZ()
+		if err != nil {
+			http.Error(w, "ssz marshal failed", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Write(data)
+	}
 }
 
 // handleFinalizedState returns the finalized state as SSZ bytes.

--- a/checkpoint/checkpoint.go
+++ b/checkpoint/checkpoint.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/geanlabs/gean/types"
@@ -15,15 +16,110 @@ const (
 	CheckpointReadTimeout    = 15 * time.Second
 )
 
+// Endpoint paths defined by leanSpec.
+const (
+	StatesFinalizedPath = "/lean/v0/states/finalized"
+	BlocksFinalizedPath = "/lean/v0/blocks/finalized"
+)
+
 // FetchCheckpointState downloads and verifies a finalized state from a peer.
 func FetchCheckpointState(
 	url string,
 	expectedGenesisTime uint64,
 	expectedValidators []*types.Validator,
 ) (*types.State, error) {
-	client := &http.Client{
-		Timeout: CheckpointConnectTimeout + CheckpointReadTimeout,
+	body, err := fetchSSZ(url)
+	if err != nil {
+		return nil, err
 	}
+
+	state := &types.State{}
+	if err := state.UnmarshalSSZ(body); err != nil {
+		return nil, fmt.Errorf("ssz decode: %w", err)
+	}
+
+	if err := VerifyCheckpointState(state, expectedGenesisTime, expectedValidators); err != nil {
+		return nil, fmt.Errorf("verify: %w", err)
+	}
+
+	return state, nil
+}
+
+// FetchCheckpointAnchor downloads the finalized state AND the matching
+// finalized SignedBlock, verifies the state↔block pair, runs the same
+// VerifyCheckpointState rules as FetchCheckpointState, and returns both.
+//
+// The stateURL is expected to end in StatesFinalizedPath; the block URL is
+// derived by replacing that suffix with BlocksFinalizedPath. Per leanSpec
+// PR #713 the pair is bound by block.state_root == hash_tree_root(state) —
+// a synthetic block fabricated from state.latest_block_header (zero
+// signature, empty body) will fail this check whenever the real anchor body
+// carried attestations, which is the typical post-genesis case.
+func FetchCheckpointAnchor(
+	stateURL string,
+	expectedGenesisTime uint64,
+	expectedValidators []*types.Validator,
+) (*types.State, *types.SignedBlock, error) {
+	blockURL, err := deriveBlockURL(stateURL)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	stateBody, err := fetchSSZ(stateURL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("fetch state: %w", err)
+	}
+	state := &types.State{}
+	if err := state.UnmarshalSSZ(stateBody); err != nil {
+		return nil, nil, fmt.Errorf("state ssz decode: %w", err)
+	}
+
+	blockBody, err := fetchSSZ(blockURL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("fetch block: %w", err)
+	}
+	signedBlock := &types.SignedBlock{}
+	if err := signedBlock.UnmarshalSSZ(blockBody); err != nil {
+		return nil, nil, fmt.Errorf("block ssz decode: %w", err)
+	}
+	if signedBlock.Block == nil {
+		return nil, nil, fmt.Errorf("block ssz decode: nil Block")
+	}
+
+	stateRoot, err := state.HashTreeRoot()
+	if err != nil {
+		return nil, nil, fmt.Errorf("state hash_tree_root: %w", err)
+	}
+	if signedBlock.Block.StateRoot != stateRoot {
+		return nil, nil, fmt.Errorf(
+			"checkpoint state/block pair mismatch: block.state_root=0x%x, hash_tree_root(state)=0x%x",
+			signedBlock.Block.StateRoot, stateRoot,
+		)
+	}
+
+	if err := VerifyCheckpointState(state, expectedGenesisTime, expectedValidators); err != nil {
+		return nil, nil, fmt.Errorf("verify state: %w", err)
+	}
+
+	return state, signedBlock, nil
+}
+
+// deriveBlockURL converts a /lean/v0/states/finalized URL into the matching
+// /lean/v0/blocks/finalized URL, preserving scheme, host, port, and query.
+func deriveBlockURL(stateURL string) (string, error) {
+	if !strings.Contains(stateURL, StatesFinalizedPath) {
+		return "", fmt.Errorf(
+			"checkpoint URL %q does not contain %q; expected the finalized-state endpoint so the block endpoint can be derived",
+			stateURL, StatesFinalizedPath,
+		)
+	}
+	return strings.Replace(stateURL, StatesFinalizedPath, BlocksFinalizedPath, 1), nil
+}
+
+// fetchSSZ performs the shared HTTP GET + body read used by both
+// FetchCheckpointState and FetchCheckpointAnchor.
+func fetchSSZ(url string) ([]byte, error) {
+	client := &http.Client{Timeout: CheckpointConnectTimeout + CheckpointReadTimeout}
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -38,24 +134,14 @@ func FetchCheckpointState(
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("http status: %d", resp.StatusCode)
+		return nil, fmt.Errorf("http status %d for %s", resp.StatusCode, url)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("read response: %w", err)
 	}
-
-	state := &types.State{}
-	if err := state.UnmarshalSSZ(body); err != nil {
-		return nil, fmt.Errorf("ssz decode: %w", err)
-	}
-
-	if err := VerifyCheckpointState(state, expectedGenesisTime, expectedValidators); err != nil {
-		return nil, fmt.Errorf("verify: %w", err)
-	}
-
-	return state, nil
+	return body, nil
 }
 
 // VerifyCheckpointState runs all 12 validation checks.

--- a/checkpoint/checkpoint_test.go
+++ b/checkpoint/checkpoint_test.go
@@ -1,6 +1,9 @@
 package checkpoint
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/geanlabs/gean/types"
@@ -156,5 +159,162 @@ func TestVerifyCheckpointStateBlockHeaderJustifiedRootMismatch(t *testing.T) {
 	err := VerifyCheckpointState(state, 1000, state.Validators)
 	if err == nil {
 		t.Fatal("should fail: block header root mismatch at justified slot")
+	}
+}
+
+func TestDeriveBlockURL(t *testing.T) {
+	tests := []struct {
+		in, want, wantErr string
+	}{
+		{
+			in:   "http://server/lean/v0/states/finalized",
+			want: "http://server/lean/v0/blocks/finalized",
+		},
+		{
+			in:   "https://x.example:8080/lean/v0/states/finalized?cache=1",
+			want: "https://x.example:8080/lean/v0/blocks/finalized?cache=1",
+		},
+		{
+			in:      "http://server/some/other/path",
+			wantErr: "/lean/v0/states/finalized",
+		},
+	}
+	for _, tt := range tests {
+		got, err := deriveBlockURL(tt.in)
+		if tt.wantErr != "" {
+			if err == nil {
+				t.Errorf("deriveBlockURL(%q) want error containing %q, got nil", tt.in, tt.wantErr)
+				continue
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("deriveBlockURL(%q) err=%q does not contain %q", tt.in, err.Error(), tt.wantErr)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("deriveBlockURL(%q) unexpected err: %v", tt.in, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("deriveBlockURL(%q): got %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// makeAnchorPair builds a (state, signedBlock) pair where the block's
+// state_root equals hash_tree_root(state), matching what a healthy
+// checkpoint-server would serve. The state's LatestBlockHeader.StateRoot
+// is zeroed (canonical post-state form, as gean's FinalizedStateHandler
+// emits) before the inner hash so it survives roundtrip.
+func makeAnchorPair(t *testing.T) (*types.State, *types.SignedBlock) {
+	t.Helper()
+	state := makeTestState(100, 1000, 3)
+	state.LatestBlockHeader.StateRoot = types.ZeroRoot
+	stateRoot, err := state.HashTreeRoot()
+	if err != nil {
+		t.Fatalf("state hash_tree_root: %v", err)
+	}
+	signed := &types.SignedBlock{
+		Block: &types.Block{
+			Slot:          state.Slot,
+			ProposerIndex: state.LatestBlockHeader.ProposerIndex,
+			ParentRoot:    state.LatestBlockHeader.ParentRoot,
+			StateRoot:     stateRoot,
+			Body:          &types.BlockBody{},
+		},
+		Signature: &types.BlockSignatures{},
+	}
+	return state, signed
+}
+
+func TestFetchCheckpointAnchor_Pairs(t *testing.T) {
+	state, signed := makeAnchorPair(t)
+	stateBytes, _ := state.MarshalSSZ()
+	blockBytes, _ := signed.MarshalSSZ()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(StatesFinalizedPath, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Write(stateBytes)
+	})
+	mux.HandleFunc(BlocksFinalizedPath, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Write(blockBytes)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	gotState, gotBlock, err := FetchCheckpointAnchor(srv.URL+StatesFinalizedPath, 1000, state.Validators)
+	if err != nil {
+		t.Fatalf("FetchCheckpointAnchor: %v", err)
+	}
+	if gotState.Slot != state.Slot {
+		t.Errorf("state slot: got %d, want %d", gotState.Slot, state.Slot)
+	}
+	if gotBlock.Block.Slot != signed.Block.Slot {
+		t.Errorf("block slot: got %d, want %d", gotBlock.Block.Slot, signed.Block.Slot)
+	}
+}
+
+func TestFetchCheckpointAnchor_RejectsPairMismatch(t *testing.T) {
+	state, signed := makeAnchorPair(t)
+	signed.Block.StateRoot = [32]byte{0xff} // poison the pair
+
+	stateBytes, _ := state.MarshalSSZ()
+	blockBytes, _ := signed.MarshalSSZ()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(StatesFinalizedPath, func(w http.ResponseWriter, r *http.Request) {
+		w.Write(stateBytes)
+	})
+	mux.HandleFunc(BlocksFinalizedPath, func(w http.ResponseWriter, r *http.Request) {
+		w.Write(blockBytes)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	_, _, err := FetchCheckpointAnchor(srv.URL+StatesFinalizedPath, 1000, state.Validators)
+	if err == nil {
+		t.Fatal("expected pair mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "pair mismatch") {
+		t.Errorf("error %q does not mention pair mismatch", err.Error())
+	}
+}
+
+func TestFetchCheckpointAnchor_StateNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(StatesFinalizedPath, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	})
+	mux.HandleFunc(BlocksFinalizedPath, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("unused"))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	_, _, err := FetchCheckpointAnchor(srv.URL+StatesFinalizedPath, 1000, nil)
+	if err == nil {
+		t.Fatal("expected fetch state error, got nil")
+	}
+}
+
+func TestFetchCheckpointAnchor_BlockNotFound(t *testing.T) {
+	state, _ := makeAnchorPair(t)
+	stateBytes, _ := state.MarshalSSZ()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(StatesFinalizedPath, func(w http.ResponseWriter, r *http.Request) {
+		w.Write(stateBytes)
+	})
+	mux.HandleFunc(BlocksFinalizedPath, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no finalized block yet", http.StatusNotFound)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	_, _, err := FetchCheckpointAnchor(srv.URL+StatesFinalizedPath, 1000, state.Validators)
+	if err == nil {
+		t.Fatal("expected fetch block error, got nil")
 	}
 }

--- a/cmd/gean/main.go
+++ b/cmd/gean/main.go
@@ -119,9 +119,13 @@ func main() {
 			existingHeader.Slot, existingHead,
 			s.LatestJustified().Slot, s.LatestFinalized().Slot)
 	} else if *checkpointURL != "" {
-		// Checkpoint sync.
+		// Checkpoint sync. Per leanSpec PR #713, fetch both the finalized
+		// state and the matching SignedBlock and verify the pair via
+		// block.state_root == hash_tree_root(state) before trusting the
+		// anchor. Storing the SignedBlock lets gean serve /blocks/finalized
+		// to the next bootstrap peer without fabricating a synthetic body.
 		logger.Info(logger.Sync, "checkpoint sync: %s", *checkpointURL)
-		state, err := checkpoint.FetchCheckpointState(*checkpointURL, genesisConfig.GenesisTime, genesisValidators)
+		state, signedBlock, err := checkpoint.FetchCheckpointAnchor(*checkpointURL, genesisConfig.GenesisTime, genesisValidators)
 		if err != nil {
 			logger.Error(logger.Sync, "checkpoint sync failed: %v", err)
 			os.Exit(1)
@@ -132,6 +136,7 @@ func main() {
 		logger.Info(logger.Sync, "checkpoint sync: slot=%d finalized_root=%x justified_root=%x head_root=%x parent_root=%x state_root=%x",
 			state.Slot, state.LatestFinalized.Root, state.LatestJustified.Root, blockRoot, header.ParentRoot, stateRoot)
 		initStoreFromState(s, state)
+		s.StorePendingBlock(blockRoot, signedBlock)
 	} else {
 		// Genesis.
 		logger.Info(logger.Node, "initializing from genesis")


### PR DESCRIPTION
## Summary

Closes #250. Implements leanSpec PR #713 in gean:

- New endpoint `GET /lean/v0/blocks/finalized` serving the SignedBlock at the latest finalized root as SSZ
- Checkpoint-sync fetches the matching block alongside the state and verifies `block.state_root == hash_tree_root(state)` before trusting the anchor
- Checkpoint-sync persists the anchor SignedBlock so gean can serve it to the next bootstrap peer

Two atomic commits, single-scope each.

## Items

### `feat(api): add /lean/v0/blocks/finalized endpoint` (`546c3dc`)

**Where:** `api/server.go` (new `FinalizedBlockHandler` + route), `api/handlers_blocks_test.go` (new).

**Behavior:**

- `200 OK` + SSZ-encoded `SignedBlock` + `Content-Type: application/octet-stream` when the store has a finalized block
- `404 Not Found` when `LatestFinalized().Root == ZeroRoot` (genesis-only state)
- `404 Not Found` when the root is recorded but `GetSignedBlock(root) == nil` (body missing)
- `500` on SSZ marshal failure (defense, should not happen)

No JSON variant — leanSpec PR #713 defines SSZ only.

**Why no storage work was needed:** gean already retains the full `SignedBlock` SSZ for every block it processes (`node/consensus_store.go` `writeBlockData` writes to `TableBlockSignatures`; `PruneOnFinalization` preserves canonical block bodies). The endpoint reads via the existing `GetSignedBlock(root)` path.

**Tests** (3):
- `TestFinalizedBlockHandler_NotFound_WhenNoFinalized` — zero-root case
- `TestFinalizedBlockHandler_NotFound_WhenSignedBlockMissing` — recorded root, no body
- `TestFinalizedBlockHandler_ReturnsSSZ_WhenPresent` — happy path, including content-type assertion and roundtrip via SSZ decode

---

### `feat(checkpoint): pair anchor state with /blocks/finalized` (`c550201`)

**Where:** `checkpoint/checkpoint.go` (new `FetchCheckpointAnchor`, `deriveBlockURL`, shared `fetchSSZ`), `checkpoint/checkpoint_test.go` (new), `cmd/gean/main.go` (wires the new fetcher into the checkpoint-sync path).

**Behavior:**

```
state = fetch(stateURL)
block = fetch(deriveBlockURL(stateURL))  // /states/finalized → /blocks/finalized
require block.state_root == hash_tree_root(state)
require VerifyCheckpointState(state, expectedGenesisTime, expectedValidators)
```

**Why pairing matters:** leanSpec PR #713 body documents the failure mode. A peer with the state but no anchor body has historically fabricated a `SignedBlock` from `state.latest_block_header` with empty body and zero signature. `hash_tree_root(synthetic) ≠ hash_tree_root(real)` whenever the real anchor body carried attestations (the typical post-genesis case), so peers fetching the anchor via `BlocksByRoot` reject the responder. The pairing assertion lets the consumer detect this at sync time.

**Why store the anchor SignedBlock:** without it, `/lean/v0/blocks/finalized` on the next bootstrap peer would 404 against gean — and gean would either have to fabricate a synthetic body (re-introducing the bug PR #713 fixes) or skip the spec endpoint. After the checkpoint-sync path, `s.StorePendingBlock(blockRoot, signedBlock)` writes the anchor body to `TableBlockSignatures` so `GetSignedBlock(root)` returns it forever after.

**CLI compatibility:** `--checkpoint-url` keeps its existing semantic (the full `/lean/v0/states/finalized` URL). `deriveBlockURL` substitutes the suffix internally. URLs not containing the expected suffix get rejected with a clear error.

**Refactor note:** `FetchCheckpointState` was refactored to share the HTTP+body-read code with `FetchCheckpointAnchor` via a private `fetchSSZ` helper. Its public signature is unchanged for backwards compatibility.

**Tests** (5):
- `TestDeriveBlockURL` — 3 cases: normal URL, URL with query string, malformed URL rejection
- `TestFetchCheckpointAnchor_Pairs` — happy path with a healthy state/block pair served by an `httptest.Server`
- `TestFetchCheckpointAnchor_RejectsPairMismatch` — poisons `block.state_root`, asserts the pair-mismatch error fires
- `TestFetchCheckpointAnchor_StateNotFound` — state endpoint returns 404, anchor fetch errors cleanly
- `TestFetchCheckpointAnchor_BlockNotFound` — block endpoint returns 404, anchor fetch errors cleanly

## Stats

- **2 commits** on `feat/api-blocks-finalized` off `origin/devnet-4` at `5dfbd7f`
- **+393 / −16** across 5 files
- **8 new tests** (3 endpoint, 1 URL derivation, 4 anchor fetcher)
- `go vet ./...` clean
- All non-spec suites green (`api`, `checkpoint`, `node`, `statetransition`, `types`, `forkchoice`, `p2p`, `storage`, `genesis`)

## Cross-client status (informs the urgency framing)

| Client | `/blocks/finalized` | Pairing verification |
|---|---|---|
| **gean** *(after this PR)* | shipped | shipped |
| **zeam** | absent (no HTTP API surface beyond `/metrics`) | absent |
| **ethlambda** | absent (router at `crates/net/rpc/src/lib.rs:62-80` has only `/states/finalized`) | absent (`bin/ethlambda/src/checkpoint_sync.rs` fetches state only) |

Neither sibling ships #713 yet. The immediate interop pain is latent — but the first sibling to ship a consumer will fail against any client that hasn't implemented the endpoint, so shipping now sets gean as the reference and avoids a scramble later.

## Spec references

- leanSpec `src/lean_spec/subspecs/api/endpoints/blocks.py` — endpoint handler
- leanSpec `src/lean_spec/subspecs/api/server.py` — `signed_block_getter: Callable[[Bytes32], SignedBlock | None]`
- leanSpec `src/lean_spec/subspecs/sync/checkpoint_sync.py` — `FINALIZED_BLOCK_ENDPOINT` + paired fetch
- leanSpec `forks/lstar/spec.py:879` `Store.create_store(state, anchor_block, ...)` — asserts `anchor_block.state_root == hash_tree_root(state)`

## Commit format

All commits follow `type(scope): subject` with single scope per commit (`feat(api):`, `feat(checkpoint):`). No `Co-authored-by` trailer.

## Test plan

- [ ] CI: `go vet ./...` + `go test ./...` green
- [ ] Spot-check: `go test ./api/ -run TestFinalizedBlockHandler -v` — 3 PASS
- [ ] Spot-check: `go test ./checkpoint/ -run "TestDeriveBlockURL|TestFetchCheckpointAnchor" -v` — 5 PASS
- [ ] Devnet co-test on the multi-client devnet-4 (gean + zeam + ethlambda + grandine):
  - [ ] `curl http://gean:8088/lean/v0/blocks/finalized -o /tmp/anchor.ssz` returns SSZ bytes; bytes round-trip via `SignedBlock.UnmarshalSSZ`
  - [ ] Compute `hash_tree_root` of the served block; compare against the `latest_finalized.root` reported by `/lean/v0/fork_choice` — must match
  - [ ] Cold-restart gean with `--checkpoint-url http://gean:8088/lean/v0/states/finalized` — observe the `checkpoint sync` log line and confirm the node enters the chain at the expected finalized slot, not at boot defaults
  - [ ] Repeat against zeam/ethlambda checkpoint URLs once they ship the endpoint — until then those will 404 the block endpoint and `FetchCheckpointAnchor` will error cleanly
- [ ] Hold open for one slot-clock day of devnet observation before merge

## Out of scope (intentional)

- leanSpec PR #708 sync-lag duty gate — bundled into the upcoming PR-D
- leanSpec PR #713 mentions a `FINALIZED_BLOCK_ENDPOINT` constant for the consumer — gean uses `BlocksFinalizedPath` as the equivalent. Cohort can converge on the name in a follow-up.