### PR TITLE
feat(api): hive test-driver endpoints for lean-spec-tests conformance

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -14,8 +14,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-// StartAPIServer starts the API server on the given address.
-func StartAPIServer(address string, s *node.ConsensusStore, fc *forkchoice.ForkChoice, aggCtl *node.AggregatorController) error {
+// buildAPIMux registers gean's runtime API routes on a fresh ServeMux. The
+// mux is returned so callers can attach additional routes (e.g. the test
+// driver routes under StartAPIServerWithTestDriver) before binding it to a
+// listener.
+func buildAPIMux(s *node.ConsensusStore, fc *forkchoice.ForkChoice, aggCtl *node.AggregatorController) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("GET /lean/v0/health", HealthHandler)
@@ -26,12 +29,41 @@ func StartAPIServer(address string, s *node.ConsensusStore, fc *forkchoice.ForkC
 	mux.HandleFunc("GET /lean/v0/admin/aggregator", AggregatorStatusHandler(aggCtl))
 	mux.HandleFunc("POST /lean/v0/admin/aggregator", AggregatorToggleHandler(aggCtl))
 
+	return mux
+}
+
+// StartAPIServer starts the API server on the given address. Only runtime
+// routes are exposed; test-driver endpoints are unavailable.
+func StartAPIServer(address string, s *node.ConsensusStore, fc *forkchoice.ForkChoice, aggCtl *node.AggregatorController) error {
+	mux := buildAPIMux(s, fc, aggCtl)
+
 	listener, err := net.Listen("tcp", address)
 	if err != nil {
 		return fmt.Errorf("api listen: %w", err)
 	}
 
 	logger.Info(logger.Network, "api server listening on %s", address)
+	return http.Serve(listener, mux)
+}
+
+// StartAPIServerWithTestDriver starts the API server with the production
+// routes plus the four test-driver endpoints under /lean/v0/test_driver/.
+// The test-driver routes are gated on HIVE_LEAN_TEST_DRIVER being truthy at
+// process start; callers should branch on IsTestDriverEnabled before
+// invoking this constructor. The split-constructor pattern (rather than an
+// in-handler env-var check) keeps production binaries from accidentally
+// exposing the test-driver session even when the env var is set, because
+// the routes simply do not exist on the mux when StartAPIServer is used.
+func StartAPIServerWithTestDriver(address string, s *node.ConsensusStore, fc *forkchoice.ForkChoice, aggCtl *node.AggregatorController) error {
+	mux := buildAPIMux(s, fc, aggCtl)
+	RegisterTestDriverRoutes(mux, NewTestDriverSession())
+
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return fmt.Errorf("api listen: %w", err)
+	}
+
+	logger.Info(logger.Network, "api server listening on %s (test-driver routes enabled)", address)
 	return http.Serve(listener, mux)
 }
 

