### PR TITLE
fix(p2p): bump go-libp2p-pubsub to v0.16.0 for lantern gossipsub interop

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/ferranbt/fastssz v1.0.0
 	github.com/golang/snappy v1.0.0
 	github.com/libp2p/go-libp2p v0.48.0
-	github.com/libp2p/go-libp2p-pubsub v0.15.0
+	github.com/libp2p/go-libp2p-pubsub v0.16.0
 	github.com/multiformats/go-multiaddr v0.16.0
 	github.com/prometheus/client_golang v1.22.0
 	golang.org/x/sync v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,8 @@ github.com/libp2p/go-libp2p v0.48.0 h1:h2BrLAgrj7X8bEN05K7qmrjpNHYA+6tnsGRdprjTn
 github.com/libp2p/go-libp2p v0.48.0/go.mod h1:Q1fBZNdmC2Hf82husCTfkKJVfHm2we5zk+NWmOGEmWk=
 github.com/libp2p/go-libp2p-asn-util v0.4.1 h1:xqL7++IKD9TBFMgnLPZR6/6iYhawHKHl950SO9L6n94=
 github.com/libp2p/go-libp2p-asn-util v0.4.1/go.mod h1:d/NI6XZ9qxw67b4e+NgpQexCIiFYJjErASrYW4PFDN8=
-github.com/libp2p/go-libp2p-pubsub v0.15.0 h1:cG7Cng2BT82WttmPFMi50gDNV+58K626m/wR00vGL1o=
-github.com/libp2p/go-libp2p-pubsub v0.15.0/go.mod h1:lr4oE8bFgQaifRcoc2uWhWWiK6tPdOEKpUuR408GFN4=
+github.com/libp2p/go-libp2p-pubsub v0.16.0 h1:j7G2C8kJwkcAQqYR7Wmq3d75d3Sgw/N0Hhiv0dVx7OY=
+github.com/libp2p/go-libp2p-pubsub v0.16.0/go.mod h1:lr4oE8bFgQaifRcoc2uWhWWiK6tPdOEKpUuR408GFN4=
 github.com/libp2p/go-libp2p-testing v0.12.0 h1:EPvBb4kKMWO29qP4mZGyhVzUyR25dvfUIK5WDu6iPUA=
 github.com/libp2p/go-libp2p-testing v0.12.0/go.mod h1:KcGDRXyN7sQCllucn1cOOS+Dmm7ujhfEyXQL5lvkcPg=
 github.com/libp2p/go-msgio v0.3.0 h1:mf3Z8B1xcFN314sWX+2vOTShIE0Mmn2TXn3YCUQGNj0=


### PR DESCRIPTION
## Summary

Bump `github.com/libp2p/go-libp2p-pubsub` from `v0.15.0` to `v0.16.0` to address a stream-lifecycle race that breaks gossipsub interop with lantern. Stacked on top of PR #261 so both changes can be tested together before merging to `devnet-4`.

## Problem

When gean shares a gossipsub mesh with lantern, lantern never registers gean's topic subscriptions. Symptom in lantern's container log:

```
drop publish for unsubscribed peer=<gean-peer-id>
  topic=/leanconsensus/12345678/block/ssz_snappy
  topics_count=0
```

This appears on every block, attestation, and aggregation gean publishes. Lantern's mesh-formation (GRAFT) skips gean as `not_subscribed`, so the mesh never forms.

Hive evidence (gean+lantern multi-client interop, v0.15.0 baseline):

- 3-node interop (2 gean + 1 lantern): gean nodes finalized to slot 30 in 180 s, lantern stayed at slot 0
- 3-node interop (1 gean + 2 lantern): all nodes stayed at slot 0
- gean↔gean works fine, only gean↔lantern fails
- 6 other Lean clients (ream, ethlambda, zeam, nlean, lstar, lantern internally) interop with lantern without issue

## Root cause

In `go-libp2p-pubsub v0.15.0`, peer state — including the trigger that announces our subscriptions to a new peer — is hooked into the **outbound stream lifecycle only** (the `AddPeer` callback fires when the outbound stream to a peer opens).

If the first outbound stream tears down before pubsub flushes its queued SUBSCRIBE frames, pubsub still considers the peer "added" when a second outbound stream attaches, and `AddPeer` does not re-fire. The peer never learns our subscription set.

