### PR TITLE
feat(validator): sync-lag duty gate with hysteresis (leanSpec #708)

### DIFF
--- a/node/consensus_store.go
+++ b/node/consensus_store.go
@@ -1,6 +1,8 @@
 package node
 
 import (
+	"encoding/binary"
+
 	"github.com/geanlabs/gean/storage"
 	"github.com/geanlabs/gean/types"
 	"github.com/geanlabs/gean/xmss"
@@ -224,6 +226,39 @@ func (s *ConsensusStore) HeadSlot() uint64 {
 		return 0
 	}
 	return h.Slot
+}
+
+// MaxStoredBlockSlot returns the highest slot across every block header
+// currently in the store, regardless of canonicality. Only signature-verified
+// blocks enter the header table, so the value is an authenticated lower
+// bound on the network tip — useful for the validator duty-gate to detect
+// network stalls without trusting peer-reported head slots.
+//
+// Reads only the first 8 bytes (slot field) of each header value rather
+// than decoding the full SSZ struct; this keeps the cost linear in the
+// number of stored blocks with a small constant.
+func (s *ConsensusStore) MaxStoredBlockSlot() uint64 {
+	rv, err := s.Backend.BeginRead()
+	if err != nil {
+		return 0
+	}
+	it, err := rv.PrefixIterator(storage.TableBlockHeaders, nil)
+	if err != nil {
+		return 0
+	}
+	defer it.Close()
+	var max uint64
+	for it.Next() {
+		v := it.Value()
+		if len(v) < 8 {
+			continue
+		}
+		slot := binary.LittleEndian.Uint64(v[:8])
+		if slot > max {
+			max = slot
+		}
+	}
+	return max
 }
 
 // StorePendingBlock stores block in DB without LiveChain entry (invisible to fork choice).

--- a/node/metrics.go
+++ b/node/metrics.go
@@ -252,6 +252,24 @@ var metricNodeSyncStatus = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Name: "lean_node_sync_status", Help: "Node sync status (one of idle/syncing/synced is set to 1)",
 }, []string{"status"})
 
+// --- Duty-gate skip counters (leanSpec PR #708) ---
+//
+// Increment once per slot the duty gate denied production. The node-local
+// prefix matches gean's convention for per-node state (lean_node_*) rather
+// than the chain-level lean_* prefix because gating is informative and may
+// differ across clients without breaking consensus.
+
+var (
+	metricBlocksSkippedLag = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "lean_node_blocks_skipped_lag_total",
+		Help: "Block proposals skipped because the local view was too stale (leanSpec PR #708 duty gate).",
+	})
+	metricAttestationsSkippedLag = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "lean_node_attestations_skipped_lag_total",
+		Help: "Attestation batches skipped because the local view was too stale (leanSpec PR #708 duty gate).",
+	})
+)
+
 // --- Public update functions ---
 
 func SetNodeInfo(name, version string) { metricNodeInfo.WithLabelValues(name, version).Set(1) }
