### PR TITLE
fix(node): checkpoint-sync anchor root + on-connect Status reqresp

### DIFF
--- a/cmd/gean/main.go
+++ b/cmd/gean/main.go
@@ -130,18 +130,24 @@ func main() {
 			logger.Error(logger.Sync, "checkpoint sync failed: %v", err)
 			os.Exit(1)
 		}
-		stateRoot, _ := state.HashTreeRoot()
-		header := state.LatestBlockHeader
-		blockRoot, _ := header.HashTreeRoot()
+		// initStoreFromState mutates state.LatestBlockHeader.StateRoot from
+		// zero (canonical post-state form) to hash_tree_root(state), so the
+		// canonical anchor block root must be read from its return value —
+		// computing header.HashTreeRoot() before that mutation yields the
+		// pre-canonicalization root, which would not match the anchor
+		// checkpoint the store sets. Using the wrong key for StorePendingBlock
+		// is what caused /lean/v0/blocks/finalized to return 404 on a freshly
+		// checkpoint-synced node despite the block being stored.
+		canonicalRoot := initStoreFromState(s, state)
+		stateRoot := state.LatestBlockHeader.StateRoot
 		logger.Info(logger.Sync, "checkpoint sync: slot=%d finalized_root=%x justified_root=%x head_root=%x parent_root=%x state_root=%x",
-			state.Slot, state.LatestFinalized.Root, state.LatestJustified.Root, blockRoot, header.ParentRoot, stateRoot)
-		initStoreFromState(s, state)
-		s.StorePendingBlock(blockRoot, signedBlock)
+			state.Slot, state.LatestFinalized.Root, state.LatestJustified.Root, canonicalRoot, state.LatestBlockHeader.ParentRoot, stateRoot)
+		s.StorePendingBlock(canonicalRoot, signedBlock)
 	} else {
 		// Genesis.
 		logger.Info(logger.Node, "initializing from genesis")
 		genesisState := genesisConfig.GenesisState()
-		initStoreFromState(s, genesisState)
+		_ = initStoreFromState(s, genesisState)
 	}
 
 	// Rehydrate store.time from wall clock before any consumer reads it.
@@ -294,7 +300,8 @@ func main() {
 	time.Sleep(500 * time.Millisecond)
 }
 
-// initStoreFromState initializes the consensus store from an anchor state.
+// initStoreFromState initializes the consensus store from an anchor state
+// and returns the canonical anchor block root.
 //
 // The anchor state becomes the new latest justified AND latest finalized
 // checkpoint — both pointing at the served block at header.Slot. This