In lantern's log we see exactly this:

- Lantern accepts an initial `/meshsub/1.1.0` stream from gean → immediate `gossipsub stream error: -6`
- A second `/meshsub/1.1.0` stream from gean attaches successfully
- Lantern reads publish frames on that second stream — but no SUBSCRIBE frame ever arrives
- Lantern's subscription registry for gean stays at `topics_count=0`
- All subsequent publishes are dropped

Upstream fix: [`libp2p/go-libp2p-pubsub#691`](https://github.com/libp2p/go-libp2p-pubsub/pull/691) (merged 2026-04-17, shipped in `v0.16.0`) splits inbound vs outbound stream lifecycles and re-triggers subscription state on reattach. [`#692`](https://github.com/libp2p/go-libp2p-pubsub/pull/692) (same release) renames the existing peer hooks to make the outbound-vs-inbound split explicit (`OnNewOutboundStream`, `OnClosedOutboundStream`, `OnNewIncomingStream`, `OnClosedIncomingStream`).

The bug is gean-specific within the Lean ecosystem because gean is the only Lean client running `go-libp2p-pubsub`. Ream/ethlambda/zeam use `rust-libp2p`; lantern uses `libp2p-c`. Lantern's `libp2p-c` handshake pattern just happens to trigger v0.15.0's stream-lifecycle race; other client pairs don't expose it.

## Fix

Bump `github.com/libp2p/go-libp2p-pubsub` from `v0.15.0` to `v0.16.0`.

No gean code changes needed. The pubsub API surface gean uses (`NewGossipSub`, `WithMessageSignaturePolicy`, `WithNoAuthor`, `WithMessageIdFn`, `WithGossipSubParams`, `WithSeenMessagesTTL`, `WithMaxMessageSize`, `pubsub.Join`, `topic.Subscribe`) is unchanged between the two releases. The renamed methods in PR #692 are in the extension/tracer interface that gean does not use. `go-libp2p` requirement (`v0.39.1`) is satisfied by our pin (`v0.48.0`) — no transitive bump needed.

## Verification

Local:

- [x] `go build ./...` clean
- [x] `go test ./p2p/... ./node/... ./statetransition/... ./types/... -count=10` passes
- [x] No transitive `go.mod`/`go.sum` churn beyond the pubsub line itself

Hive — multi-client interop (gean + lantern filtered):

- [ ] **In progress** at time of opening this PR. Suite 2 (client-interop) expected to complete shortly.
- [ ] Pre/post `drop publish for unsubscribed peer` count comparison (target: post-bump → 0)
- [ ] 3-node interop (2 gean + 1 lantern): all nodes `finalized_slot > 0` (target: lantern no longer stuck at 0)
- [ ] 3-node interop (1 gean + 2 lantern): all nodes `finalized_slot > 0`

Results will be added as a comment on this PR once the hive run completes.

## Risk

`v0.16.0` introduces the Partial Messages Extension (PRs #631, #656-663, #669, #671, #683-685, #690). This is an opt-in feature gean does not wire up, so it is dormant in our build. The non-extension changes between v0.15.0 and v0.16.0 are:

- #673: threadsafe dynamic direct peer handling (additive)
- #676: FanoutOnly topic option (opt-in)
- #678: WithMessageFilter option (opt-in)
- #691 + #692: the stream-lifecycle split this PR is adopting
- #694: log message fix (cosmetic)

None of these should regress existing gean behavior. The largest churn is in `pubsub.go` (+60/-20) and `comm.go` (+40/-11), both within the stream-lifecycle refactor.

## Test plan

- [ ] `go build ./...` clean (already done locally)
- [ ] `go test ./p2p/... ./node/... -count=10` passes (already done locally)
- [ ] `make docker-build` succeeds against this branch's HEAD
- [ ] Hive gean+lantern run shows zero `drop publish for unsubscribed peer=<gean>` lines
- [ ] Hive 3-node interop (2 gean + 1 lantern) reaches `finalized_slot > 0` for all nodes
- [ ] Hive 3-node interop (1 gean + 2 lantern) reaches `finalized_slot > 0` for all nodes
- [ ] Combined-state hive run with PR #261's changes + this bump together passes
- [ ] Dashboard score reflects improvement on next rebuild