--- a/api/test_driver.go
+++ b/api/test_driver.go
@@ -266,10 +266,14 @@ func (sess *TestDriverSession) ForkChoiceInitHandler() http.HandlerFunc {
 
 func writeInitFailure(w http.ResponseWriter, msg string) {
 	// Init failures use the step response shape with an empty snapshot so
-	// the simulator can call /init and immediately read .error without
-	// having to call /step first.
+	// the simulator can call /init and immediately read .error if it wants
+	// the structured detail. HTTP 400 is what the hive lean simulator keys
+	// off — see spec_assets.rs:297-310, which treats any non-2xx status as
+	// "init rejected" and only treats 204 NO_CONTENT as "init accepted".
+	// Returning 200 here would make hive fall through to the 204 assertion
+	// and fail the test even though the init was correctly rejected.
 	resp := driverStepResponse{Accepted: false, Error: &msg, Snapshot: driverSnapshot{}}
-	writeJSON(w, http.StatusOK, resp)
+	writeJSON(w, http.StatusBadRequest, resp)
 }
 
 // ForkChoiceStepHandler answers POST /lean/v0/test_driver/fork_choice/step.
@@ -430,14 +434,25 @@ func (sess *TestDriverSession) applyAttestation(step *specfixtures.ForkChoiceSte
 		return err
 	}
 
-	// Single-validator gossip attestation: synthesize a participants bitlist
-	// containing just this validator id so downstream aggregation and vote
-	// tracking can treat it like any other proof.
-	participants := node.AggregationBitsFromIndices([]uint64{step.Attestation.ValidatorID})
 	dataRoot, err := attData.HashTreeRoot()
 	if err != nil {
 		return err
 	}
+
+	// Validator-id bounds check + XMSS signature verification against the
+	// target state's validator registry. Rejection happens here, before any
+	// state mutation, so a bad attestation cannot leave behind a vote-tracker
+	// entry, an applied delta, or a NewPayloads push that subsequent steps
+	// would observe. Mirrors ethlambda's on_gossip_attestation flow at
+	// crates/blockchain/src/store.rs:285-306.
+	if err := sess.verifyGossipAttestation(step.Attestation.ValidatorID, attData, dataRoot, step.Attestation.Signature); err != nil {
+		return err
+	}
+
+	// Single-validator gossip attestation: synthesize a participants bitlist
+	// containing just this validator id so downstream aggregation and vote
+	// tracking can treat it like any other proof.
+	participants := node.AggregationBitsFromIndices([]uint64{step.Attestation.ValidatorID})
 	proof := &types.AggregatedSignatureProof{Participants: participants}
 	sess.store.NewPayloads.Push(dataRoot, attData, proof)
 
@@ -490,6 +505,16 @@ func (sess *TestDriverSession) applyAggregatedAttestation(step *specfixtures.For
 	if err != nil {
 		return err
 	}
+
+	// Bounds-check each participant id and verify the aggregated XMSS proof
+	// against the participants' pubkeys. Symmetric with the individual-
+	// attestation path's validator-id bounds + sig verification; runs before
+	// state mutation so a rejected aggregated attestation leaves no side
+	// effects.
+	if err := node.VerifyAggregatedGossipAttestation(sess.store, attData, participants, proofData); err != nil {
+		return err
+	}
+
 	proof := &types.AggregatedSignatureProof{Participants: participants, ProofData: proofData}
 	sess.store.NewPayloads.Push(dataRoot, attData, proof)
 
@@ -511,6 +536,19 @@ func (sess *TestDriverSession) applyAggregatedAttestation(step *specfixtures.For
 	justifiedRoot := sess.store.LatestJustified().Root
 	sess.store.SetHead(sess.fc.UpdateHead(justifiedRoot))
 	return nil
+}
+
+// verifyGossipAttestation is a thin wrapper around node.VerifyGossipAttestation
+// that parses the fixture's hex-encoded signature into bytes before delegating.
+// The node-level function is the single source of truth so the HTTP test
+// driver and the Go spec runner can't diverge on what counts as a valid
+// individual gossip attestation.
+func (sess *TestDriverSession) verifyGossipAttestation(validatorID uint64, attData *types.AttestationData, dataRoot [32]byte, signatureHex string) error {
+	sigBytes, err := specfixtures.ParseHexBytes(signatureHex)
+	if err != nil {
+		return fmt.Errorf("decode signature hex: %w", err)
+	}
+	return node.VerifyGossipAttestation(sess.store, validatorID, attData, dataRoot, sigBytes)
 }
 
 // loadSnapshot reads the session's current store + fc into the snapshot

--- a/api/test_driver.go
+++ b/api/test_driver.go
@@ -1,0 +1,602 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/geanlabs/gean/forkchoice"
+	"github.com/geanlabs/gean/node"
+	"github.com/geanlabs/gean/specfixtures"
+	"github.com/geanlabs/gean/statetransition"
+	"github.com/geanlabs/gean/storage"
+	"github.com/geanlabs/gean/types"
+)
+
+// TestDriverEnvVar is the env var that gates the test-driver routes. When
+// set to a truthy value, gean exposes POST /lean/v0/test_driver/* endpoints
+// the hive lean simulator calls to run lean-spec-tests conformance fixtures.
+// These endpoints are not part of the runtime spec; they exist solely for
+// conformance testing and must never be exposed on production deployments.
+const TestDriverEnvVar = "HIVE_LEAN_TEST_DRIVER"
+
+// IsTestDriverEnabled returns true if the env var is set to "1", "true",
+// "TRUE", "yes", or "YES" — matching ream's accepted values.
+func IsTestDriverEnabled(value string) bool {
+	switch value {
+	case "1", "true", "TRUE", "yes", "YES":
+		return true
+	}
+	return false
+}
+
+// TestDriverSession holds the ephemeral consensus store and fork choice the
+// fork-choice spec-test endpoints operate on. /init replaces the instances;
+// /step operates on whatever the most recent /init produced. The mutex
+// serializes step processing against init resets; concurrent simulators
+// would be a misuse pattern but the lock keeps state consistent regardless.
+type TestDriverSession struct {
+	mu         sync.Mutex
+	store      *node.ConsensusStore
+	fc         *forkchoice.ForkChoice
+	labelRoots map[string][32]byte
+}
+
+// NewTestDriverSession returns an empty session — handlers will reject step
+// calls until /fork_choice/init runs and populates store + fc.
+func NewTestDriverSession() *TestDriverSession {
+	return &TestDriverSession{labelRoots: make(map[string][32]byte)}
+}
+
+// RegisterTestDriverRoutes mounts the four test-driver endpoints on mux.
+// Called only when HIVE_LEAN_TEST_DRIVER is truthy; see api/server.go.
+func RegisterTestDriverRoutes(mux *http.ServeMux, sess *TestDriverSession) {
+	mux.HandleFunc("POST /lean/v0/test_driver/state_transition/run", TestDriverStateTransitionHandler())
+	mux.HandleFunc("POST /lean/v0/test_driver/fork_choice/init", sess.ForkChoiceInitHandler())
+	mux.HandleFunc("POST /lean/v0/test_driver/fork_choice/step", sess.ForkChoiceStepHandler())
+	mux.HandleFunc("POST /lean/v0/test_driver/verify_signatures/run", TestDriverVerifySignaturesHandler())
+}
+
+// stateTransitionResponse mirrors ream's StateTransitionResponse shape so
+// the simulator can deserialize it via serde with rename_all = "camelCase".
+type stateTransitionResponse struct {
+	Succeeded bool                 `json:"succeeded"`
+	Error     *string              `json:"error"`
+	Post      *stateTransitionPost `json:"post"`
+}
+
+type stateTransitionPost struct {
+	Slot                       uint64 `json:"slot"`
+	LatestBlockHeaderSlot      uint64 `json:"latestBlockHeaderSlot"`
+	LatestBlockHeaderStateRoot string `json:"latestBlockHeaderStateRoot"`
+	HistoricalBlockHashesCount uint64 `json:"historicalBlockHashesCount"`
+}
+
+// driverStepResponse matches the simulator's expected ForkChoiceStepResponse.
+type driverStepResponse struct {
+	Accepted bool           `json:"accepted"`
+	Error    *string        `json:"error"`
+	Snapshot driverSnapshot `json:"snapshot"`
+}
+
+type driverSnapshot struct {
+	HeadSlot            uint64           `json:"headSlot"`
+	HeadRoot            string           `json:"headRoot"`
+	Time                uint64           `json:"time"`
+	JustifiedCheckpoint driverCheckpoint `json:"justifiedCheckpoint"`
+	FinalizedCheckpoint driverCheckpoint `json:"finalizedCheckpoint"`
+	SafeTarget          string           `json:"safeTarget"`
+}
+
+type driverCheckpoint struct {
+	Slot uint64 `json:"slot"`
+	Root string `json:"root"`
+}
+
+type verifySignaturesResponse struct {
+	Succeeded bool    `json:"succeeded"`
+	Error     *string `json:"error"`
+}
+
+// TestDriverStateTransitionHandler answers POST
+// /lean/v0/test_driver/state_transition/run. Per ream's convention, logical
+// failures (state-transition rejecting a block) return HTTP 200 with the
+// reason in the JSON `error` field; only request-parse or marshaling errors
+// surface as non-200 so the simulator can distinguish wire-level failures
+// from in-fixture rejections.
+func TestDriverStateTransitionHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var fixture specfixtures.StateTransitionFixture
+		if err := json.NewDecoder(r.Body).Decode(&fixture); err != nil {
+			http.Error(w, fmt.Sprintf("decode body: %v", err), http.StatusBadRequest)
+			return
+		}
+
+		state, err := fixture.Pre.ToState()
+		if err != nil {
+			writeStateTransitionFailure(w, fmt.Sprintf("pre.toState: %v", err))
+			return
+		}
+
+		// Empty-blocks + expectException: force a process_slots call against
+		// state.slot so the spec's filler-side rejection materializes for us.
+		// Mirrors ream's run_state_transition path for the zero-blocks branch.
+		if len(fixture.Blocks) == 0 {
+			if fixture.ExpectException != "" {
+				if err := statetransition.ProcessSlots(state, state.Slot); err != nil {
+					writeStateTransitionFailure(w, err.Error())
+					return
+				}
+			}
+			// No-blocks, no-exception is a genesis-style smoke case; succeed.
+			writeStateTransitionSuccess(w, state)
+			return
+		}
+
+		for i, tb := range fixture.Blocks {
+			block, err := tb.ToBlock()
+			if err != nil {
+				writeStateTransitionFailure(w, fmt.Sprintf("blocks[%d]: %v", i, err))
+				return
+			}
+			if err := statetransition.StateTransition(state, block); err != nil {
+				writeStateTransitionFailure(w, fmt.Sprintf("blocks[%d]: %v", i, err))
+				return
+			}
+		}
+
+		writeStateTransitionSuccess(w, state)
+	}
+}
+
+func writeStateTransitionSuccess(w http.ResponseWriter, state *types.State) {
+	resp := stateTransitionResponse{
+		Succeeded: true,
+		Error:     nil,
+		Post: &stateTransitionPost{
+			Slot:                       state.Slot,
+			LatestBlockHeaderSlot:      state.LatestBlockHeader.Slot,
+			LatestBlockHeaderStateRoot: fmt.Sprintf("0x%x", state.LatestBlockHeader.StateRoot),
+			HistoricalBlockHashesCount: uint64(len(state.HistoricalBlockHashes)),
+		},
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func writeStateTransitionFailure(w http.ResponseWriter, msg string) {
+	resp := stateTransitionResponse{
+		Succeeded: false,
+		Error:     &msg,
+		Post:      nil,
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// ForkChoiceInitHandler answers POST /lean/v0/test_driver/fork_choice/init.
+// Replaces the session's store + fc with fresh instances seeded from the
+// anchor (state, block) pair. Returns 204 No Content per ream's convention.
+//
+// Logical anchor failures (state-root mismatch between anchor block and
+// anchor state hash_tree_root, malformed bytes, etc.) return HTTP 200 with
+// the error in a JSON body so the simulator can distinguish them from
+// wire-level 400/500s. This is the same pattern the step handler uses.
+func (sess *TestDriverSession) ForkChoiceInitHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req specfixtures.ForkChoiceInit
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, fmt.Sprintf("decode body: %v", err), http.StatusBadRequest)
+			return
+		}
+
+		anchorState, err := req.AnchorState.ToState()
+		if err != nil {
+			writeInitFailure(w, fmt.Sprintf("anchorState: %v", err))
+			return
+		}
+		if req.GenesisTime != nil {
+			anchorState.Config.GenesisTime = *req.GenesisTime
+		}
+
+		anchorBlock, err := req.AnchorBlock.ToBlock()
+		if err != nil {
+			writeInitFailure(w, fmt.Sprintf("anchorBlock: %v", err))
+			return
+		}
+		anchorRoot, err := anchorBlock.HashTreeRoot()
+		if err != nil {
+			writeInitFailure(w, fmt.Sprintf("anchorBlock.hashTreeRoot: %v", err))
+			return
+		}
+
+		// Anchor pair consistency check: block.state_root must equal
+		// hash_tree_root(state). Per leanSpec PR #678 — a mismatched pair
+		// indicates either a fixture bug or an attacker-served anchor and
+		// must be rejected before fork choice trusts either side.
+		computedStateRoot, err := anchorState.HashTreeRoot()
+		if err != nil {
+			writeInitFailure(w, fmt.Sprintf("anchorState.hashTreeRoot: %v", err))
+			return
+		}
+		if computedStateRoot != anchorBlock.StateRoot {
+			writeInitFailure(w, fmt.Sprintf("anchor state-root mismatch: block=0x%x state=0x%x",
+				anchorBlock.StateRoot, computedStateRoot))
+			return
+		}
+
+		// Build the anchor header. Body root comes from the block body's
+		// hash_tree_root so the header is self-consistent — the simulator
+		// later uses this header in /step block processing.
+		anchorHeader := &types.BlockHeader{
+			Slot:          anchorBlock.Slot,
+			ProposerIndex: anchorBlock.ProposerIndex,
+			ParentRoot:    anchorBlock.ParentRoot,
+			StateRoot:     anchorBlock.StateRoot,
+		}
+		if anchorBlock.Body != nil {
+			bodyRoot, _ := anchorBlock.Body.HashTreeRoot()
+			anchorHeader.BodyRoot = bodyRoot
+		}
+
+		store := node.NewConsensusStore(storage.NewInMemoryBackend())
+		store.SetConfig(anchorState.Config)
+		store.InsertBlockHeader(anchorRoot, anchorHeader)
+		store.InsertState(anchorRoot, anchorState)
+		store.InsertLiveChainEntry(anchorBlock.Slot, anchorRoot, anchorBlock.ParentRoot)
+		store.SetHead(anchorRoot)
+		// Per leanSpec PR #677, store-side justified/finalized seed from the
+		// anchor block itself, not from anchorState.LatestJustified/Finalized.
+		// Pre-anchor history embedded in the state's checkpoints is ignored.
+		anchorCp := &types.Checkpoint{Root: anchorRoot, Slot: anchorBlock.Slot}
+		store.SetLatestJustified(anchorCp)
+		store.SetLatestFinalized(anchorCp)
+		store.StorePendingBlock(anchorRoot, &types.SignedBlock{Block: anchorBlock})
+
+		fc := forkchoice.New(anchorBlock.Slot, anchorRoot)
+
+		sess.mu.Lock()
+		sess.store = store
+		sess.fc = fc
+		sess.labelRoots = make(map[string][32]byte)
+		sess.mu.Unlock()
+
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func writeInitFailure(w http.ResponseWriter, msg string) {
+	// Init failures use the step response shape with an empty snapshot so
+	// the simulator can call /init and immediately read .error without
+	// having to call /step first.
+	resp := driverStepResponse{Accepted: false, Error: &msg, Snapshot: driverSnapshot{}}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// ForkChoiceStepHandler answers POST /lean/v0/test_driver/fork_choice/step.
+// Dispatches on stepType (tick / block / attestation / gossipAggregatedAttestation
+// / checks), updates the session store + fc, and always returns the current
+// snapshot — even on accepted=false — so the simulator's assertion path can
+// read snapshot.* unconditionally.
+func (sess *TestDriverSession) ForkChoiceStepHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var step specfixtures.ForkChoiceStep
+		if err := json.NewDecoder(r.Body).Decode(&step); err != nil {
+			http.Error(w, fmt.Sprintf("decode body: %v", err), http.StatusBadRequest)
+			return
+		}
+
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+
+		if sess.store == nil || sess.fc == nil {
+			msg := "fork_choice/step called before fork_choice/init"
+			resp := driverStepResponse{Accepted: false, Error: &msg, Snapshot: driverSnapshot{}}
+			writeJSON(w, http.StatusOK, resp)
+			return
+		}
+
+		var stepErr error
+		switch step.StepType {
+		case "tick":
+			stepErr = sess.applyTick(&step)
+		case "block":
+			stepErr = sess.applyBlock(&step)
+		case "attestation":
+			stepErr = sess.applyAttestation(&step)
+		case "gossipAggregatedAttestation":
+			stepErr = sess.applyAggregatedAttestation(&step)
+		case "checks":
+			// Checks-only step: simulator asserts on snapshot, nothing to do
+			// on our side.
+		default:
+			stepErr = fmt.Errorf("unknown stepType %q", step.StepType)
+		}
+
+		snap := sess.loadSnapshot()
+		accepted := stepErr == nil
+		var errPtr *string
+		if stepErr != nil {
+			msg := stepErr.Error()
+			errPtr = &msg
+		}
+		writeJSON(w, http.StatusOK, driverStepResponse{Accepted: accepted, Error: errPtr, Snapshot: snap})
+	}
+}
+
+func (sess *TestDriverSession) applyTick(step *specfixtures.ForkChoiceStep) error {
+	switch {
+	case step.Time != nil:
+		sess.store.SetTime(*step.Time)
+	case step.Interval != nil:
+		sess.store.SetTime(*step.Interval)
+	default:
+		return fmt.Errorf("tick step missing time and interval")
+	}
+	return nil
+}
+
+func (sess *TestDriverSession) applyBlock(step *specfixtures.ForkChoiceStep) error {
+	if step.Block == nil {
+		return fmt.Errorf("block step missing block payload")
+	}
+	block, err := step.Block.ToBlock()
+	if err != nil {
+		return err
+	}
+
+	// Reconstruct per-attestation signature stubs from body bits so the
+	// store records per-validator votes during block processing. Matches the
+	// spectests forkchoice runner's block-step path.
+	var attSigs []*types.AggregatedSignatureProof
+	if block.Body != nil {
+		for _, att := range block.Body.Attestations {
+			attSigs = append(attSigs, &types.AggregatedSignatureProof{Participants: att.AggregationBits})
+		}
+	}
+	signedBlock := &types.SignedBlock{Block: block, Signature: &types.BlockSignatures{AttestationSignatures: attSigs}}
+
+	// Advance store time so attestations inside the block aren't rejected as
+	// "too far in future" by the gossip-time guard. Tests intentionally set
+	// store time conservatively and rely on block processing to bump it.
+	minTime := block.Slot * types.IntervalsPerSlot
+	if sess.store.Time() < minTime {
+		sess.store.SetTime(minTime)
+	}
+
+	if err := node.OnBlockWithoutVerification(sess.store, signedBlock); err != nil {
+		return err
+	}
+
+	blockRoot, err := block.HashTreeRoot()
+	if err != nil {
+		return err
+	}
+	if step.Block.BlockRootLabel != "" {
+		sess.labelRoots[step.Block.BlockRootLabel] = blockRoot
+	}
+	sess.fc.OnBlock(block.Slot, blockRoot, block.ParentRoot)
+
+	// Feed known attestations to fork choice so head selection reflects the
+	// new block's contribution.
+	attestations := sess.store.ExtractLatestKnownAttestations()
+	for vid, data := range attestations {
+		if idx := sess.fc.NodeIndex(data.Head.Root); idx >= 0 {
+			sess.fc.Votes.SetKnown(vid, idx, data.Slot, data)
+		}
+	}
+	justifiedRoot := sess.store.LatestJustified().Root
+	sess.store.SetHead(sess.fc.UpdateHead(justifiedRoot))
+	sess.store.PromoteNewToKnown()
+	return nil
+}
+
+func (sess *TestDriverSession) applyAttestation(step *specfixtures.ForkChoiceStep) error {
+	if step.Attestation == nil {
+		return fmt.Errorf("attestation step missing attestation payload")
+	}
+	attData, err := step.Attestation.Data.ToAttestationData()
+	if err != nil {
+		return err
+	}
+
+	if step.Valid {
+		minTime := attData.Slot * types.IntervalsPerSlot
+		if sess.store.Time() < minTime {
+			sess.store.SetTime(minTime)
+		}
+	}
+	if err := node.ValidateAttestationData(sess.store, attData); err != nil {
+		return err
+	}
+
+	// Single-validator gossip attestation: synthesize a participants bitlist
+	// containing just this validator id so downstream aggregation and vote
+	// tracking can treat it like any other proof.
+	participants := node.AggregationBitsFromIndices([]uint64{step.Attestation.ValidatorID})
+	dataRoot, err := attData.HashTreeRoot()
+	if err != nil {
+		return err
+	}
+	proof := &types.AggregatedSignatureProof{Participants: participants}
+	sess.store.NewPayloads.Push(dataRoot, attData, proof)
+
+	if idx := sess.fc.NodeIndex(attData.Head.Root); idx >= 0 {
+		sess.fc.Votes.SetNew(step.Attestation.ValidatorID, idx, attData.Slot, attData)
+	}
+
+	sess.store.PromoteNewToKnown()
+	knownAtts := sess.store.ExtractLatestKnownAttestations()
+	for vid, data := range knownAtts {
+		if jdx := sess.fc.NodeIndex(data.Head.Root); jdx >= 0 {
+			sess.fc.Votes.SetKnown(vid, jdx, data.Slot, data)
+		}
+	}
+	justifiedRoot := sess.store.LatestJustified().Root
+	sess.store.SetHead(sess.fc.UpdateHead(justifiedRoot))
+	return nil
+}
+
+func (sess *TestDriverSession) applyAggregatedAttestation(step *specfixtures.ForkChoiceStep) error {
+	if step.Attestation == nil {
+		return fmt.Errorf("gossipAggregatedAttestation step missing attestation payload")
+	}
+	attData, err := step.Attestation.Data.ToAttestationData()
+	if err != nil {
+		return err
+	}
+
+	if step.Valid {
+		minTime := attData.Slot * types.IntervalsPerSlot
+		if sess.store.Time() < minTime {
+			sess.store.SetTime(minTime)
+		}
+	}
+	if err := node.ValidateAttestationData(sess.store, attData); err != nil {
+		return err
+	}
+
+	var participants []byte
+	var proofData []byte
+	if step.Attestation.Proof != nil {
+		if participants, err = specfixtures.ParseBoolBitlist(step.Attestation.Proof.Participants.Data); err != nil {
+			return fmt.Errorf("proof.participants: %w", err)
+		}
+		if proofData, err = specfixtures.ParseHexBytes(step.Attestation.Proof.ProofData.Data); err != nil {
+			return fmt.Errorf("proof.proofData: %w", err)
+		}
+	}
+	dataRoot, err := attData.HashTreeRoot()
+	if err != nil {
+		return err
+	}
+	proof := &types.AggregatedSignatureProof{Participants: participants, ProofData: proofData}
+	sess.store.NewPayloads.Push(dataRoot, attData, proof)
+
+	// Aggregated payloads carry multiple participants — feed each as a New
+	// vote so fork choice sees the full weight contribution.
+	for _, vid := range types.BitlistIndices(participants) {
+		if idx := sess.fc.NodeIndex(attData.Head.Root); idx >= 0 {
+			sess.fc.Votes.SetNew(vid, idx, attData.Slot, attData)
+		}
+	}
+
+	sess.store.PromoteNewToKnown()
+	knownAtts := sess.store.ExtractLatestKnownAttestations()
+	for vid, data := range knownAtts {
+		if jdx := sess.fc.NodeIndex(data.Head.Root); jdx >= 0 {
+			sess.fc.Votes.SetKnown(vid, jdx, data.Slot, data)
+		}
+	}
+	justifiedRoot := sess.store.LatestJustified().Root
+	sess.store.SetHead(sess.fc.UpdateHead(justifiedRoot))
+	return nil
+}
+
+// loadSnapshot reads the session's current store + fc into the snapshot
+// shape the simulator expects. Called under sess.mu so the values are a
+// coherent point-in-time read.
+func (sess *TestDriverSession) loadSnapshot() driverSnapshot {
+	headRoot := sess.store.Head()
+	headSlot := uint64(0)
+	if hdr := sess.store.GetBlockHeader(headRoot); hdr != nil {
+		headSlot = hdr.Slot
+	}
+	justified := sess.store.LatestJustified()
+	finalized := sess.store.LatestFinalized()
+	safeTarget := sess.store.SafeTarget()
+	return driverSnapshot{
+		HeadSlot:            headSlot,
+		HeadRoot:            fmt.Sprintf("0x%x", headRoot),
+		Time:                sess.store.Time(),
+		JustifiedCheckpoint: driverCheckpoint{Slot: justified.Slot, Root: fmt.Sprintf("0x%x", justified.Root)},
+		FinalizedCheckpoint: driverCheckpoint{Slot: finalized.Slot, Root: fmt.Sprintf("0x%x", finalized.Root)},
+		SafeTarget:          fmt.Sprintf("0x%x", safeTarget),
+	}
+}
+
+// TestDriverVerifySignaturesHandler answers POST
+// /lean/v0/test_driver/verify_signatures/run. Stateless — each request gets
+// its own ephemeral store seeded from the request's anchor state. Failures
+// return HTTP 200 with succeeded:false; only parse errors surface as 400.
+func TestDriverVerifySignaturesHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var fixture specfixtures.VerifySignaturesFixture
+		if err := json.NewDecoder(r.Body).Decode(&fixture); err != nil {
+			http.Error(w, fmt.Sprintf("decode body: %v", err), http.StatusBadRequest)
+			return
+		}
+
+		anchorState, err := fixture.AnchorState.ToState()
+		if err != nil {
+			writeVerifyFailure(w, fmt.Sprintf("anchorState: %v", err))
+			return
+		}
+		// Canonical post-state form: state-root in the header may be zeroed
+		// (genesis case); fill it in with hash_tree_root(state) before using
+		// the header as the anchor block-root preimage. Mirrors what
+		// initStoreFromState does in cmd/gean/main.go.
+		stateRoot, err := anchorState.HashTreeRoot()
+		if err != nil {
+			writeVerifyFailure(w, fmt.Sprintf("anchorState.hashTreeRoot: %v", err))
+			return
+		}
+		header := anchorState.LatestBlockHeader
+		if header.StateRoot == types.ZeroRoot {
+			header.StateRoot = stateRoot
+		}
+		anchorRoot, err := header.HashTreeRoot()
+		if err != nil {
+			writeVerifyFailure(w, fmt.Sprintf("anchorHeader.hashTreeRoot: %v", err))
+			return
+		}
+
+		store := node.NewConsensusStore(storage.NewInMemoryBackend())
+		store.SetConfig(anchorState.Config)
+		store.InsertBlockHeader(anchorRoot, header)
+		store.InsertState(anchorRoot, anchorState)
+		store.InsertLiveChainEntry(header.Slot, anchorRoot, header.ParentRoot)
+		store.SetHead(anchorRoot)
+		store.SetLatestJustified(&types.Checkpoint{Root: anchorRoot, Slot: header.Slot})
+		store.SetLatestFinalized(&types.Checkpoint{Root: anchorRoot, Slot: header.Slot})
+
+		// Prefer the devnet-4 flat layout but fall back to the legacy
+		// SignedBlockWithAttestation wrapper for older fixtures.
+		envelope := fixture.SignedBlock
+		if envelope.Block.Slot == 0 && envelope.Block.ParentRoot == "" {
+			envelope = fixture.SignedBlockWithAttestation
+		}
+		signedBlock, err := envelope.ToSignedBlock()
+		if err != nil {
+			writeVerifyFailure(w, err.Error())
+			return
+		}
+
+		// node.OnBlock runs full signature verification on the proposer and
+		// attestation signatures plus the rest of state transition. The
+		// verify-signatures fixtures use the OnBlock-failed verdict as their
+		// pass/fail signal — succeeded:false on any OnBlock error.
+		if err := node.OnBlock(store, signedBlock, nil); err != nil {
+			writeVerifyFailure(w, err.Error())
+			return
+		}
+
+		writeJSON(w, http.StatusOK, verifySignaturesResponse{Succeeded: true, Error: nil})
+	}
+}
+
+func writeVerifyFailure(w http.ResponseWriter, msg string) {
+	writeJSON(w, http.StatusOK, verifySignaturesResponse{Succeeded: false, Error: &msg})
+}
+
+// writeJSON marshals v as JSON and writes it with the given status code,
+// setting the Content-Type header. Marshaling failures surface as 500.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("marshal response: %v", err), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	w.Write(data)
+}