@@ -302,11 +309,18 @@ func main() {
 // trusts the served state as the new finalization anchor and starts forward
 // sync from there.
 //
+// The returned root is the canonical anchor block root — computed AFTER the
+// header.StateRoot canonicalization step. Callers that need to associate
+// out-of-band data with the anchor block (e.g. StorePendingBlock for the
+// checkpoint-sync SignedBlock) must use this return value, not a root
+// computed before the function ran; the pre-canonicalization root would not
+// match what the store records as latest_finalized.Root.
+//
 // Note: state.LatestJustified and state.LatestFinalized inside the served
 // state point to EARLIER slots (the finalization status from when the block
 // was processed). We deliberately do NOT use those — the served block IS
 // the new anchor, regardless of what its internal pointers say.
-func initStoreFromState(s *node.ConsensusStore, state *types.State) {
+func initStoreFromState(s *node.ConsensusStore, state *types.State) [32]byte {
 	// Compute anchor block root from header.
 	stateRoot, _ := state.HashTreeRoot()
 	header := state.LatestBlockHeader
@@ -336,6 +350,7 @@ func initStoreFromState(s *node.ConsensusStore, state *types.State) {
 
 	logger.Info(logger.Store, "store initialized from anchor: slot=%d head=%x parent_root=%x state_root=%x",
 		header.Slot, blockRoot, header.ParentRoot, stateRoot)
+	return blockRoot
 }
 
 // recoverStoreTime sets store.time to the interval index corresponding to the

--- a/cmd/gean/main.go
+++ b/cmd/gean/main.go
@@ -254,8 +254,14 @@ func main() {
 
 	// Start sync driver: periodic status-poll + BlocksByRange backfill when
 	// peers are far enough ahead. No-op while node is synced or has no peers.
-	syncDriver := node.NewSyncDriver(n, p2pHost)
-	go syncDriver.Run(ctx)
+	// Wire OnPeerConnected as the libp2p PeerStatusHook BEFORE starting the
+	// driver so a fast initial dial that completes during start-up still
+	// fires the on-connect Status handshake. Sending Status only from the
+	// periodic poll is too slow for cold-start single-peer scenarios to
+	// learn the peer's head and drive backfill.
+	syncDriver := node.NewSyncDriver(ctx, n, p2pHost)
+	p2p.PeerStatusHook = syncDriver.OnPeerConnected
+	go syncDriver.Run()
 
 	// --- Start HTTP servers ---
 

--- a/node/sync.go
+++ b/node/sync.go
@@ -34,6 +34,13 @@ type SyncDriver struct {
 	engine *Engine
 	p2p    SyncDriverP2P
 
+	// ctx captured at construction so OnPeerConnected (invoked from libp2p's
+	// network goroutine via p2p.PeerStatusHook) can derive request contexts
+	// without a data race against Run setting it. Construction happens in
+	// main before any goroutine can call OnPeerConnected, so the field is
+	// safely published by happens-before of subsequent goroutine starts.
+	ctx context.Context
+
 	// Per-peer in-flight fetch dedup. Prevents stacking range requests to the
 	// same peer across overlapping polling cycles.
 	mu       sync.Mutex
@@ -41,16 +48,19 @@ type SyncDriver struct {
 }
 
 // NewSyncDriver constructs a driver bound to the given engine and p2p host.
-func NewSyncDriver(engine *Engine, p2pHost SyncDriverP2P) *SyncDriver {
+// ctx is captured for use by OnPeerConnected callbacks (see field doc); Run
+// reads cancellation from the same ctx.
+func NewSyncDriver(ctx context.Context, engine *Engine, p2pHost SyncDriverP2P) *SyncDriver {
 	return &SyncDriver{
+		ctx:      ctx,
 		engine:   engine,
 		p2p:      p2pHost,
 		inFlight: make(map[libp2ppeer.ID]bool),
 	}
 }
 
-// Run is the polling loop. Cancel ctx to stop.
-func (sd *SyncDriver) Run(ctx context.Context) {
+// Run is the polling loop. Cancel the ctx passed to NewSyncDriver to stop.
+func (sd *SyncDriver) Run() {
 	ticker := time.NewTicker(p2p.SyncPollInterval)
 	defer ticker.Stop()
 
@@ -59,17 +69,32 @@ func (sd *SyncDriver) Run(ctx context.Context) {
 
 	for {
 		select {
-		case <-ctx.Done():
+		case <-sd.ctx.Done():
 			return
 		case <-ticker.C:
 			switch sd.engine.GetSyncStatus() {
 			case SyncSyncing:
-				sd.refreshSyncFromPeers(ctx)
+				sd.refreshSyncFromPeers(sd.ctx)
 			case SyncIdle, SyncSynced:
 				// No work: no peers to poll, or already at chain head.
 			}
 		}
 	}
+}
+
+// OnPeerConnected is the p2p.PeerStatusHook callback. Fires once per
+// newly-connected peer (gated by PeerStore.AddNew upstream) and initiates
+// the lean P2P Status reqresp handshake using the same pollPeer code path
+// the periodic loop uses. Bounded by a 10s timeout so a slow or
+// unresponsive peer cannot hold the goroutine indefinitely; on success the
+// resulting peer status drives the usual checkAndBackfill dispatch.
+//
+// Wired by cmd/gean/main.go: p2p.PeerStatusHook = syncDriver.OnPeerConnected
+func (sd *SyncDriver) OnPeerConnected(peerID libp2ppeer.ID) {
+	ctx, cancel := context.WithTimeout(sd.ctx, 10*time.Second)
+	defer cancel()
+	ourStatus := sd.makeStatusMessage()
+	sd.pollPeer(ctx, peerID, ourStatus)
 }
 
 // refreshSyncFromPeers polls every connected peer for status, in parallel.

--- a/node/sync_test.go
+++ b/node/sync_test.go
@@ -101,7 +101,7 @@ func drainBlockCh(t *testing.T, e *Engine, expected int, timeout time.Duration) 
 func TestSyncDriver_CheckAndBackfill_PeerNotAhead(t *testing.T) {
 	e := makeTestEngine()
 	mock := &mockSyncP2P{}
-	sd := NewSyncDriver(e, mock)
+	sd := NewSyncDriver(context.Background(), e, mock)
 
 	// Engine head is at slot 0. Peer is also at slot 0 — not ahead.
 	peerStatus := &p2p.StatusMessage{HeadSlot: 0}
@@ -115,7 +115,7 @@ func TestSyncDriver_CheckAndBackfill_PeerNotAhead(t *testing.T) {
 func TestSyncDriver_CheckAndBackfill_GapBelowThreshold(t *testing.T) {
 	e := makeTestEngine()
 	mock := &mockSyncP2P{}
-	sd := NewSyncDriver(e, mock)
+	sd := NewSyncDriver(context.Background(), e, mock)
 
 	// Gap of 10 < BlocksByRangeSyncThreshold (64). Should NOT trigger range fetch.
 	peerStatus := &p2p.StatusMessage{HeadSlot: 10}
@@ -134,7 +134,7 @@ func TestSyncDriver_CheckAndBackfill_FetchesWhenAhead(t *testing.T) {
 			{Block: &types.Block{Slot: 2, Body: &types.BlockBody{}}},
 		},
 	}
-	sd := NewSyncDriver(e, mock)
+	sd := NewSyncDriver(context.Background(), e, mock)
 
 	// Gap of 100 > BlocksByRangeSyncThreshold (64). Should trigger range fetch.
 	peerStatus := &p2p.StatusMessage{HeadSlot: 100}
@@ -158,7 +158,7 @@ func TestSyncDriver_CheckAndBackfill_FallsBackToRoot(t *testing.T) {
 			{Block: &types.Block{Slot: 100, Body: &types.BlockBody{}}},
 		},
 	}
-	sd := NewSyncDriver(e, mock)
+	sd := NewSyncDriver(context.Background(), e, mock)
 
 	var headRoot [32]byte
 	headRoot[0] = 0xAB
@@ -187,7 +187,7 @@ func TestSyncDriver_CheckAndBackfill_PerPeerDedup(t *testing.T) {
 		},
 		rangeBlock: rangeBlock,
 	}
-	sd := NewSyncDriver(e, mock)
+	sd := NewSyncDriver(context.Background(), e, mock)
 
 	peerStatus := &p2p.StatusMessage{HeadSlot: 100}
 	peerID := libp2ppeer.ID("p1")

--- a/p2p/gossip.go
+++ b/p2p/gossip.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/geanlabs/gean/logger"
 	"github.com/geanlabs/gean/types"
@@ -36,6 +37,15 @@ var (
 	PeerConnectedHook    func(direction string)
 	PeerDisconnectedHook func(direction, reason string)
 	PeerCountHook        func(count int)
+
+	// PeerStatusHook fires once per newly-connected peer (gated by
+	// PeerStore.AddNew so reconnect events do not retrigger) with the peer's
+	// ID. Wired by node-layer code to initiate the lean P2P Status reqresp
+	// handshake the protocol expects on each new connection. Sending Status
+	// from the libp2p connection notifier (rather than only from the sync
+	// driver's periodic poll) is required so cold-start single-peer setups
+	// learn the peer's head promptly enough to drive backfill.
+	PeerStatusHook func(peerID peer.ID)
 )
 
 // StartGossipListeners starts goroutines that read from each subscribed topic

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -128,7 +128,13 @@ func NewHost(ctx context.Context, nodeKeyPath string, listenPort int, committeeC
 	h.Network().Notify(&network.NotifyBundle{
 		ConnectedF: func(n network.Network, conn network.Conn) {
 			peerID := conn.RemotePeer()
-			p2pHost.peerStore.Add(peerID)
+			// AddNew atomically registers and reports whether this is the
+			// first connection to this peer. libp2p emits ConnectedF for
+			// every connection event (including additional connections to
+			// an already-connected peer or redial races), so we gate the
+			// one-shot on-connect work — the Status reqresp handshake —
+			// behind that flag.
+			isNew := p2pHost.peerStore.AddNew(peerID)
 			direction := directionLabel(conn.Stat().Direction)
 			count := p2pHost.peerStore.Count()
 			logger.Info(logger.Network, "peer connected peer_id=%s direction=%s peers=%d",
@@ -138,6 +144,13 @@ func NewHost(ctx context.Context, nodeKeyPath string, listenPort int, committeeC
 			}
 			if PeerCountHook != nil {
 				PeerCountHook(count)
+			}
+			if isNew && PeerStatusHook != nil {
+				// Async — ConnectedF runs on libp2p's network goroutine;
+				// the Status reqresp opens a new stream and waits for a
+				// response, which would block all subsequent libp2p
+				// network events if invoked inline.
+				go PeerStatusHook(peerID)
 			}
 		},
 		DisconnectedF: func(n network.Network, conn network.Conn) {

--- a/p2p/peers.go
+++ b/p2p/peers.go
@@ -55,6 +55,20 @@ func (ps *PeerStore) Add(id peer.ID) {
 	ps.peers[id] = true
 }
 
+// AddNew atomically registers a peer and reports whether the peer was newly
+// added (true) or was already present (false). Used by the libp2p connection
+// notifier to gate on-connect work (e.g. firing the Status reqresp) so that
+// reconnect events for an already-known peer do not retrigger the work.
+func (ps *PeerStore) AddNew(id peer.ID) bool {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	if ps.peers[id] {
+		return false
+	}
+	ps.peers[id] = true
+	return true
+}
+
 // Remove unregisters a peer.
 func (ps *PeerStore) Remove(id peer.ID) {
 	ps.mu.Lock()


### PR DESCRIPTION
Fixes #257

## Summary

Two cold-start bootstrap reliability fixes. Stacked on top of #255.

- **`fix(checkpoint-sync)` (f3ef40f)** — `initStoreFromState` mutates `state.LatestBlockHeader.StateRoot` from zero to `hash_tree_root(state)` before computing the anchor block root the store keys finalized blocks by. The caller in `cmd/gean/main.go` was computing `header.HashTreeRoot()` *before* that mutation, so `StorePendingBlock` was keyed by the pre-canonicalization root while `SetLatestFinalized` recorded the post-canonicalization root. Symptom: `/lean/v0/blocks/finalized` returned 404 on a freshly checkpoint-synced node despite the block being stored — peers attempting to checkpoint-sync *from* a fresh gean node therefore failed to bootstrap. Fix: refactor `initStoreFromState` to return the canonical anchor root and key `StorePendingBlock` off the return value.

- **`feat(p2p)` (2e85112)** — Previously the lean P2P Status reqresp handshake fired only from `SyncDriver`'s 32s periodic poll while in `SyncSyncing` state, which doesn't fire promptly on cold-start single-peer scenarios. Peers thus took up to 32s to learn each other's heads and start backfill. Wire a `PeerStatusHook` from `p2p.Host`'s libp2p `ConnectionEstablished` notifier to a new `SyncDriver.OnPeerConnected` callback, fired once per newly-connected peer (gated by `PeerStore.AddNew` so reconnect events do not retrigger). The hook runs in a fresh goroutine bounded by a 10s timeout so a slow peer cannot block the libp2p network loop. To enable invocation from the libp2p network goroutine without a data race, `SyncDriver` now captures `ctx` at construction time.

Paired because both target the same user-visible failure: gean failing to bootstrap a peer (or be bootstrapped *from*) on cold start.

## Verification (local)

- `go vet ./...` — clean
- `go build ./...` — clean
- `go test -race ./...` — full module green
- `go test -race -count=10 ./node/... ./p2p/... ./cmd/gean/...` — green (fresh cache, no flake at 10x)
- `go test -tags=spectests -count=20 ./spectests/` — green at 20x (~212s)
- Standalone build at commit-1 (no working changes): clean — commit-1 does not depend on commit-2

## Test plan

- [ ] `make docker-build` → `docker tag ghcr.io/geanlabs/gean:devnet4 ghcr.io/geanlabs/gean:devnet3` → run hive lean simulator with `gean-only-devnet4.yaml` and `--docker.nocache`; confirm tally improves vs. the 190/214 baseline currently produced by `feat/test-driver-endpoints` alone
- [ ] Specifically watch for:
  - Tests that previously failed due to `/lean/v0/blocks/finalized` 404 on a freshly checkpoint-synced node — should now pass
  - Tests that require two cold-start peers to discover each other's heads within the test's bootstrap window — should now converge in ~seconds instead of ~32s
- [ ] No regressions vs. the `feat/test-driver-endpoints` baseline