@@ -287,6 +305,8 @@ func IncAttestationsValid(n uint64)          { metricAttestationsValid.Add(float
 func IncAttestationsInvalid()                { metricAttestationsInvalid.Inc() }
 func IncAttestationsBufferEvicted(n int)     { metricAttestationsBufferEvicted.Add(float64(n)) }
 func IncForkChoiceReorgs()                   { metricForkChoiceReorgs.Inc() }
+func IncBlocksSkippedLag()                   { metricBlocksSkippedLag.Inc() }
+func IncAttestationsSkippedLag()             { metricAttestationsSkippedLag.Inc() }
 func IncPqSigAggregatedTotal()               { metricPqSigAggregatedSignaturesTotal.Inc() }
 func IncPqSigAttestationsInAggregated(n int) { metricPqSigAttestationsInAggregated.Add(float64(n)) }
 func IncPqSigAggregatedValid()               { metricPqSigAggregatedValid.Inc() }

--- a/node/node.go
+++ b/node/node.go
@@ -36,6 +36,7 @@ type Engine struct {
 	P2P                 *p2p.Host
 	Keys                *xmss.KeyManager
 	AggCtl              *AggregatorController
+	DutyGate            *DutyGate // gates validator signing when local view is stale
 	CommitteeCount      uint64
 	PendingBlocks       map[[32]byte]map[[32]byte]bool // parent_root -> {child_roots}
 	PendingBlockParents map[[32]byte][32]byte          // block_root -> missing_ancestor
@@ -70,6 +71,7 @@ func New(
 		P2P:                 p2pHost,
 		Keys:                keys,
 		AggCtl:              aggCtl,
+		DutyGate:            NewDutyGate(),
 		CommitteeCount:      committeeCount,
 		PendingBlocks:       make(map[[32]byte]map[[32]byte]bool),
 		PendingBlockParents: make(map[[32]byte][32]byte),

--- a/node/sync_lag_gate.go
+++ b/node/sync_lag_gate.go
@@ -1,0 +1,106 @@
+package node
+
+import (
+	"sync"
+
+	"github.com/geanlabs/gean/logger"
+)
+
+// Validator duty-gate thresholds mirroring leanSpec subspecs/validator/constants.py.
+// Informative, not normative: they shape when this node signs without
+// changing what consensus accepts. Clients may diverge without breaking
+// interop.
+const (
+	// SyncLagThreshold is the slot lag past which the local view is too
+	// stale to sign. Roughly one full justification window behind real time.
+	SyncLagThreshold uint64 = 4
+
+	// NetworkStallThreshold is the lag past which the entire network is
+	// treated as stalled. Set to 2 * SyncLagThreshold so ordinary jitter
+	// at the local boundary cannot trip the network-stall branch.
+	NetworkStallThreshold uint64 = 8
+
+	// HysteresisBand keeps the gate closed near the threshold. Once closed,
+	// the gate reopens only when lag drops to SyncLagThreshold - HysteresisBand.
+	HysteresisBand uint64 = 2
+)
+
+// DutyGate decides whether validator duties may run for a given slot, given
+// the local store's head and the freshest block slot the store has observed.
+// State is per-node (one local store, one gate); a single instance lives on
+// Engine.
+//
+// Transitions (open ↔ closed) are logged; intermediate checks are silent.
+type DutyGate struct {
+	mu     sync.Mutex
+	closed bool
+}
+
+// NewDutyGate returns a DutyGate in the open state.
+func NewDutyGate() *DutyGate {
+	return &DutyGate{}
+}
+
+// IsClosed reports the gate's current state. Concurrency-safe.
+func (g *DutyGate) IsClosed() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.closed
+}
+
+// Decide returns true if a duty may run for wallSlot. duty is a free-form
+// label ("block", "attestation", ...) included in transition log lines.
+//
+//   - headSlot       — slot of the canonical chain head from local store.
+//   - maxStoredSlot  — max slot across all blocks already validated into
+//     the store. Authenticated lower bound on the network tip because
+//     only signature-verified blocks enter the map. A stale max here
+//     means the network is not producing.
+//
+// Decision matrix:
+//
+//   - network stalling (network_lag > NetworkStallThreshold):
+//     keep signing; reopen the gate if it was closed.
+//   - gate currently closed: reopen only when lag <= SyncLagThreshold - HysteresisBand.
+//   - gate currently open:   close as soon as lag > SyncLagThreshold.
+func (g *DutyGate) Decide(duty string, wallSlot, headSlot, maxStoredSlot uint64) bool {
+	lag := uint64(0)
+	if wallSlot > headSlot {
+		lag = wallSlot - headSlot
+	}
+	networkLag := uint64(0)
+	if wallSlot > maxStoredSlot {
+		networkLag = wallSlot - maxStoredSlot
+	}
+	networkStalling := networkLag > NetworkStallThreshold
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if networkStalling {
+		if g.closed {
+			g.closed = false
+			logger.Info(logger.Validator, "duty gate reopened: network stall detected. duty=%s slot=%d head_slot=%d lag=%d max_seen_slot=%d network_lag=%d",
+				duty, wallSlot, headSlot, lag, maxStoredSlot, networkLag)
+		}
+		return true
+	}
+
+	if g.closed {
+		allow := lag <= SyncLagThreshold-HysteresisBand
+		if allow {
+			g.closed = false
+			logger.Info(logger.Validator, "duty gate reopened: local view caught up. duty=%s slot=%d head_slot=%d lag=%d",
+				duty, wallSlot, headSlot, lag)
+		}
+		return allow
+	}
+
+	allow := lag <= SyncLagThreshold
+	if !allow {
+		g.closed = true
+		logger.Info(logger.Validator, "duty gate closed: local view is stale. duty=%s slot=%d head_slot=%d lag=%d max_seen_slot=%d network_lag=%d",
+			duty, wallSlot, headSlot, lag, maxStoredSlot, networkLag)
+	}
+	return allow
+}

--- a/node/sync_lag_gate_test.go
+++ b/node/sync_lag_gate_test.go
@@ -1,0 +1,132 @@
+package node
+
+import "testing"
+
+func TestDutyGate_StartsOpen(t *testing.T) {
+	g := NewDutyGate()
+	if g.IsClosed() {
+		t.Fatal("new gate should start open")
+	}
+}
+
+func TestDutyGate_AllowsWhenInsideThreshold(t *testing.T) {
+	g := NewDutyGate()
+	// lag = 4 = SyncLagThreshold — at the boundary, still allowed.
+	if !g.Decide("attestation", 10, 6, 10) {
+		t.Fatal("lag at threshold should be allowed")
+	}
+	if g.IsClosed() {
+		t.Fatal("gate should remain open at threshold")
+	}
+}
+
+func TestDutyGate_ClosesWhenLagCrossesThreshold(t *testing.T) {
+	g := NewDutyGate()
+	// lag = 5 > SyncLagThreshold (4) — should close.
+	// networkLag = 5 too; not > NetworkStallThreshold (8), so no override.
+	if g.Decide("attestation", 10, 5, 5) {
+		t.Fatal("lag past threshold should be denied")
+	}
+	if !g.IsClosed() {
+		t.Fatal("gate should close after crossing threshold")
+	}
+}
+
+func TestDutyGate_Hysteresis_DoesNotReopenAtThreshold(t *testing.T) {
+	g := NewDutyGate()
+	// Step 1: close the gate.
+	g.Decide("attestation", 10, 5, 5) // lag = 5
+	if !g.IsClosed() {
+		t.Fatal("setup: gate should be closed")
+	}
+
+	// Step 2: drop to lag = 3. SyncLagThreshold - HysteresisBand = 2.
+	// 3 > 2, so the gate stays closed despite being below the open-threshold.
+	if g.Decide("attestation", 10, 7, 7) {
+		t.Fatal("hysteresis: lag = 3 should keep the gate closed")
+	}
+	if !g.IsClosed() {
+		t.Fatal("gate should still be closed")
+	}
+}
+
+func TestDutyGate_Hysteresis_ReopensBelowBand(t *testing.T) {
+	g := NewDutyGate()
+	g.Decide("attestation", 10, 5, 5) // close it
+	if !g.IsClosed() {
+		t.Fatal("setup: gate should be closed")
+	}
+
+	// lag = 2 = SyncLagThreshold - HysteresisBand. Should reopen.
+	if !g.Decide("attestation", 10, 8, 8) {
+		t.Fatal("hysteresis: lag = 2 should reopen the gate")
+	}
+	if g.IsClosed() {
+		t.Fatal("gate should have reopened")
+	}
+}
+
+func TestDutyGate_NetworkStallOverridesGate(t *testing.T) {
+	g := NewDutyGate()
+	// Close the gate first.
+	g.Decide("attestation", 10, 5, 5)
+	if !g.IsClosed() {
+		t.Fatal("setup: gate should be closed")
+	}
+
+	// Now: lag = 5 (still > threshold) but network_lag = 9 > NetworkStallThreshold.
+	// Duties must keep firing so the chain can advance through the gap.
+	if !g.Decide("attestation", 10, 5, 1) {
+		t.Fatal("network stall must override the closed gate")
+	}
+	if g.IsClosed() {
+		t.Fatal("network stall should reopen the gate")
+	}
+}
+
+func TestDutyGate_NetworkStallKeepsOpenGateOpen(t *testing.T) {
+	g := NewDutyGate()
+	// network_lag = 9 > 8, lag = 9. Gate was open. Stays open via stall branch.
+	if !g.Decide("block", 10, 1, 1) {
+		t.Fatal("network stall should keep duties live")
+	}
+	if g.IsClosed() {
+		t.Fatal("network stall should not close the gate")
+	}
+}
+
+func TestDutyGate_HeadAheadOfWallSaturatesAtZero(t *testing.T) {
+	g := NewDutyGate()
+	// head_slot ahead of wall_slot — lag saturates at 0, never trips threshold.
+	if !g.Decide("attestation", 10, 100, 100) {
+		t.Fatal("head ahead of wall should allow duties")
+	}
+}
+
+func TestDutyGate_TransitionLogsOnlyOnEdges(t *testing.T) {
+	// This test cannot easily assert log output but at minimum verifies the
+	// internal state machine: repeated open->open or closed->closed calls
+	// don't toggle .closed.
+	g := NewDutyGate()
+	for i := 0; i < 5; i++ {
+		// lag = 1, well inside threshold. Should stay open every iteration.
+		if !g.Decide("attestation", 10, 9, 9) {
+			t.Fatalf("iter %d: should remain open", i)
+		}
+		if g.IsClosed() {
+			t.Fatalf("iter %d: should not toggle to closed", i)
+		}
+	}
+
+	// Force close.
+	g.Decide("attestation", 10, 5, 5)
+	for i := 0; i < 5; i++ {
+		// lag = 3 — above re-open band, gate stays closed.
+		if g.Decide("attestation", 10, 7, 7) {
+			t.Fatalf("iter %d: should remain closed", i)
+		}
+		if !g.IsClosed() {
+			t.Fatalf("iter %d: should not toggle to open", i)
+		}
+	}
+}

--- a/node/validator.go
+++ b/node/validator.go
@@ -21,6 +21,13 @@ func (e *Engine) maybePropose(slot, validatorID uint64) {
 		return
 	}
 
+	// Sync-lag duty gate (leanSpec PR #708). Skip when the local view is
+	// too stale relative to a network that is otherwise making progress.
+	if e.DutyGate != nil && !e.DutyGate.Decide("block", slot, e.Store.HeadSlot(), e.Store.MaxStoredBlockSlot()) {
+		IncBlocksSkippedLag()
+		return
+	}
+
 	logger.Info(logger.Validator, "proposing block slot=%d validator=%d", slot, validatorID)
 
 	// Spec get_proposal_head: promote pending attestations and update head
@@ -84,6 +91,14 @@ func (e *Engine) maybePropose(slot, validatorID uint64) {
 // produceAttestations creates and publishes attestations for all local validators.
 func (e *Engine) produceAttestations(slot uint64) {
 	if e.Keys == nil {
+		return
+	}
+
+	// Sync-lag duty gate (leanSpec PR #708). Skip the whole batch when the
+	// local view is too stale relative to a network that is otherwise
+	// making progress. Counter ticks once per skipped slot, not per validator.
+	if e.DutyGate != nil && !e.DutyGate.Decide("attestation", slot, e.Store.HeadSlot(), e.Store.MaxStoredBlockSlot()) {
+		IncAttestationsSkippedLag()
 		return
 	}
 


### PR DESCRIPTION
## Summary

Closes #252. Implements leanSpec PR #708 in gean: a per-node duty gate that silences validator signing when the local view is too stale relative to a network making progress, with hysteresis to prevent flapping and a network-stall override that keeps duties live through gap streaks.

Two atomic commits, single-scope each.

## Items

### `feat(validator): sync-lag duty gate with hysteresis` (`0c06643`)

**Where:** new `node/sync_lag_gate.go` (106 LOC) and `node/sync_lag_gate_test.go` (132 LOC, 9 tests).

**Constants** (verbatim from `leanSpec/subspecs/validator/constants.py`):

| Constant | Value | Purpose |
|---|---|---|
| `SyncLagThreshold` | 4 | Slot lag past which the local view is too stale to sign. |
| `NetworkStallThreshold` | 8 | = 2 * SyncLagThreshold. Lag past which the entire network is treated as stalled (keep signing). |
| `HysteresisBand` | 2 | Once closed, reopen only at `lag <= SyncLagThreshold - HysteresisBand` (= 2). |

**`Decide(duty, wallSlot, headSlot, maxStoredSlot)`** mirrors the spec's `_is_synced_for_duties`:

```
lag         = max(0, wallSlot - headSlot)
network_lag = max(0, wallSlot - maxStoredSlot)
network_stalling = network_lag > NetworkStallThreshold

if network_stalling: allow = True; reopen if closed (log).
elif closed:         allow = lag <= SyncLagThreshold - HysteresisBand; reopen if catching up (log).
else (open):         allow = lag <= SyncLagThreshold; close if crossing (log).
```

Concurrency: mutex around the hysteresis bool. State is per-node (one local store, one gate). Transitions are logged once at the edge; intermediate checks are silent.

**Tests** (9):
- `TestDutyGate_StartsOpen`
- `TestDutyGate_AllowsWhenInsideThreshold` (boundary at `lag = SyncLagThreshold`)
- `TestDutyGate_ClosesWhenLagCrossesThreshold`
- `TestDutyGate_Hysteresis_DoesNotReopenAtThreshold` (`lag = 3 > SyncLagThreshold - HysteresisBand`)
- `TestDutyGate_Hysteresis_ReopensBelowBand` (`lag = 2`)
- `TestDutyGate_NetworkStallOverridesGate` (closed gate + network stall → reopen + allow)
- `TestDutyGate_NetworkStallKeepsOpenGateOpen`
- `TestDutyGate_HeadAheadOfWallSaturatesAtZero` (defends against clock drift on the local node)
- `TestDutyGate_TransitionLogsOnlyOnEdges` (verifies the state machine doesn't toggle on repeated same-direction calls)

---

### `feat(node): wire duty gate into validator production with skipped-lag metrics` (`e96d3fa`)

**Where:** `node/consensus_store.go` (new primitive), `node/node.go` (Engine wiring), `node/validator.go` (gate check), `node/metrics.go` (counters).

**1. `ConsensusStore.MaxStoredBlockSlot()`** — scans `TableBlockHeaders`, returns the highest stored slot. Implements the spec's `max(b.slot for b in store.blocks.values())` semantic — an authenticated lower bound on the network tip since only signature-verified blocks enter the header table. Reads only the first 8 bytes (the slot field of the SSZ container) per entry to keep per-call cost linear with a small constant.

**2. `Engine.DutyGate`** — single instance created in `Engine.New`. Lives for the process lifetime.

**3. Gate check in `maybePropose`:**

```go
if e.DutyGate != nil && !e.DutyGate.Decide("block", slot, e.Store.HeadSlot(), e.Store.MaxStoredBlockSlot()) {
    IncBlocksSkippedLag()
    return
}
```

**4. Same pattern in `produceAttestations`** with `IncAttestationsSkippedLag` — counter ticks once per skipped slot, not per validator (the gate denies the whole batch).

**5. Metrics:**

- `lean_node_blocks_skipped_lag_total`
- `lean_node_attestations_skipped_lag_total`

The `lean_node_*` prefix follows gean's convention for per-node state (`lean_node_sync_status`, `lean_node_info`, `lean_node_start_time_seconds`) since the gate is informative and may differ across clients without breaking consensus.

## Stats

- 2 commits on `feat/sync-lag-duty-gate` off `origin/devnet-4` at `5dfbd7f`
- +310 / 0 across 6 files (3 new, 3 modified)
- 9 new behavioral tests covering the gate state machine
- `go vet ./...` clean
- All non-spec suites green (`node`, `types`, `forkchoice`, `p2p`, `statetransition`, `api`, `checkpoint`, `storage`, `genesis`)

## Cross-client framing — gean is first

Neither sibling ships #708 yet. zeam has a simpler binary `behind_peers` gate driven by peer-reported finalized slots (the previous-generation design that #708 explicitly replaces with local-store evidence). ethlambda has no duty-skip path. This PR positions gean as the reference implementation.

## Commit format

`feat(validator):` and `feat(node):` — single scope per commit. No `Co-authored-by` trailer.

## Test plan

- [ ] CI: `go vet ./...` + `go test ./...` green
- [ ] Spot-check: `go test ./node/ -run TestDutyGate -v` — 9 PASS
- [ ] Devnet co-test on the multi-client devnet-4 (gean + zeam + ethlambda + grandine):
  - [ ] Cold-start gean and confirm the gate stays open under normal operation (`lean_node_blocks_skipped_lag_total` and `lean_node_attestations_skipped_lag_total` remain at 0 across the first hour)
  - [ ] Disconnect gean from the network for ~10 slots, reconnect, and confirm:
    - [ ] During disconnect: `head_slot` falls behind, gate closes (one `duty gate closed` log line), skip counters tick once per slot
    - [ ] On reconnect: blocks flow in, gate reopens (one `duty gate reopened: local view caught up` log line)
  - [ ] Pause the validator that proposes for several slots in a row to trigger a network-stall scenario, confirm gean stays in the open state via the network-stall override
  - [ ] Confirm no logger spam — at most one transition log per gate edge
- [ ] Hold open for one slot-clock day of devnet observation before merge

## Out of scope (intentional)

- The existing `SyncLagSlots = 2` constant in `node/tick.go` driving the `lean_node_sync_status` gauge is left untouched. That's a *reporting* threshold (1-2 slots is "lagging" in the UI); the gate is a *signing* threshold (4+ slots is "too stale to sign"). Separation matches the spec's framing of informative-not-normative.
- Per-validator gate state: spec says per-node. We keep it that way.