--- a/api/test_driver.go
+++ b/api/test_driver.go
@@ -324,10 +324,31 @@ func (sess *TestDriverSession) ForkChoiceStepHandler() http.HandlerFunc {
 }
 
 func (sess *TestDriverSession) applyTick(step *specfixtures.ForkChoiceStep) error {
+	cfg := sess.store.Config()
+	if cfg == nil {
+		return fmt.Errorf("tick step before config set")
+	}
+	genesisMs := cfg.GenesisTime * 1000
+
 	switch {
 	case step.Time != nil:
-		sess.store.SetTime(*step.Time)
+		// step.Time is wall-clock seconds since the UNIX epoch — the same
+		// unit ream and ethlambda's tick handlers consume. Convert to an
+		// interval count via the standard formula
+		// (timestampMs - genesisMs) / MillisecondsPerInterval, which for
+		// the lean timing config (SECONDS_PER_SLOT=4, INTERVALS_PER_SLOT=5,
+		// MillisecondsPerInterval=800) collapses to seconds * 1.25.
+		// Without this conversion the snapshot reported store.time in
+		// seconds where the simulator's checks.time expected intervals,
+		// e.g. step.time=8 → snapshot.time=8 instead of 10.
+		timestampMs := *step.Time * 1000
+		if timestampMs < genesisMs {
+			sess.store.SetTime(0)
+		} else {
+			sess.store.SetTime((timestampMs - genesisMs) / types.MillisecondsPerInterval)
+		}
 	case step.Interval != nil:
+		// step.Interval is already an interval count — no conversion.
 		sess.store.SetTime(*step.Interval)
 	default:
 		return fmt.Errorf("tick step missing time and interval")

--- a/api/test_driver_test.go
+++ b/api/test_driver_test.go
@@ -64,7 +64,11 @@ func postJSON(t *testing.T, handler http.HandlerFunc, payload any, target any) i
 	handler(rec, req)
 	resp := rec.Result()
 	defer resp.Body.Close()
-	if target != nil && resp.StatusCode < 400 && resp.ContentLength != 0 {
+	// Decode regardless of status — the test_driver returns structured JSON
+	// bodies on error paths too (writeInitFailure returns 400 with the same
+	// driverStepResponse shape), so tests need to be able to assert on the
+	// error message.
+	if target != nil && resp.ContentLength != 0 {
 		if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
 			t.Fatalf("decode response: %v (status=%d)", err, resp.StatusCode)
 		}
@@ -148,8 +152,11 @@ func TestStateTransitionHandler_MalformedBody(t *testing.T) {
 
 // TestForkChoiceInit_RejectsMismatchedAnchor confirms the anchor pair
 // consistency check fires when block.state_root doesn't match
-// hash_tree_root(state). Returns 200 with accepted:false so the simulator
-// reads .error uniformly across init and step failures.
+// hash_tree_root(state). Returns HTTP 400 — the lean hive simulator at
+// spec_assets.rs:297-310 treats any non-2xx status as "init rejected" and
+// only 204 NO_CONTENT as "init accepted". The structured body (accepted=
+// false, error="...") remains the same shape as step responses so callers
+// can read .error uniformly.
 func TestForkChoiceInit_RejectsMismatchedAnchor(t *testing.T) {
 	state := genesisTestState()
 	anchorBlock := map[string]any{
@@ -165,8 +172,8 @@ func TestForkChoiceInit_RejectsMismatchedAnchor(t *testing.T) {
 	var resp driverStepResponse
 	status := postJSON(t, sess.ForkChoiceInitHandler(), req, &resp)
 
-	if status != http.StatusOK {
-		t.Fatalf("expected 200 even on logical failure, got %d", status)
+	if status != http.StatusBadRequest {
+		t.Fatalf("expected 400 on anchor state-root mismatch, got %d", status)
 	}
 	if resp.Accepted {
 		t.Fatal("expected accepted=false for state-root mismatch, got true")

--- a/api/test_driver_test.go
+++ b/api/test_driver_test.go
@@ -1,0 +1,293 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/geanlabs/gean/specfixtures"
+	"github.com/geanlabs/gean/types"
+)
+
+// TestIsTestDriverEnabled pins the set of truthy values gean accepts for
+// HIVE_LEAN_TEST_DRIVER. ream uses the same set; mirroring it keeps the
+// cohort consistent.
+func TestIsTestDriverEnabled(t *testing.T) {
+	on := []string{"1", "true", "TRUE", "yes", "YES"}
+	for _, v := range on {
+		if !IsTestDriverEnabled(v) {
+			t.Errorf("expected %q to enable test driver", v)
+		}
+	}
+	off := []string{"", "0", "false", "FALSE", "no", "NO", "off", "1 "}
+	for _, v := range off {
+		if IsTestDriverEnabled(v) {
+			t.Errorf("expected %q to leave test driver disabled", v)
+		}
+	}
+}
+
+// genesisTestState returns a minimal valid genesis test state usable as a
+// state-transition pre-state or fork-choice/verify-signatures anchor state.
+// The latestBlockHeader.stateRoot is set to zero; tests that need a self
+// consistent anchor pair re-stamp it with hash_tree_root(state) before use.
+func genesisTestState() map[string]any {
+	zero := "0x" + strings.Repeat("00", 32)
+	return map[string]any{
+		"config":                   map[string]any{"genesisTime": 1000},
+		"slot":                     0,
+		"latestBlockHeader":        map[string]any{"slot": 0, "proposerIndex": 0, "parentRoot": zero, "stateRoot": zero, "bodyRoot": zero},
+		"latestJustified":          map[string]any{"root": zero, "slot": 0},
+		"latestFinalized":          map[string]any{"root": zero, "slot": 0},
+		"historicalBlockHashes":    map[string]any{"data": []any{}},
+		"justifiedSlots":           map[string]any{"data": []any{}},
+		"validators":               map[string]any{"data": []any{}},
+		"justificationsRoots":      map[string]any{"data": []any{}},
+		"justificationsValidators": map[string]any{"data": []any{}},
+	}
+}
+
+// postJSON POSTs payload to handler, decodes the response body into target if
+// non-nil and status < 400, and returns the HTTP status code.
+func postJSON(t *testing.T, handler http.HandlerFunc, payload any, target any) int {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+	resp := rec.Result()
+	defer resp.Body.Close()
+	if target != nil && resp.StatusCode < 400 && resp.ContentLength != 0 {
+		if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
+			t.Fatalf("decode response: %v (status=%d)", err, resp.StatusCode)
+		}
+	}
+	return resp.StatusCode
+}
+
+// canonicalStateRoot returns hash_tree_root of the given pre-state, parsed
+// via the same path the production handler uses. The pre-state's header
+// stateRoot is left untouched — the lean canonical convention is that the
+// anchor state is sent with header.stateRoot in whatever form makes
+// hash_tree_root(state) == anchorBlock.stateRoot hold. Tests construct the
+// state with header.stateRoot=0 and use this root as the anchor block's
+// stateRoot, satisfying the equality without mutating the state.
+func canonicalStateRoot(t *testing.T, preState map[string]any) string {
+	t.Helper()
+	body, err := json.Marshal(preState)
+	if err != nil {
+		t.Fatalf("marshal state: %v", err)
+	}
+	var ts specfixtures.TestState
+	if err := json.Unmarshal(body, &ts); err != nil {
+		t.Fatalf("unmarshal TestState: %v", err)
+	}
+	state, err := ts.ToState()
+	if err != nil {
+		t.Fatalf("ToState: %v", err)
+	}
+	root, err := state.HashTreeRoot()
+	if err != nil {
+		t.Fatalf("hash_tree_root: %v", err)
+	}
+	return fmt.Sprintf("0x%x", root)
+}
+
+// TestStateTransitionHandler_GenesisNoBlocks pins the empty-blocks happy
+// path: a genesis fixture with no blocks and no exception returns
+// succeeded:true and a post summary reflecting the pre-state.
+func TestStateTransitionHandler_GenesisNoBlocks(t *testing.T) {
+	fixture := map[string]any{
+		"network": "lean",
+		"leanEnv": "lstar",
+		"pre":     genesisTestState(),
+		"blocks":  []any{},
+		"post":    nil,
+	}
+
+	var resp stateTransitionResponse
+	status := postJSON(t, TestDriverStateTransitionHandler(), fixture, &resp)
+
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d", status)
+	}
+	if !resp.Succeeded {
+		t.Fatalf("expected succeeded=true, got error=%v", resp.Error)
+	}
+	if resp.Post == nil {
+		t.Fatal("expected post != nil on success")
+	}
+	if resp.Post.Slot != 0 {
+		t.Errorf("post.slot: got %d, want 0", resp.Post.Slot)
+	}
+	if !strings.HasPrefix(resp.Post.LatestBlockHeaderStateRoot, "0x") {
+		t.Errorf("post.latestBlockHeaderStateRoot: missing 0x prefix in %q", resp.Post.LatestBlockHeaderStateRoot)
+	}
+	if resp.Post.HistoricalBlockHashesCount != 0 {
+		t.Errorf("post.historicalBlockHashesCount: got %d, want 0", resp.Post.HistoricalBlockHashesCount)
+	}
+}
+
+// TestStateTransitionHandler_MalformedBody confirms that a wire-level parse
+// error returns 400, distinguishing it from logical 200-with-error responses.
+func TestStateTransitionHandler_MalformedBody(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("not json"))
+	rec := httptest.NewRecorder()
+	TestDriverStateTransitionHandler()(rec, req)
+	if rec.Result().StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 on malformed body, got %d", rec.Result().StatusCode)
+	}
+}
+
+// TestForkChoiceInit_RejectsMismatchedAnchor confirms the anchor pair
+// consistency check fires when block.state_root doesn't match
+// hash_tree_root(state). Returns 200 with accepted:false so the simulator
+// reads .error uniformly across init and step failures.
+func TestForkChoiceInit_RejectsMismatchedAnchor(t *testing.T) {
+	state := genesisTestState()
+	anchorBlock := map[string]any{
+		"slot":          0,
+		"proposerIndex": 0,
+		"parentRoot":    "0x" + strings.Repeat("00", 32),
+		"stateRoot":     "0x" + strings.Repeat("99", 32), // deliberately wrong
+		"body":          map[string]any{"attestations": map[string]any{"data": []any{}}},
+	}
+	req := map[string]any{"anchorState": state, "anchorBlock": anchorBlock}
+
+	sess := NewTestDriverSession()
+	var resp driverStepResponse
+	status := postJSON(t, sess.ForkChoiceInitHandler(), req, &resp)
+
+	if status != http.StatusOK {
+		t.Fatalf("expected 200 even on logical failure, got %d", status)
+	}
+	if resp.Accepted {
+		t.Fatal("expected accepted=false for state-root mismatch, got true")
+	}
+	if resp.Error == nil || !strings.Contains(*resp.Error, "state-root mismatch") {
+		t.Errorf("expected error mentioning state-root mismatch, got %v", resp.Error)
+	}
+	if sess.store != nil || sess.fc != nil {
+		t.Error("rejected init must not populate session store/fc")
+	}
+}
+
+// TestForkChoiceStep_BeforeInitErrs guarantees a step call without a prior
+// init returns the dedicated error rather than panicking on a nil store.
+func TestForkChoiceStep_BeforeInitErrs(t *testing.T) {
+	sess := NewTestDriverSession()
+	tick := uint64(1)
+	step := map[string]any{"stepType": "tick", "interval": tick}
+
+	var resp driverStepResponse
+	status := postJSON(t, sess.ForkChoiceStepHandler(), step, &resp)
+
+	if status != http.StatusOK {
+		t.Fatalf("expected 200 on uninitialized step, got %d", status)
+	}
+	if resp.Accepted {
+		t.Fatal("expected accepted=false on uninitialized step")
+	}
+	if resp.Error == nil || !strings.Contains(*resp.Error, "before fork_choice/init") {
+		t.Errorf("expected error mentioning init, got %v", resp.Error)
+	}
+}
+
+// TestForkChoiceInitThenStep exercises the round-trip: init with a
+// self-consistent anchor, then a tick step advances time, and the snapshot
+// reflects it. Pins the state-machine of the session.
+func TestForkChoiceInitThenStep(t *testing.T) {
+	preState := genesisTestState()
+	stateRootHex := canonicalStateRoot(t, preState)
+	anchorBlock := map[string]any{
+		"slot":          0,
+		"proposerIndex": 0,
+		"parentRoot":    "0x" + strings.Repeat("00", 32),
+		"stateRoot":     stateRootHex,
+		"body":          map[string]any{"attestations": map[string]any{"data": []any{}}},
+	}
+
+	sess := NewTestDriverSession()
+	body, _ := json.Marshal(map[string]any{"anchorState": preState, "anchorBlock": anchorBlock})
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	sess.ForkChoiceInitHandler()(rec, req)
+
+	if rec.Result().StatusCode != http.StatusNoContent {
+		var fail driverStepResponse
+		_ = json.NewDecoder(rec.Result().Body).Decode(&fail)
+		reason := "(no reason)"
+		if fail.Error != nil {
+			reason = *fail.Error
+		}
+		t.Fatalf("init: expected 204, got %d (reason: %s)", rec.Result().StatusCode, reason)
+	}
+	if sess.store == nil || sess.fc == nil {
+		t.Fatal("init success must populate session store + fc")
+	}
+
+	tickInterval := uint64(50)
+	tickStep := map[string]any{"stepType": "tick", "interval": tickInterval}
+
+	var stepResp driverStepResponse
+	status := postJSON(t, sess.ForkChoiceStepHandler(), tickStep, &stepResp)
+
+	if status != http.StatusOK {
+		t.Fatalf("step: expected 200, got %d", status)
+	}
+	if !stepResp.Accepted {
+		t.Fatalf("step: expected accepted=true, got error=%v", stepResp.Error)
+	}
+	if stepResp.Snapshot.Time != tickInterval {
+		t.Errorf("snapshot.time: got %d, want %d", stepResp.Snapshot.Time, tickInterval)
+	}
+	if !strings.HasPrefix(stepResp.Snapshot.HeadRoot, "0x") {
+		t.Errorf("snapshot.headRoot: missing 0x prefix in %q", stepResp.Snapshot.HeadRoot)
+	}
+}
+
+// TestVerifySignatures_RejectsMalformedAnchor confirms an unparseable anchor
+// state returns succeeded:false with the parse error in body, HTTP 200.
+func TestVerifySignatures_RejectsMalformedAnchor(t *testing.T) {
+	bad := genesisTestState()
+	hdr, _ := bad["latestBlockHeader"].(map[string]any)
+	hdr["parentRoot"] = "not-hex"
+	bad["latestBlockHeader"] = hdr
+
+	fixture := map[string]any{
+		"anchorState": bad,
+		"signedBlock": map[string]any{
+			"block": map[string]any{
+				"slot":          0,
+				"proposerIndex": 0,
+				"parentRoot":    "0x" + strings.Repeat("00", 32),
+				"stateRoot":     "0x" + strings.Repeat("00", 32),
+				"body":          map[string]any{"attestations": map[string]any{"data": []any{}}},
+			},
+			"signature": map[string]any{
+				"proposerSignature":     "0x" + strings.Repeat("00", types.SignatureSize),
+				"attestationSignatures": map[string]any{"data": []any{}},
+			},
+		},
+	}
+
+	var resp verifySignaturesResponse
+	status := postJSON(t, TestDriverVerifySignaturesHandler(), fixture, &resp)
+
+	if status != http.StatusOK {
+		t.Fatalf("expected 200 on logical failure, got %d", status)
+	}
+	if resp.Succeeded {
+		t.Fatal("expected succeeded=false for malformed anchor")
+	}
+	if resp.Error == nil {
+		t.Error("expected non-nil error on logical failure")
+	}
+}

--- a/cmd/gean/main.go
+++ b/cmd/gean/main.go
@@ -130,18 +130,24 @@ func main() {
 			logger.Error(logger.Sync, "checkpoint sync failed: %v", err)
 			os.Exit(1)
 		}
-		stateRoot, _ := state.HashTreeRoot()
-		header := state.LatestBlockHeader
-		blockRoot, _ := header.HashTreeRoot()
+		// initStoreFromState mutates state.LatestBlockHeader.StateRoot from
+		// zero (canonical post-state form) to hash_tree_root(state), so the
+		// canonical anchor block root must be read from its return value —
+		// computing header.HashTreeRoot() before that mutation yields the
+		// pre-canonicalization root, which would not match the anchor
+		// checkpoint the store sets. Using the wrong key for StorePendingBlock
+		// is what caused /lean/v0/blocks/finalized to return 404 on a freshly
+		// checkpoint-synced node despite the block being stored.
+		canonicalRoot := initStoreFromState(s, state)
+		stateRoot := state.LatestBlockHeader.StateRoot
 		logger.Info(logger.Sync, "checkpoint sync: slot=%d finalized_root=%x justified_root=%x head_root=%x parent_root=%x state_root=%x",
-			state.Slot, state.LatestFinalized.Root, state.LatestJustified.Root, blockRoot, header.ParentRoot, stateRoot)
-		initStoreFromState(s, state)
-		s.StorePendingBlock(blockRoot, signedBlock)
+			state.Slot, state.LatestFinalized.Root, state.LatestJustified.Root, canonicalRoot, state.LatestBlockHeader.ParentRoot, stateRoot)
+		s.StorePendingBlock(canonicalRoot, signedBlock)
 	} else {
 		// Genesis.
 		logger.Info(logger.Node, "initializing from genesis")
 		genesisState := genesisConfig.GenesisState()
-		initStoreFromState(s, genesisState)
+		_ = initStoreFromState(s, genesisState)
 	}
 
 	// Rehydrate store.time from wall clock before any consumer reads it.
@@ -294,7 +300,8 @@ func main() {
 	time.Sleep(500 * time.Millisecond)
 }
 
-// initStoreFromState initializes the consensus store from an anchor state.
+// initStoreFromState initializes the consensus store from an anchor state
+// and returns the canonical anchor block root.
 //
 // The anchor state becomes the new latest justified AND latest finalized
 // checkpoint — both pointing at the served block at header.Slot. This
@@ -302,11 +309,18 @@ func main() {
 // trusts the served state as the new finalization anchor and starts forward
 // sync from there.
 //
+// The returned root is the canonical anchor block root — computed AFTER the
+// header.StateRoot canonicalization step. Callers that need to associate
+// out-of-band data with the anchor block (e.g. StorePendingBlock for the
+// checkpoint-sync SignedBlock) must use this return value, not a root
+// computed before the function ran; the pre-canonicalization root would not
+// match what the store records as latest_finalized.Root.
+//
 // Note: state.LatestJustified and state.LatestFinalized inside the served
 // state point to EARLIER slots (the finalization status from when the block
 // was processed). We deliberately do NOT use those — the served block IS
 // the new anchor, regardless of what its internal pointers say.
-func initStoreFromState(s *node.ConsensusStore, state *types.State) {
+func initStoreFromState(s *node.ConsensusStore, state *types.State) [32]byte {
 	// Compute anchor block root from header.
 	stateRoot, _ := state.HashTreeRoot()
 	header := state.LatestBlockHeader
@@ -336,6 +350,7 @@ func initStoreFromState(s *node.ConsensusStore, state *types.State) {
 
 	logger.Info(logger.Store, "store initialized from anchor: slot=%d head=%x parent_root=%x state_root=%x",
 		header.Slot, blockRoot, header.ParentRoot, stateRoot)
+	return blockRoot
 }
 
 // recoverStoreTime sets store.time to the interval index corresponding to the

--- a/cmd/gean/main.go
+++ b/cmd/gean/main.go
@@ -254,8 +254,14 @@ func main() {
 
 	// Start sync driver: periodic status-poll + BlocksByRange backfill when
 	// peers are far enough ahead. No-op while node is synced or has no peers.
-	syncDriver := node.NewSyncDriver(n, p2pHost)
-	go syncDriver.Run(ctx)
+	// Wire OnPeerConnected as the libp2p PeerStatusHook BEFORE starting the
+	// driver so a fast initial dial that completes during start-up still
+	// fires the on-connect Status handshake. Sending Status only from the
+	// periodic poll is too slow for cold-start single-peer scenarios to
+	// learn the peer's head and drive backfill.
+	syncDriver := node.NewSyncDriver(ctx, n, p2pHost)
+	p2p.PeerStatusHook = syncDriver.OnPeerConnected
+	go syncDriver.Run()
 
 	// --- Start HTTP servers ---
 

--- a/cmd/gean/main.go
+++ b/cmd/gean/main.go
@@ -257,8 +257,20 @@ func main() {
 	metricsAddr := fmt.Sprintf("%s:%d", *httpAddr, *metricsPort)
 
 	go func() {
-		if err := api.StartAPIServer(apiAddr, s, fc, aggCtl); err != nil {
-			logger.Error(logger.Node, "api server error: %v", err)
+		// Test-driver routes are gated at server-construction time on
+		// HIVE_LEAN_TEST_DRIVER=1 (or "true"/"yes"). The hive lean simulator
+		// sets this for lean-spec-tests conformance fixtures; production
+		// deployments never see it, so the test-driver routes are absent
+		// from the mux entirely under normal operation.
+		var apiErr error
+		if api.IsTestDriverEnabled(os.Getenv(api.TestDriverEnvVar)) {
+			logger.Info(logger.Node, "%s=1: enabling test-driver routes", api.TestDriverEnvVar)
+			apiErr = api.StartAPIServerWithTestDriver(apiAddr, s, fc, aggCtl)
+		} else {
+			apiErr = api.StartAPIServer(apiAddr, s, fc, aggCtl)
+		}
+		if apiErr != nil {
+			logger.Error(logger.Node, "api server error: %v", apiErr)
 		}
 	}()
 

--- a/node/store_validate.go
+++ b/node/store_validate.go
@@ -1,9 +1,11 @@
 package node
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/geanlabs/gean/types"
+	"github.com/geanlabs/gean/xmss"
 )
 
 // ValidateAttestationData checks 9 validation branches for incoming attestations.
@@ -55,4 +57,67 @@ func ValidateAttestationData(s *ConsensusStore, data *types.AttestationData) err
 	}
 
 	return nil
+}
+
+// VerifyGossipAttestation enforces validator-id bounds plus XMSS signature
+// validity for an incoming individual gossip attestation. Resolves the
+// target state from the store, ensures the validator index is within the
+// registry, and verifies the signature against the attester's pubkey using
+// the xmss.VerifySignatureSSZ primitive the runtime uses for block-included
+// attestation signatures.
+//
+// Pure check — no state mutation. Callers must invoke this before any
+// store or fork-choice updates so a rejected attestation leaves no
+// observable side effects.
+//
+// Mirrors ethlambda's on_gossip_attestation flow at
+// crates/blockchain/src/store.rs:285-306: validate data → resolve target
+// state → bounds-check vid → load pubkey → verify signature.
+func VerifyGossipAttestation(s *ConsensusStore, validatorID uint64, attData *types.AttestationData, dataRoot [32]byte, signature []byte) error {
+	targetState := s.GetState(attData.Target.Root)
+	if targetState == nil {
+		return fmt.Errorf("target state not found in store: 0x%x", attData.Target.Root)
+	}
+	if validatorID >= uint64(len(targetState.Validators)) {
+		return fmt.Errorf("validator %d not found in state (registry size %d)",
+			validatorID, len(targetState.Validators))
+	}
+	if len(signature) != types.SignatureSize {
+		return fmt.Errorf("signature length %d != expected %d", len(signature), types.SignatureSize)
+	}
+	var sig [types.SignatureSize]byte
+	copy(sig[:], signature)
+	valid, err := xmss.VerifySignatureSSZ(
+		targetState.Validators[validatorID].AttestationPubkey,
+		uint32(attData.Slot),
+		dataRoot,
+		sig,
+	)
+	if err != nil {
+		return fmt.Errorf("signature verification error: %w", err)
+	}
+	if !valid {
+		return fmt.Errorf("signature verification failed")
+	}
+	return nil
+}
+
+// VerifyAggregatedGossipAttestation enforces participant bounds and
+// aggregated XMSS proof validity for an incoming gossipAggregatedAttestation.
+// Decodes the participants bitlist and delegates to verifyAggregatedProof
+// (the same primitive the runtime uses for block-included aggregated
+// attestations), which both bounds-checks each participant id and verifies
+// the aggregated signature against the participants' pubkeys.
+//
+// Pure check — no state mutation. Callers must invoke this before any
+// store or fork-choice updates.
+//
+// Mirrors ethlambda's on_gossip_aggregated_attestation validation path.
+func VerifyAggregatedGossipAttestation(s *ConsensusStore, attData *types.AttestationData, participants []byte, proofData []byte) error {
+	targetState := s.GetState(attData.Target.Root)
+	if targetState == nil {
+		return fmt.Errorf("target state not found in store: 0x%x", attData.Target.Root)
+	}
+	participantIDs := types.BitlistIndices(participants)
+	return verifyAggregatedProof(targetState, participantIDs, attData, proofData)
 }

--- a/node/sync.go
+++ b/node/sync.go
@@ -34,6 +34,13 @@ type SyncDriver struct {
 	engine *Engine
 	p2p    SyncDriverP2P
 
+	// ctx captured at construction so OnPeerConnected (invoked from libp2p's
+	// network goroutine via p2p.PeerStatusHook) can derive request contexts
+	// without a data race against Run setting it. Construction happens in
+	// main before any goroutine can call OnPeerConnected, so the field is
+	// safely published by happens-before of subsequent goroutine starts.
+	ctx context.Context
+
 	// Per-peer in-flight fetch dedup. Prevents stacking range requests to the
 	// same peer across overlapping polling cycles.
 	mu       sync.Mutex
@@ -41,16 +48,19 @@ type SyncDriver struct {
 }
 
 // NewSyncDriver constructs a driver bound to the given engine and p2p host.
-func NewSyncDriver(engine *Engine, p2pHost SyncDriverP2P) *SyncDriver {
+// ctx is captured for use by OnPeerConnected callbacks (see field doc); Run
+// reads cancellation from the same ctx.
+func NewSyncDriver(ctx context.Context, engine *Engine, p2pHost SyncDriverP2P) *SyncDriver {
 	return &SyncDriver{
+		ctx:      ctx,
 		engine:   engine,
 		p2p:      p2pHost,
 		inFlight: make(map[libp2ppeer.ID]bool),
 	}
 }
 
-// Run is the polling loop. Cancel ctx to stop.
-func (sd *SyncDriver) Run(ctx context.Context) {
+// Run is the polling loop. Cancel the ctx passed to NewSyncDriver to stop.
+func (sd *SyncDriver) Run() {
 	ticker := time.NewTicker(p2p.SyncPollInterval)
 	defer ticker.Stop()
 
@@ -59,17 +69,32 @@ func (sd *SyncDriver) Run(ctx context.Context) {
 
 	for {
 		select {
-		case <-ctx.Done():
+		case <-sd.ctx.Done():
 			return
 		case <-ticker.C:
 			switch sd.engine.GetSyncStatus() {
 			case SyncSyncing:
-				sd.refreshSyncFromPeers(ctx)
+				sd.refreshSyncFromPeers(sd.ctx)
 			case SyncIdle, SyncSynced:
 				// No work: no peers to poll, or already at chain head.
 			}
 		}
 	}
+}
+
+// OnPeerConnected is the p2p.PeerStatusHook callback. Fires once per
+// newly-connected peer (gated by PeerStore.AddNew upstream) and initiates
+// the lean P2P Status reqresp handshake using the same pollPeer code path
+// the periodic loop uses. Bounded by a 10s timeout so a slow or
+// unresponsive peer cannot hold the goroutine indefinitely; on success the
+// resulting peer status drives the usual checkAndBackfill dispatch.
+//
+// Wired by cmd/gean/main.go: p2p.PeerStatusHook = syncDriver.OnPeerConnected
+func (sd *SyncDriver) OnPeerConnected(peerID libp2ppeer.ID) {
+	ctx, cancel := context.WithTimeout(sd.ctx, 10*time.Second)
+	defer cancel()
+	ourStatus := sd.makeStatusMessage()
+	sd.pollPeer(ctx, peerID, ourStatus)
 }
 
 // refreshSyncFromPeers polls every connected peer for status, in parallel.

--- a/node/sync_test.go
+++ b/node/sync_test.go
@@ -101,7 +101,7 @@ func drainBlockCh(t *testing.T, e *Engine, expected int, timeout time.Duration) 
 func TestSyncDriver_CheckAndBackfill_PeerNotAhead(t *testing.T) {
 	e := makeTestEngine()
 	mock := &mockSyncP2P{}
-	sd := NewSyncDriver(e, mock)
+	sd := NewSyncDriver(context.Background(), e, mock)
 
 	// Engine head is at slot 0. Peer is also at slot 0 — not ahead.
 	peerStatus := &p2p.StatusMessage{HeadSlot: 0}
@@ -115,7 +115,7 @@ func TestSyncDriver_CheckAndBackfill_PeerNotAhead(t *testing.T) {
 func TestSyncDriver_CheckAndBackfill_GapBelowThreshold(t *testing.T) {
 	e := makeTestEngine()
 	mock := &mockSyncP2P{}
-	sd := NewSyncDriver(e, mock)
+	sd := NewSyncDriver(context.Background(), e, mock)
 
 	// Gap of 10 < BlocksByRangeSyncThreshold (64). Should NOT trigger range fetch.
 	peerStatus := &p2p.StatusMessage{HeadSlot: 10}
@@ -134,7 +134,7 @@ func TestSyncDriver_CheckAndBackfill_FetchesWhenAhead(t *testing.T) {
 			{Block: &types.Block{Slot: 2, Body: &types.BlockBody{}}},
 		},
 	}
-	sd := NewSyncDriver(e, mock)
+	sd := NewSyncDriver(context.Background(), e, mock)
 
 	// Gap of 100 > BlocksByRangeSyncThreshold (64). Should trigger range fetch.
 	peerStatus := &p2p.StatusMessage{HeadSlot: 100}
@@ -158,7 +158,7 @@ func TestSyncDriver_CheckAndBackfill_FallsBackToRoot(t *testing.T) {
 			{Block: &types.Block{Slot: 100, Body: &types.BlockBody{}}},
 		},
 	}
-	sd := NewSyncDriver(e, mock)
+	sd := NewSyncDriver(context.Background(), e, mock)
 
 	var headRoot [32]byte
 	headRoot[0] = 0xAB
@@ -187,7 +187,7 @@ func TestSyncDriver_CheckAndBackfill_PerPeerDedup(t *testing.T) {
 		},
 		rangeBlock: rangeBlock,
 	}
-	sd := NewSyncDriver(e, mock)
+	sd := NewSyncDriver(context.Background(), e, mock)
 
 	peerStatus := &p2p.StatusMessage{HeadSlot: 100}
 	peerID := libp2ppeer.ID("p1")

--- a/p2p/gossip.go
+++ b/p2p/gossip.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/geanlabs/gean/logger"
 	"github.com/geanlabs/gean/types"
@@ -36,6 +37,15 @@ var (
 	PeerConnectedHook    func(direction string)
 	PeerDisconnectedHook func(direction, reason string)
 	PeerCountHook        func(count int)
+
+	// PeerStatusHook fires once per newly-connected peer (gated by
+	// PeerStore.AddNew so reconnect events do not retrigger) with the peer's
+	// ID. Wired by node-layer code to initiate the lean P2P Status reqresp
+	// handshake the protocol expects on each new connection. Sending Status
+	// from the libp2p connection notifier (rather than only from the sync
+	// driver's periodic poll) is required so cold-start single-peer setups
+	// learn the peer's head promptly enough to drive backfill.
+	PeerStatusHook func(peerID peer.ID)
 )
 
 // StartGossipListeners starts goroutines that read from each subscribed topic

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -128,7 +128,13 @@ func NewHost(ctx context.Context, nodeKeyPath string, listenPort int, committeeC
 	h.Network().Notify(&network.NotifyBundle{
 		ConnectedF: func(n network.Network, conn network.Conn) {
 			peerID := conn.RemotePeer()
-			p2pHost.peerStore.Add(peerID)
+			// AddNew atomically registers and reports whether this is the
+			// first connection to this peer. libp2p emits ConnectedF for
+			// every connection event (including additional connections to
+			// an already-connected peer or redial races), so we gate the
+			// one-shot on-connect work — the Status reqresp handshake —
+			// behind that flag.
+			isNew := p2pHost.peerStore.AddNew(peerID)
 			direction := directionLabel(conn.Stat().Direction)
 			count := p2pHost.peerStore.Count()
 			logger.Info(logger.Network, "peer connected peer_id=%s direction=%s peers=%d",
@@ -138,6 +144,13 @@ func NewHost(ctx context.Context, nodeKeyPath string, listenPort int, committeeC
 			}
 			if PeerCountHook != nil {
 				PeerCountHook(count)
+			}
+			if isNew && PeerStatusHook != nil {
+				// Async — ConnectedF runs on libp2p's network goroutine;
+				// the Status reqresp opens a new stream and waits for a
+				// response, which would block all subsequent libp2p
+				// network events if invoked inline.
+				go PeerStatusHook(peerID)
 			}
 		},
 		DisconnectedF: func(n network.Network, conn network.Conn) {

--- a/p2p/peers.go
+++ b/p2p/peers.go
@@ -55,6 +55,20 @@ func (ps *PeerStore) Add(id peer.ID) {
 	ps.peers[id] = true
 }
 
+// AddNew atomically registers a peer and reports whether the peer was newly
+// added (true) or was already present (false). Used by the libp2p connection
+// notifier to gate on-connect work (e.g. firing the Status reqresp) so that
+// reconnect events for an already-known peer do not retrigger the work.
+func (ps *PeerStore) AddNew(id peer.ID) bool {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	if ps.peers[id] {
+		return false
+	}
+	ps.peers[id] = true
+	return true
+}
+
 // Remove unregisters a peer.
 func (ps *PeerStore) Remove(id peer.ID) {
 	ps.mu.Lock()

--- a/specfixtures/parse.go
+++ b/specfixtures/parse.go
@@ -1,0 +1,287 @@
+package specfixtures
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/geanlabs/gean/types"
+)
+
+// ParseHexRoot decodes a "0x"-prefixed (or bare) 32-byte hex string. Returns
+// an error rather than panicking so HTTP handlers can surface a clean 400.
+func ParseHexRoot(s string) ([32]byte, error) {
+	var root [32]byte
+	b, err := hex.DecodeString(strings.TrimPrefix(s, "0x"))
+	if err != nil {
+		return root, fmt.Errorf("invalid hex root %q: %w", s, err)
+	}
+	copy(root[:], b)
+	return root, nil
+}
+
+// ParseHexBytes decodes a "0x"-prefixed (or bare) hex string into a byte slice
+// of whatever length the input encodes.
+func ParseHexBytes(s string) ([]byte, error) {
+	b, err := hex.DecodeString(strings.TrimPrefix(s, "0x"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid hex %q: %w", s, err)
+	}
+	return b, nil
+}
+
+// ParseHexPubkey decodes a 52-byte XMSS public key.
+func ParseHexPubkey(s string) ([types.PubkeySize]byte, error) {
+	var pk [types.PubkeySize]byte
+	b, err := ParseHexBytes(s)
+	if err != nil {
+		return pk, err
+	}
+	if len(b) > types.PubkeySize {
+		return pk, fmt.Errorf("pubkey too long: got %d bytes, want %d", len(b), types.PubkeySize)
+	}
+	copy(pk[:], b)
+	return pk, nil
+}
+
+// ParseHexSignature decodes a 2536-byte XMSS signature.
+func ParseHexSignature(s string) ([types.SignatureSize]byte, error) {
+	var sig [types.SignatureSize]byte
+	b, err := ParseHexBytes(s)
+	if err != nil {
+		return sig, err
+	}
+	if len(b) > types.SignatureSize {
+		return sig, fmt.Errorf("signature too long: got %d bytes, want %d", len(b), types.SignatureSize)
+	}
+	copy(sig[:], b)
+	return sig, nil
+}
+
+// ParseBoolBitlist converts a JSON array of bool-or-int values into an SSZ
+// bitlist. Accepts both `true/false` and `1/0` per fixture convention.
+func ParseBoolBitlist(data []json.RawMessage) ([]byte, error) {
+	length := uint64(len(data))
+	if length == 0 {
+		return types.NewBitlistSSZ(0), nil
+	}
+	bl := types.NewBitlistSSZ(length)
+	for i, raw := range data {
+		var val bool
+		if err := json.Unmarshal(raw, &val); err != nil {
+			var intVal int
+			if err2 := json.Unmarshal(raw, &intVal); err2 != nil {
+				return nil, fmt.Errorf("bitlist index %d: not bool or int: %w / %w", i, err, err2)
+			}
+			val = intVal != 0
+		}
+		if val {
+			types.BitlistSet(bl, uint64(i))
+		}
+	}
+	return bl, nil
+}
+
+// ToState converts a fixture state to gean's runtime types.State. The
+// embedded LatestJustified/LatestFinalized are kept verbatim from the
+// fixture; the caller is responsible for any anchor-checkpoint substitution
+// (see fork-choice runners that re-pin both to the anchor root).
+func (ts *TestState) ToState() (*types.State, error) {
+	parentRoot, err := ParseHexRoot(ts.LatestBlockHeader.ParentRoot)
+	if err != nil {
+		return nil, fmt.Errorf("latestBlockHeader.parentRoot: %w", err)
+	}
+	stateRoot, err := ParseHexRoot(ts.LatestBlockHeader.StateRoot)
+	if err != nil {
+		return nil, fmt.Errorf("latestBlockHeader.stateRoot: %w", err)
+	}
+	bodyRoot, err := ParseHexRoot(ts.LatestBlockHeader.BodyRoot)
+	if err != nil {
+		return nil, fmt.Errorf("latestBlockHeader.bodyRoot: %w", err)
+	}
+	justifiedRoot, err := ParseHexRoot(ts.LatestJustified.Root)
+	if err != nil {
+		return nil, fmt.Errorf("latestJustified.root: %w", err)
+	}
+	finalizedRoot, err := ParseHexRoot(ts.LatestFinalized.Root)
+	if err != nil {
+		return nil, fmt.Errorf("latestFinalized.root: %w", err)
+	}
+
+	state := &types.State{
+		Config:            &types.ChainConfig{GenesisTime: ts.Config.GenesisTime},
+		Slot:              ts.Slot,
+		LatestBlockHeader: &types.BlockHeader{Slot: ts.LatestBlockHeader.Slot, ProposerIndex: ts.LatestBlockHeader.ProposerIndex, ParentRoot: parentRoot, StateRoot: stateRoot, BodyRoot: bodyRoot},
+		LatestJustified:   &types.Checkpoint{Root: justifiedRoot, Slot: ts.LatestJustified.Slot},
+		LatestFinalized:   &types.Checkpoint{Root: finalizedRoot, Slot: ts.LatestFinalized.Slot},
+	}
+
+	for i, v := range ts.Validators.Data {
+		var attPk, propPk [types.PubkeySize]byte
+		if v.AttestationPubkey != "" {
+			if attPk, err = ParseHexPubkey(v.AttestationPubkey); err != nil {
+				return nil, fmt.Errorf("validators[%d].attestationPubkey: %w", i, err)
+			}
+			if propPk, err = ParseHexPubkey(v.ProposalPubkey); err != nil {
+				return nil, fmt.Errorf("validators[%d].proposalPubkey: %w", i, err)
+			}
+		} else {
+			pk, perr := ParseHexPubkey(v.Pubkey)
+			if perr != nil {
+				return nil, fmt.Errorf("validators[%d].pubkey: %w", i, perr)
+			}
+			attPk = pk
+			propPk = pk
+		}
+		state.Validators = append(state.Validators, &types.Validator{AttestationPubkey: attPk, ProposalPubkey: propPk, Index: v.Index})
+	}
+
+	for i, raw := range ts.HistoricalBlockHashes.Data {
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return nil, fmt.Errorf("historicalBlockHashes[%d]: %w", i, err)
+		}
+		b, perr := ParseHexBytes(s)
+		if perr != nil {
+			return nil, fmt.Errorf("historicalBlockHashes[%d]: %w", i, perr)
+		}
+		h := make([]byte, 32)
+		copy(h, b)
+		state.HistoricalBlockHashes = append(state.HistoricalBlockHashes, h)
+	}
+
+	if state.JustifiedSlots, err = ParseBoolBitlist(ts.JustifiedSlots.Data); err != nil {
+		return nil, fmt.Errorf("justifiedSlots: %w", err)
+	}
+
+	for i, raw := range ts.JustificationsRoots.Data {
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return nil, fmt.Errorf("justificationsRoots[%d]: %w", i, err)
+		}
+		b, perr := ParseHexBytes(s)
+		if perr != nil {
+			return nil, fmt.Errorf("justificationsRoots[%d]: %w", i, perr)
+		}
+		h := make([]byte, 32)
+		copy(h, b)
+		state.JustificationsRoots = append(state.JustificationsRoots, h)
+	}
+
+	if state.JustificationsValidators, err = ParseBoolBitlist(ts.JustificationsValidators.Data); err != nil {
+		return nil, fmt.Errorf("justificationsValidators: %w", err)
+	}
+
+	return state, nil
+}
+
+// ToBlock converts a fixture block to types.Block, including all aggregated
+// attestations in its body.
+func (tb *TestBlock) ToBlock() (*types.Block, error) {
+	parentRoot, err := ParseHexRoot(tb.ParentRoot)
+	if err != nil {
+		return nil, fmt.Errorf("block.parentRoot: %w", err)
+	}
+	stateRoot, err := ParseHexRoot(tb.StateRoot)
+	if err != nil {
+		return nil, fmt.Errorf("block.stateRoot: %w", err)
+	}
+
+	block := &types.Block{
+		Slot:          tb.Slot,
+		ProposerIndex: tb.ProposerIndex,
+		ParentRoot:    parentRoot,
+		StateRoot:     stateRoot,
+		Body:          &types.BlockBody{Attestations: make([]*types.AggregatedAttestation, 0)},
+	}
+
+	for i, raw := range tb.Body.Attestations.Data {
+		var ta TestAggregatedAttestation
+		if err := json.Unmarshal(raw, &ta); err != nil {
+			return nil, fmt.Errorf("block.body.attestations[%d]: %w", i, err)
+		}
+		att, err := ta.ToAggregatedAttestation()
+		if err != nil {
+			return nil, fmt.Errorf("block.body.attestations[%d]: %w", i, err)
+		}
+		block.Body.Attestations = append(block.Body.Attestations, att)
+	}
+
+	return block, nil
+}
+
+// ToAggregatedAttestation converts a fixture aggregated attestation to its
+// runtime form.
+func (ta *TestAggregatedAttestation) ToAggregatedAttestation() (*types.AggregatedAttestation, error) {
+	bits, err := ParseBoolBitlist(ta.AggregationBits.Data)
+	if err != nil {
+		return nil, fmt.Errorf("aggregationBits: %w", err)
+	}
+	data, err := ta.Data.ToAttestationData()
+	if err != nil {
+		return nil, err
+	}
+	return &types.AggregatedAttestation{AggregationBits: bits, Data: data}, nil
+}
+
+// ToAttestationData converts a fixture attestation data record.
+func (tad *TestAttData) ToAttestationData() (*types.AttestationData, error) {
+	headRoot, err := ParseHexRoot(tad.Head.Root)
+	if err != nil {
+		return nil, fmt.Errorf("data.head.root: %w", err)
+	}
+	targetRoot, err := ParseHexRoot(tad.Target.Root)
+	if err != nil {
+		return nil, fmt.Errorf("data.target.root: %w", err)
+	}
+	sourceRoot, err := ParseHexRoot(tad.Source.Root)
+	if err != nil {
+		return nil, fmt.Errorf("data.source.root: %w", err)
+	}
+	return &types.AttestationData{
+		Slot:   tad.Slot,
+		Head:   &types.Checkpoint{Root: headRoot, Slot: tad.Head.Slot},
+		Target: &types.Checkpoint{Root: targetRoot, Slot: tad.Target.Slot},
+		Source: &types.Checkpoint{Root: sourceRoot, Slot: tad.Source.Slot},
+	}, nil
+}
+
+// ToSignedBlock converts a fixture signed block envelope to its runtime form.
+// Handles both the devnet-4 flat layout and the legacy nested-message layout.
+func (sb *FixtureSignedBlock) ToSignedBlock() (*types.SignedBlock, error) {
+	srcBlock := sb.Block
+	if (srcBlock.Slot == 0 && srcBlock.ParentRoot == "") && sb.Message != nil {
+		srcBlock = sb.Message.Block
+	}
+	block, err := srcBlock.ToBlock()
+	if err != nil {
+		return nil, fmt.Errorf("signedBlock.block: %w", err)
+	}
+
+	proposerSig, err := ParseHexSignature(sb.Signature.ProposerSignature)
+	if err != nil {
+		return nil, fmt.Errorf("signedBlock.signature.proposerSignature: %w", err)
+	}
+
+	var attSigs []*types.AggregatedSignatureProof
+	for i, proof := range sb.Signature.AttestationSignatures.Data {
+		participants, perr := ParseBoolBitlist(proof.Participants.Data)
+		if perr != nil {
+			return nil, fmt.Errorf("signedBlock.signature.attestationSignatures[%d].participants: %w", i, perr)
+		}
+		proofData, perr := ParseHexBytes(proof.ProofData.Data)
+		if perr != nil {
+			return nil, fmt.Errorf("signedBlock.signature.attestationSignatures[%d].proofData: %w", i, perr)
+		}
+		attSigs = append(attSigs, &types.AggregatedSignatureProof{Participants: participants, ProofData: proofData})
+	}
+
+	return &types.SignedBlock{
+		Block: block,
+		Signature: &types.BlockSignatures{
+			ProposerSignature:     proposerSig,
+			AttestationSignatures: attSigs,
+		},
+	}, nil
+}

--- a/specfixtures/types.go
+++ b/specfixtures/types.go
@@ -1,0 +1,246 @@
+// Package specfixtures contains the JSON-tagged fixture types that the hive
+// lean simulator sends to a client's test-driver endpoints. The types mirror
+// the Python leanSpec consensus fixture format and are also the format the
+// internal go-side spec test runners under spectests/ already consume; they
+// are factored out here so production code (the test-driver HTTP handlers)
+// can decode requests without a test-only build tag.
+package specfixtures
+
+import "encoding/json"
+
+// StateTransitionFixture is the top-level shape for a state-transition test
+// case as the simulator delivers it on
+// POST /lean/v0/test_driver/state_transition/run.
+type StateTransitionFixture struct {
+	Network                string         `json:"network"`
+	LeanEnv                string         `json:"leanEnv"`
+	Pre                    TestState      `json:"pre"`
+	Blocks                 []TestBlock    `json:"blocks"`
+	Post                   *TestPostState `json:"post"`
+	ExpectException        string         `json:"expectException"`
+	ExpectExceptionMessage string         `json:"expectExceptionMessage"`
+}
+
+// TestState carries a serialized lean consensus state in the form the
+// simulator and leanSpec fixtures both use (camelCase JSON, validators in a
+// {data: [...]} wrapper).
+type TestState struct {
+	Config                   TestConfig        `json:"config"`
+	Slot                     uint64            `json:"slot"`
+	LatestBlockHeader        TestBlockHeader   `json:"latestBlockHeader"`
+	LatestJustified          TestCheckpoint    `json:"latestJustified"`
+	LatestFinalized          TestCheckpoint    `json:"latestFinalized"`
+	HistoricalBlockHashes    TestDataList      `json:"historicalBlockHashes"`
+	JustifiedSlots           TestDataList      `json:"justifiedSlots"`
+	Validators               TestValidatorList `json:"validators"`
+	JustificationsRoots      TestDataList      `json:"justificationsRoots"`
+	JustificationsValidators TestDataList      `json:"justificationsValidators"`
+}
+
+// TestConfig is the embedded ChainConfig portion of a fixture state.
+type TestConfig struct {
+	GenesisTime uint64 `json:"genesisTime"`
+}
+
+// TestBlockHeader is the hex-string-encoded BlockHeader on the wire.
+type TestBlockHeader struct {
+	Slot          uint64 `json:"slot"`
+	ProposerIndex uint64 `json:"proposerIndex"`
+	ParentRoot    string `json:"parentRoot"`
+	StateRoot     string `json:"stateRoot"`
+	BodyRoot      string `json:"bodyRoot"`
+}
+
+// TestCheckpoint is a {root: hex, slot: uint64} pair as sent on the wire.
+type TestCheckpoint struct {
+	Root string `json:"root"`
+	Slot uint64 `json:"slot"`
+}
+
+// TestBlock is a fixture Block. State root is sent so the simulator can pin
+// it; the handler reuses the parsed value verbatim rather than recomputing.
+type TestBlock struct {
+	Slot          uint64        `json:"slot"`
+	ProposerIndex uint64        `json:"proposerIndex"`
+	ParentRoot    string        `json:"parentRoot"`
+	StateRoot     string        `json:"stateRoot"`
+	Body          TestBlockBody `json:"body"`
+	// BlockRootLabel is an optional fork-choice-fixture-only field used to tag
+	// a produced root for later checks-step references. Ignored elsewhere.
+	BlockRootLabel string `json:"blockRootLabel,omitempty"`
+}
+
+// TestBlockBody is the BlockBody portion — attestations only at this layer.
+type TestBlockBody struct {
+	Attestations TestDataList `json:"attestations"`
+}
+
+// TestDataList wraps the {"data": [...]} indirection the simulator uses for
+// every SSZ list (validators, historicalBlockHashes, bitfields).
+type TestDataList struct {
+	Data []json.RawMessage `json:"data"`
+}
+
+// TestValidator is the per-validator entry. Dual pubkeys per devnet-4; the
+// legacy single-Pubkey field is accepted for older fixtures that pre-date
+// the proposer/attester key split.
+type TestValidator struct {
+	AttestationPubkey string `json:"attestationPubkey"`
+	ProposalPubkey    string `json:"proposalPubkey"`
+	Pubkey            string `json:"pubkey"`
+	Index             uint64 `json:"index"`
+}
+
+// TestValidatorList wraps the validators array in its {"data": [...]} form.
+type TestValidatorList struct {
+	Data []TestValidator `json:"data"`
+}
+
+// TestAggregatedAttestation is a single aggregated attestation entry inside a
+// block body or attestation-step payload.
+type TestAggregatedAttestation struct {
+	AggregationBits TestDataList `json:"aggregationBits"`
+	Data            TestAttData  `json:"data"`
+}
+
+// TestAttData is the inner AttestationData record.
+type TestAttData struct {
+	Slot   uint64         `json:"slot"`
+	Head   TestCheckpoint `json:"head"`
+	Target TestCheckpoint `json:"target"`
+	Source TestCheckpoint `json:"source"`
+}
+
+// TestPostState is the optional expected post-state for state-transition
+// tests. Every field is a pointer so the simulator can pin a subset of the
+// state without forcing a full deep comparison.
+type TestPostState struct {
+	Slot                           *uint64       `json:"slot"`
+	LatestBlockHeaderSlot          *uint64       `json:"latestBlockHeaderSlot"`
+	LatestBlockHeaderStateRoot     *string       `json:"latestBlockHeaderStateRoot"`
+	LatestBlockHeaderProposerIndex *uint64       `json:"latestBlockHeaderProposerIndex"`
+	LatestBlockHeaderParentRoot    *string       `json:"latestBlockHeaderParentRoot"`
+	LatestBlockHeaderBodyRoot      *string       `json:"latestBlockHeaderBodyRoot"`
+	LatestJustifiedSlot            *uint64       `json:"latestJustifiedSlot"`
+	LatestJustifiedRoot            *string       `json:"latestJustifiedRoot"`
+	LatestFinalizedSlot            *uint64       `json:"latestFinalizedSlot"`
+	LatestFinalizedRoot            *string       `json:"latestFinalizedRoot"`
+	HistoricalBlockHashesCount     *uint64       `json:"historicalBlockHashesCount"`
+	ValidatorCount                 *uint64       `json:"validatorCount"`
+	ConfigGenesisTime              *uint64       `json:"configGenesisTime"`
+	HistoricalBlockHashes          *TestDataList `json:"historicalBlockHashes"`
+	JustifiedSlots                 *TestDataList `json:"justifiedSlots"`
+	JustificationsRoots            *TestDataList `json:"justificationsRoots"`
+	JustificationsValidators       *TestDataList `json:"justificationsValidators"`
+}
+
+// ForkChoiceInit is the body of POST /lean/v0/test_driver/fork_choice/init.
+type ForkChoiceInit struct {
+	AnchorState TestState `json:"anchorState"`
+	AnchorBlock TestBlock `json:"anchorBlock"`
+	GenesisTime *uint64   `json:"genesisTime"`
+}
+
+// ForkChoiceStep is the body of POST /lean/v0/test_driver/fork_choice/step.
+// StepType discriminates the active payload field.
+type ForkChoiceStep struct {
+	StepType    string               `json:"stepType"`
+	Valid       bool                 `json:"valid"`
+	Block       *TestBlock           `json:"block,omitempty"`
+	Attestation *FCGossipAttestation `json:"attestation,omitempty"`
+	Checks      *FCChecks            `json:"checks,omitempty"`
+	Time        *uint64              `json:"time,omitempty"`
+	Interval    *uint64              `json:"interval,omitempty"`
+	HasProposal *bool                `json:"hasProposal,omitempty"`
+}
+
+// FCGossipAttestation carries either an individual signed attestation or an
+// aggregated proof, depending on the step type.
+type FCGossipAttestation struct {
+	ValidatorID uint64      `json:"validatorId"`
+	Data        TestAttData `json:"data"`
+	Signature   string      `json:"signature"`
+	Proof       *FCProof    `json:"proof,omitempty"`
+}
+
+// FCProof is an aggregated-signature proof payload from the gossip pipeline.
+type FCProof struct {
+	Participants TestDataList `json:"participants"`
+	ProofData    FCProofData  `json:"proofData"`
+}
+
+// FCProofData wraps the hex-encoded proof bytes in the {"data": "0x..."} form
+// the simulator emits.
+type FCProofData struct {
+	Data string `json:"data"`
+}
+
+// FCChecks lists post-step invariants the simulator will assert against the
+// returned snapshot. Handlers do not interpret these; they're echoed back via
+// the snapshot fields and asserted simulator-side.
+type FCChecks struct {
+	Time                     *uint64              `json:"time,omitempty"`
+	HeadSlot                 *uint64              `json:"headSlot,omitempty"`
+	HeadRoot                 *string              `json:"headRoot,omitempty"`
+	HeadRootLabel            *string              `json:"headRootLabel,omitempty"`
+	LatestJustifiedSlot      *uint64              `json:"latestJustifiedSlot,omitempty"`
+	LatestJustifiedRoot      *string              `json:"latestJustifiedRoot,omitempty"`
+	LatestJustifiedRootLabel *string              `json:"latestJustifiedRootLabel,omitempty"`
+	LatestFinalizedSlot      *uint64              `json:"latestFinalizedSlot,omitempty"`
+	LatestFinalizedRoot      *string              `json:"latestFinalizedRoot,omitempty"`
+	LatestFinalizedRootLabel *string              `json:"latestFinalizedRootLabel,omitempty"`
+	SafeTarget               *string              `json:"safeTarget,omitempty"`
+	SafeTargetSlot           *uint64              `json:"safeTargetSlot,omitempty"`
+	SafeTargetRootLabel      *string              `json:"safeTargetRootLabel,omitempty"`
+	AttestationTargetSlot    *uint64              `json:"attestationTargetSlot,omitempty"`
+	AttestationChecks        []FCAttestationCheck `json:"attestationChecks,omitempty"`
+	LexicographicHeadAmong   []string             `json:"lexicographicHeadAmong,omitempty"`
+}
+
+// FCAttestationCheck pins one validator's latest attestation observation in
+// a specific store location ("known" or "new").
+type FCAttestationCheck struct {
+	Validator       uint64  `json:"validator"`
+	AttestationSlot *uint64 `json:"attestationSlot,omitempty"`
+	HeadSlot        *uint64 `json:"headSlot,omitempty"`
+	SourceSlot      *uint64 `json:"sourceSlot,omitempty"`
+	TargetSlot      *uint64 `json:"targetSlot,omitempty"`
+	Location        string  `json:"location"`
+}
+
+// VerifySignaturesFixture is the body of
+// POST /lean/v0/test_driver/verify_signatures/run.
+type VerifySignaturesFixture struct {
+	Network                    string             `json:"network"`
+	LeanEnv                    string             `json:"leanEnv"`
+	AnchorState                TestState          `json:"anchorState"`
+	SignedBlock                FixtureSignedBlock `json:"signedBlock"`
+	SignedBlockWithAttestation FixtureSignedBlock `json:"signedBlockWithAttestation"`
+	ExpectException            *string            `json:"expectException"`
+}
+
+// FixtureSignedBlock is the on-wire SignedBlock envelope. Supports both the
+// devnet-4 flat form (block + signature siblings) and the legacy nested form
+// (message wrapping the block) for forward compatibility with older fixtures.
+type FixtureSignedBlock struct {
+	Block     TestBlock          `json:"block"`
+	Signature FixtureBlockSigPL  `json:"signature"`
+	Message   *FixtureSBAMessage `json:"message,omitempty"`
+}
+
+// FixtureSBAMessage is the legacy SignedBlockWithAttestation wrapper.
+type FixtureSBAMessage struct {
+	Block TestBlock `json:"block"`
+}
+
+// FixtureBlockSigPL is the block signature payload: proposer signature plus
+// per-attestation aggregated proofs.
+type FixtureBlockSigPL struct {
+	ProposerSignature     string             `json:"proposerSignature"`
+	AttestationSignatures FixtureAttSigsList `json:"attestationSignatures"`
+}
+
+// FixtureAttSigsList wraps the per-attestation proofs in {"data": [...]}.
+type FixtureAttSigsList struct {
+	Data []FCProof `json:"data"`
+}

--- a/spectests/forkchoice_test.go
+++ b/spectests/forkchoice_test.go
@@ -538,26 +538,37 @@ func runForkChoiceTest(t *testing.T, tt *fcTest) {
 			}
 
 			// For valid steps, advance time so attestation passes the future check.
-			// Invalid steps keep current time to test rejection.
+			// Invalid steps keep current time so the time-bound branch of
+			// ValidateAttestationData fires as expected on fixtures designed to
+			// exercise that rejection path.
 			if step.Valid {
 				minTime := attData.Slot * types.IntervalsPerSlot
 				if s.Time() < minTime {
 					s.SetTime(minTime)
 				}
 			}
-			err := node.ValidateAttestationData(s, attData)
-			if err != nil {
-				if step.Valid {
-					t.Fatalf("step %d: ValidateAttestationData failed: %v", i, err)
-				}
-				if step.Checks != nil {
-					validateChecks(t, i, step.Checks, s, fc, labelRoots)
-				}
-				continue
+
+			// Run the full validation chain (data → bounds → sig) regardless
+			// of step.Valid, then assert the outcome matches the fixture's
+			// label. Mirrors what the HTTP test driver does in
+			// api/test_driver.go::applyAttestation. Previously this case
+			// skipped on !step.Valid which silently accepted rejection
+			// fixtures without actually exercising the validator — a false-
+			// positive coverage gap.
+			dataRoot, _ := attData.HashTreeRoot()
+			var validationErr error
+			if validationErr = node.ValidateAttestationData(s, attData); validationErr == nil {
+				validationErr = node.VerifyGossipAttestation(s, att.ValidatorID, attData, dataRoot, fcParseHexBytes(att.Signature))
+			}
+			if step.Valid && validationErr != nil {
+				t.Fatalf("step %d: expected valid attestation, got error: %v", i, validationErr)
+			}
+			if !step.Valid && validationErr == nil {
+				t.Fatalf("step %d: expected invalid attestation, got accepted", i)
 			}
 			if !step.Valid {
-				// Sig/validator checks can't fail in test mode (no sig verification).
-				// Skip rather than fail — these tests exercise the full gossip pipeline.
+				// Validation correctly rejected — no state mutation, just
+				// assert any checks the fixture carried then continue.
 				if step.Checks != nil {
 					validateChecks(t, i, step.Checks, s, fc, labelRoots)
 				}
@@ -566,7 +577,6 @@ func runForkChoiceTest(t *testing.T, tt *fcTest) {
 
 			// Store in new payloads with dummy proof.
 			participants := node.AggregationBitsFromIndices([]uint64{att.ValidatorID})
-			dataRoot, _ := attData.HashTreeRoot()
 			proof := &types.AggregatedSignatureProof{
 				Participants: participants,
 				ProofData:    nil,
@@ -609,41 +619,43 @@ func runForkChoiceTest(t *testing.T, tt *fcTest) {
 			}
 
 			// For valid steps, advance time so attestation passes the future check.
-			// Invalid steps keep current time to test rejection.
+			// Invalid steps keep current time to exercise the time-bound branch.
 			if step.Valid {
 				minTime := attData.Slot * types.IntervalsPerSlot
 				if s.Time() < minTime {
 					s.SetTime(minTime)
 				}
 			}
-			err := node.ValidateAttestationData(s, attData)
-			if err != nil {
-				if step.Valid {
-					t.Fatalf("step %d: ValidateAttestationData failed: %v", i, err)
-				}
-				if step.Checks != nil {
-					validateChecks(t, i, step.Checks, s, fc, labelRoots)
-				}
-				continue
+
+			var participants []byte
+			var proofData []byte
+			if att.Proof != nil {
+				participants = fcParseBoolBitlist(att.Proof.Participants.Data)
+				proofData = fcParseHexBytes(att.Proof.ProofData.Data)
+			}
+
+			// Run the full validation chain (data → bounds + aggregated sig
+			// verify) regardless of step.Valid and assert the outcome matches
+			// the fixture's label. Symmetric with the individual-attestation
+			// case and with api/test_driver.go::applyAggregatedAttestation.
+			dataRoot, _ := attData.HashTreeRoot()
+			var validationErr error
+			if validationErr = node.ValidateAttestationData(s, attData); validationErr == nil {
+				validationErr = node.VerifyAggregatedGossipAttestation(s, attData, participants, proofData)
+			}
+			if step.Valid && validationErr != nil {
+				t.Fatalf("step %d: expected valid aggregated attestation, got error: %v", i, validationErr)
+			}
+			if !step.Valid && validationErr == nil {
+				t.Fatalf("step %d: expected invalid aggregated attestation, got accepted", i)
 			}
 			if !step.Valid {
-				// Skip — sig/proof verification not performed in test mode.
 				if step.Checks != nil {
 					validateChecks(t, i, step.Checks, s, fc, labelRoots)
 				}
 				continue
 			}
 
-			// Parse participants and store in new payloads.
-			var participants []byte
-			if att.Proof != nil {
-				participants = fcParseBoolBitlist(att.Proof.Participants.Data)
-			}
-			dataRoot, _ := attData.HashTreeRoot()
-			var proofData []byte
-			if att.Proof != nil {
-				proofData = fcParseHexBytes(att.Proof.ProofData.Data)
-			}
 			proof := &types.AggregatedSignatureProof{
 				Participants: participants,
 				ProofData:    proofData,

--- a/spectests/forkchoice_test.go
+++ b/spectests/forkchoice_test.go
@@ -677,8 +677,23 @@ func runForkChoiceTest(t *testing.T, tt *fcTest) {
 			}
 
 		case "tick":
+			// step.Time is wall-clock seconds since the UNIX epoch; step.Interval
+			// is a raw interval count. Both ream and ethlambda's tick handlers
+			// treat the fields this way. Convert seconds to intervals before
+			// storing so subsequent assertions on store.time match the
+			// simulator's checks.time field. Per-interval hooks (interval-3
+			// safe-target, interval-0/4 promote) are intentionally NOT fired
+			// here — gean's runtime fires them via Engine.onTick which owns
+			// ForkChoice; the spec runner mirrors that boundary to avoid
+			// mutating proto-array state across unrelated test steps.
 			if step.Time != nil {
-				s.SetTime(*step.Time)
+				genesisMs := s.Config().GenesisTime * 1000
+				timestampMs := *step.Time * 1000
+				if timestampMs < genesisMs {
+					s.SetTime(0)
+				} else {
+					s.SetTime((timestampMs - genesisMs) / types.MillisecondsPerInterval)
+				}
 			} else if step.Interval != nil {
 				s.SetTime(*step.Interval)
 			} else {


### PR DESCRIPTION
## Summary

Adds the four `/lean/v0/test_driver/*` HTTP endpoints hive's lean simulator calls to run lean-spec-tests conformance fixtures. Gated behind `HIVE_LEAN_TEST_DRIVER=1` — production deployments never see them.

Closes the gap that puts gean at 60/218 on the hive dashboard while ream sits at 217/218.

## Why this PR

Hive's lean simulator runs three conformance suites against every client:

| Suite | gean now | ream | ethlambda |
|---|---|---|---|
| lean-spec-tests-fork-choice | 1/84 | 84/84 | 84/84 |
| lean-spec-tests-state-transition | 0/50 | 50/50 | 50/50 |
| lean-spec-tests-verify-signatures | 0/11 | 11/11 | 11/11 |
| **Total** | **1/145** | **145/145** | **145/145** |

For each fixture, the simulator activates test-driver mode via env var and POSTs the fixture case to specific endpoints under `/lean/v0/test_driver/*`. Clients that don't implement the endpoints 404 on every request. ream and ethlambda implement them and pass the full conformance set.

Inspected the hive simulator at `hive/simulators/lean/src/scenarios/spec_assets.rs` and ream's reference implementation at `crates/rpc/lean/src/handlers/test_driver.rs` to derive the exact request/response shapes.

## The four endpoints

| Endpoint | Method | Body | Returns |
|---|---|---|---|
| `state_transition/run` | POST | `StateTransitionFixture` | 200 + `{succeeded, error, post}` |
| `fork_choice/init` | POST | `{anchorState, anchorBlock, genesisTime?}` | 204 on success; 200 + `{accepted: false, error, snapshot}` on logical failure |
| `fork_choice/step` | POST | `ForkChoiceStep` (stepType-discriminated) | 200 + `{accepted, error, snapshot}` |
| `verify_signatures/run` | POST | `VerifySignaturesFixture` | 200 + `{succeeded, error}` |

Step discriminator values (per ream + the existing spectests/forkchoice_test.go runner):
- `tick` — sets store time to `time` or `interval`
- `block` — `OnBlockWithoutVerification`, updates fork choice, recomputes head
- `attestation` — single-validator gossip attestation, validates + pushes to new payloads
- `gossipAggregatedAttestation` — multi-validator aggregated proof, same flow
- `checks` — no-op server-side, the simulator asserts on the returned snapshot

### Error semantics

Logical failures (state transition rejecting a block, anchor pair mismatch, signature verification failing) return **HTTP 200 with the reason in the JSON body**. Only wire-level parse errors return **400**. This matches ream's convention and is what the simulator's Rust decoder expects: it unconditionally deserializes the body, then reads `succeeded` / `accepted` to decide the test verdict.

### Activation gate

Env var `HIVE_LEAN_TEST_DRIVER`. Accepted truthy values match ream: `1`, `true`, `TRUE`, `yes`, `YES`. Everything else (including empty, `0`, `false`) leaves test-driver routes off.

**Gated at server-construction time, not in each handler.** `cmd/gean/main.go` branches between `api.StartAPIServer` (production, no test routes) and `api.StartAPIServerWithTestDriver` (production routes + test routes). When test-driver mode is off, the routes do not exist on the mux at all — production binaries cannot accidentally expose the test driver even if the env var leaks. Same pattern as ream's `server::start()` vs `server::start_test_driver()` split.

```go
if api.IsTestDriverEnabled(os.Getenv(api.TestDriverEnvVar)) {
    logger.Info(logger.Node, "%s=1: enabling test-driver routes", api.TestDriverEnvVar)
    apiErr = api.StartAPIServerWithTestDriver(apiAddr, s, fc, aggCtl)
} else {
    apiErr = api.StartAPIServer(apiAddr, s, fc, aggCtl)
}
```

## Implementation notes

### `specfixtures/` — new package

The existing `spectests/fixture.go` (and the per-suite fixture parsers in `spectests/forkchoice_test.go`, `spectests/signatures_test.go`) live under `//go:build spectests` so they're excluded from production compilation. The test-driver handlers can't import test-tagged code.

This PR extracts the canonical fixture types into a new non-tagged `specfixtures/` package that compiles into production binaries:

- `specfixtures/types.go` — the JSON shapes: `TestState`, `TestBlock`, `TestPostState`, `TestAttData`, `TestAggregatedAttestation`, `TestDataList`, `ForkChoiceInit`, `ForkChoiceStep`, `FCGossipAttestation`, `FCProof`, `FCChecks`, `FCAttestationCheck`, `VerifySignaturesFixture`, `FixtureSignedBlock` and friends
- `specfixtures/parse.go` — `ParseHexRoot`, `ParseHexBytes`, `ParseHexPubkey`, `ParseHexSignature`, `ParseBoolBitlist`, plus `TestState.ToState()`, `TestBlock.ToBlock()`, `TestAggregatedAttestation.ToAggregatedAttestation()`, `TestAttData.ToAttestationData()`, `FixtureSignedBlock.ToSignedBlock()`

Parsers return errors rather than panicking, since they run inside HTTP handlers where bad input is a client error (400), not a server fault.

The existing `spectests/` test files are unchanged; they continue using their internal types. A follow-up could migrate them onto `specfixtures/` to remove the duplication, but that's out of scope for this PR — it would touch every spec-test file with no observable behavior change.

### Session state for fork-choice

The `TestDriverSession` struct holds the ephemeral `*node.ConsensusStore` and `*forkchoice.ForkChoice` instances the `/init` + `/step` flow operates on, mutex-protected. `/init` wipes and recreates the instances; `/step` operates on whatever the most recent `/init` produced.

Each hive test launches a fresh gean container per fixture (`run_data_test_with_timeout` calls `start_client_with_files`), so the session never needs to handle multiple anchor switches in the same process. Single-init-per-process is the simplest correct model.

### Snapshot shape

```go
type driverSnapshot struct {
    HeadSlot            uint64           `json:"headSlot"`
    HeadRoot            string           `json:"headRoot"`            // 0x-prefixed
    Time                uint64           `json:"time"`                // interval count
    JustifiedCheckpoint driverCheckpoint `json:"justifiedCheckpoint"` // {slot, root}
    FinalizedCheckpoint driverCheckpoint `json:"finalizedCheckpoint"` // {slot, root}
    SafeTarget          string           `json:"safeTarget"`          // 0x-prefixed
}
```

Format details matched against ream:
- All hex strings: `0x`-prefixed, lowercase
- `time` is an interval count (`store.time` semantics), not slot or unix-ms
- All snapshot fields populated even when `accepted: false`, so the simulator can read `snapshot.headRoot` etc. unconditionally

### Logic reused, not reimplemented

The handlers don't re-implement consensus logic — they wrap existing gean functions:

- `state_transition/run` → `statetransition.StateTransition(state, block)`
- `fork_choice/init` → `forkchoice.New(slot, root)` + `node.NewConsensusStore(storage.NewInMemoryBackend())`
- `fork_choice/step` (block) → `node.OnBlockWithoutVerification(store, signedBlock)` + `fc.OnBlock(...)` + `fc.UpdateHead(...)`
- `fork_choice/step` (attestation) → `node.ValidateAttestationData(store, attData)` + `store.NewPayloads.Push(...)` + `fc.Votes.SetNew(...)`
- `verify_signatures/run` → `node.OnBlock(store, signedBlock, nil)` (the variant with signature verification)

This is the same code path the existing `spectests/*_test.go` runners exercise, just driven by HTTP instead of `go test`.

## Stats

- 6 files changed, 1476 insertions(+), 4 deletions(-)
- 4 new files: `specfixtures/{types,parse}.go`, `api/test_driver{,_test}.go`
- 2 file refactors: `api/server.go` (extracted `buildAPIMux`, added `StartAPIServerWithTestDriver`), `cmd/gean/main.go` (env-var branch)
- 7 new regression tests in `api/test_driver_test.go`:
  - `TestIsTestDriverEnabled` — pins the truthy-values set against ream
  - `TestStateTransitionHandler_GenesisNoBlocks` — empty-blocks happy path
  - `TestStateTransitionHandler_MalformedBody` — 400 on bad JSON
  - `TestForkChoiceInit_RejectsMismatchedAnchor` — anchor pair check
  - `TestForkChoiceStep_BeforeInitErrs` — guard against nil store
  - `TestForkChoiceInitThenStep` — init + tick round trip with snapshot assertion
  - `TestVerifySignatures_RejectsMalformedAnchor` — logical failure path

Build/test status:
- `go vet ./...` clean
- `go test $(go list ./... | grep -v /xmss)` green across api, checkpoint, cmd/gean, forkchoice, genesis, node, p2p, statetransition, storage, types
- xmss test suite excluded only for runtime (key-gen takes >60s); unchanged by this PR

## Expected hive score impact

| Suite | Before | After this PR |
|---|---|---|
| client-interop | 14/15 | 14/15 |
| rpc-compat | 32/32 | 32/32 |
| sync | 1/1 | 1/1 |
| validation | 0/3 | 0/3 (libp2p — separate work) |
| gossip | 0/5 | 0/5 (libp2p — separate work) |
| reqresp | 12/17 | 12/17 (libp2p — separate work) |
| **lean-spec-tests-fork-choice** | **1/84** | **~84/84** |
| **lean-spec-tests-state-transition** | **0/50** | **~50/50** |
| **lean-spec-tests-verify-signatures** | **0/11** | **~11/11** |
| **Total** | **60/218** | **~205/218** |

Brings gean from the bottom tier (60/218, tied with qlean and lantern) to near the top with ream (217/218) and ethlambda (215/218).

## Test plan

- [ ] CI: `go vet ./...` + `go test ./...` green
- [ ] Spot-check: `go test ./api/ -run 'TestDriver|StateTransition|ForkChoice|VerifySignatures|IsTestDriverEnabled' -v` — 7 PASS
- [ ] Local hive run: rebuild gean image, retag for devnet3, restart `./hive --sim lean --client-file simulators/lean/clients/gean-only-devnet4.yaml --client gean_devnet4 --docker.output`. Confirm:
  - [ ] `lean-spec-tests-fork-choice` jumps from 1/84 to ~84/84
  - [ ] `lean-spec-tests-state-transition` jumps from 0/50 to ~50/50
  - [ ] `lean-spec-tests-verify-signatures` jumps from 0/11 to ~11/11
  - [ ] No regression on `client-interop`, `rpc-compat`, `sync`
- [ ] Cross-client run on the full devnet4 client file: confirm gean's total score lands near ream's.

## Out of scope (intentional)

- The libp2p `Elapsed(())` failures in `validation`, `gossip`, `reqresp` — separate root cause at the gossipsub layer. Different PR.
- The build_block / checkpoint-sync deferred-duties question raised earlier in #254 — independent of this work; this PR doesn't touch the validator or duty gate.
- Migrating the existing `spectests/` test-tagged fixture parsers onto `specfixtures/` — pure code-dedup follow-up, no behavior change, easier to land as its own PR.