### PR TITLE
Fix/forkchoice anchor parent root

### DIFF
--- a/api/test_driver.go
+++ b/api/test_driver.go
@@ -252,7 +252,7 @@ func (sess *TestDriverSession) ForkChoiceInitHandler() http.HandlerFunc {
 		store.SetLatestFinalized(anchorCp)
 		store.StorePendingBlock(anchorRoot, &types.SignedBlock{Block: anchorBlock})
 
-		fc := forkchoice.New(anchorBlock.Slot, anchorRoot)
+		fc := forkchoice.New(anchorBlock.Slot, anchorRoot, anchorBlock.ParentRoot)
 
 		sess.mu.Lock()
 		sess.store = store

--- a/cmd/gean/main.go
+++ b/cmd/gean/main.go
@@ -179,7 +179,7 @@ func main() {
 
 	headRoot := s.Head()
 	headHeader := s.GetBlockHeader(headRoot)
-	fc := forkchoice.New(headHeader.Slot, headRoot)
+	fc := forkchoice.New(headHeader.Slot, headRoot, headHeader.ParentRoot)
 
 	// --- Initialize P2P ---
 

--- a/forkchoice/forkchoice.go
+++ b/forkchoice/forkchoice.go
@@ -7,9 +7,9 @@ type ForkChoice struct {
 }
 
 // New creates a ForkChoice initialized with an anchor block.
-func New(anchorSlot uint64, anchorRoot [32]byte) *ForkChoice {
+func New(anchorSlot uint64, anchorRoot, anchorParentRoot [32]byte) *ForkChoice {
 	return &ForkChoice{
-		Array: NewProtoArray(anchorSlot, anchorRoot),
+		Array: NewProtoArray(anchorSlot, anchorRoot, anchorParentRoot),
 		Votes: NewVoteStore(),
 	}
 }

--- a/forkchoice/forkchoice_test.go
+++ b/forkchoice/forkchoice_test.go
@@ -121,7 +121,7 @@ func TestSpecLMDGhostTiebreakLexicographic(t *testing.T) {
 
 func TestProtoArrayLinearChain(t *testing.T) {
 	rootA, rootB, rootC := root(1), root(2), root(3)
-	fc := New(0, rootA)
+	fc := New(0, rootA, [32]byte{})
 	fc.OnBlock(1, rootB, rootA)
 	fc.OnBlock(2, rootC, rootB)
 
@@ -136,7 +136,7 @@ func TestProtoArrayLinearChain(t *testing.T) {
 
 func TestProtoArrayForkHeavier(t *testing.T) {
 	rootA, rootB, rootC := root(1), root(2), root(3)
-	fc := New(0, rootA)
+	fc := New(0, rootA, [32]byte{})
 	fc.OnBlock(1, rootB, rootA)
 	fc.OnBlock(1, rootC, rootA)
 
@@ -155,7 +155,7 @@ func TestProtoArrayTiebreakLexicographic(t *testing.T) {
 	rootA := root(1)
 	rootB := root(2)
 	rootC := root(3) // larger -> wins
-	fc := New(0, rootA)
+	fc := New(0, rootA, [32]byte{})
 	fc.OnBlock(1, rootB, rootA)
 	fc.OnBlock(1, rootC, rootA)
 
@@ -170,7 +170,7 @@ func TestProtoArrayTiebreakLexicographic(t *testing.T) {
 
 func TestProtoArrayNoAttestations(t *testing.T) {
 	rootA := root(1)
-	fc := New(0, rootA)
+	fc := New(0, rootA, [32]byte{})
 	head := fc.UpdateHead(rootA)
 	if head != rootA {
 		t.Fatalf("expected rootA with no attestations, got %x", head[:4])
@@ -179,7 +179,7 @@ func TestProtoArrayNoAttestations(t *testing.T) {
 
 func TestProtoArrayVoteChange(t *testing.T) {
 	rootA, rootB, rootC := root(1), root(2), root(3)
-	fc := New(0, rootA)
+	fc := New(0, rootA, [32]byte{})
 	fc.OnBlock(1, rootB, rootA)
 	fc.OnBlock(1, rootC, rootA)
 
@@ -200,7 +200,7 @@ func TestProtoArrayVoteChange(t *testing.T) {
 
 func TestProtoArrayPrune(t *testing.T) {
 	rootA, rootB, rootC := root(1), root(2), root(3)
-	fc := New(0, rootA)
+	fc := New(0, rootA, [32]byte{})
 	fc.OnBlock(1, rootB, rootA)
 	fc.OnBlock(2, rootC, rootB)
 
@@ -226,7 +226,7 @@ func TestProtoArrayDeepChain(t *testing.T) {
 	for i := range roots {
 		roots[i] = root(byte(i + 1))
 	}
-	fc := New(0, roots[0])
+	fc := New(0, roots[0], [32]byte{})
 	for i := 1; i < 10; i++ {
 		fc.OnBlock(uint64(i), roots[i], roots[i-1])
 	}
@@ -257,7 +257,7 @@ func TestDebugOracleLinearChain(t *testing.T) {
 	specHead, _ := SpecComputeLMDGhostHead(rootA, blocks, attestations, 0)
 
 	// Proto-array
-	fc := New(0, rootA)
+	fc := New(0, rootA, [32]byte{})
 	fc.OnBlock(1, rootB, rootA)
 	fc.OnBlock(2, rootC, rootB)
 	fc.Votes.SetKnown(0, fc.NodeIndex(rootC), 2, makeAttData(rootC, 2))
@@ -284,7 +284,7 @@ func TestDebugOracleFork(t *testing.T) {
 	}
 	specHead, _ := SpecComputeLMDGhostHead(rootA, blocks, attestations, 0)
 
-	fc := New(0, rootA)
+	fc := New(0, rootA, [32]byte{})
 	fc.OnBlock(1, rootB, rootA)
 	fc.OnBlock(1, rootC, rootA)
 	fc.Votes.SetKnown(0, fc.NodeIndex(rootB), 1, makeAttData(rootB, 1))
@@ -313,7 +313,7 @@ func TestDebugOracleTiebreak(t *testing.T) {
 	}
 	specHead, _ := SpecComputeLMDGhostHead(rootA, blocks, attestations, 0)
 
-	fc := New(0, rootA)
+	fc := New(0, rootA, [32]byte{})
 	fc.OnBlock(1, rootB, rootA)
 	fc.OnBlock(1, rootC, rootA)
 	fc.Votes.SetKnown(0, fc.NodeIndex(rootB), 1, makeAttData(rootB, 1))
@@ -329,7 +329,7 @@ func TestReorgDepth(t *testing.T) {
 	// Anchor (slot 0) -> A (slot 1) -> A2 (slot 2) -> A3 (slot 3)
 	//                  \-> B (slot 1) -> B2 (slot 2)
 	anchor, a, a2, a3, b, b2 := root(1), root(2), root(3), root(4), root(5), root(6)
-	fc := New(0, anchor)
+	fc := New(0, anchor, [32]byte{})
 	fc.OnBlock(1, a, anchor)
 	fc.OnBlock(2, a2, a)
 	fc.OnBlock(3, a3, a2)
@@ -358,5 +358,37 @@ func TestReorgDepth(t *testing.T) {
 					tc.oldHead[:1], tc.newHead[:1], got, tc.wantDepth)
 			}
 		})
+	}
+}
+
+func TestAnchorParentRootPreserved(t *testing.T) {
+	anchorRoot := root(7)
+	anchorParent := root(6)
+
+	fc := New(12, anchorRoot, anchorParent)
+
+	nodes := fc.Array.Nodes()
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 anchor node, got %d", len(nodes))
+	}
+	if nodes[0].ParentRoot != anchorParent {
+		t.Fatalf("anchor ParentRoot = %x, want %x", nodes[0].ParentRoot, anchorParent)
+	}
+	if nodes[0].Root != anchorRoot {
+		t.Fatalf("anchor Root = %x, want %x", nodes[0].Root, anchorRoot)
+	}
+	if nodes[0].Slot != 12 {
+		t.Fatalf("anchor Slot = %d, want 12", nodes[0].Slot)
+	}
+}
+
+func TestGenesisAnchorParentRootZero(t *testing.T) {
+	genesisRoot := root(1)
+
+	fc := New(0, genesisRoot, [32]byte{})
+
+	nodes := fc.Array.Nodes()
+	if nodes[0].ParentRoot != ([32]byte{}) {
+		t.Fatalf("genesis ParentRoot = %x, want zero", nodes[0].ParentRoot)
 	}
 }

--- a/forkchoice/protoarray.go
+++ b/forkchoice/protoarray.go
@@ -20,14 +20,14 @@ type ProtoArray struct {
 }
 
 // NewProtoArray creates a proto-array with an anchor block.
-func NewProtoArray(anchorSlot uint64, anchorRoot [32]byte) *ProtoArray {
+func NewProtoArray(anchorSlot uint64, anchorRoot, anchorParentRoot [32]byte) *ProtoArray {
 	pa := &ProtoArray{
 		indices: make(map[[32]byte]int),
 	}
 	pa.nodes = append(pa.nodes, ProtoNode{
 		Slot:           anchorSlot,
 		Root:           anchorRoot,
-		ParentRoot:     [32]byte{},
+		ParentRoot:     anchorParentRoot,
 		Parent:         -1,
 		Weight:         0,
 		BestChild:      -1,

--- a/forkchoice/votes_test.go
+++ b/forkchoice/votes_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestRemapIndicesAfterPrune(t *testing.T) {
 	// Setup: 5 nodes [A(0), B(1), C(2), D(3), E(4)]
-	fc := New(0, [32]byte{0xAA})
+	fc := New(0, [32]byte{0xAA}, [32]byte{})
 	fc.OnBlock(1, [32]byte{0xBB}, [32]byte{0xAA})
 	fc.OnBlock(2, [32]byte{0xCC}, [32]byte{0xBB})
 	fc.OnBlock(3, [32]byte{0xDD}, [32]byte{0xCC})
@@ -74,7 +74,7 @@ func TestRemapIndicesAfterPrune(t *testing.T) {
 }
 
 func TestRemapIndicesPrunedVotesInvalidated(t *testing.T) {
-	fc := New(0, [32]byte{0xAA})
+	fc := New(0, [32]byte{0xAA}, [32]byte{})
 	fc.OnBlock(1, [32]byte{0xBB}, [32]byte{0xAA})
 	fc.OnBlock(2, [32]byte{0xCC}, [32]byte{0xBB})
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -42,7 +42,7 @@ func makeTestEngine() *Engine {
 	}
 	s.InsertState(genesisRoot, genesisState)
 
-	fc := forkchoice.New(0, genesisRoot)
+	fc := forkchoice.New(0, genesisRoot, [32]byte{})
 
 	return New(s, fc, nil, nil, NewAggregatorController(false), 1)
 }

--- a/spectests/api_test.go
+++ b/spectests/api_test.go
@@ -131,7 +131,7 @@ func runAPIFixture(t *testing.T, fx apiFixture) {
 	s.InsertBlockHeader(blockRoot, header)
 	s.InsertState(blockRoot, state)
 
-	fc := forkchoice.New(0, blockRoot)
+	fc := forkchoice.New(0, blockRoot, [32]byte{})
 
 	// Per-fixture aggregator controller, seeded from initialIsAggregator
 	// (leanSpec PR #636). Nil means the fixture doesn't exercise the admin

--- a/spectests/forkchoice_test.go
+++ b/spectests/forkchoice_test.go
@@ -447,7 +447,7 @@ func runForkChoiceTest(t *testing.T, tt *fcTest) {
 	s.StorePendingBlock(anchorRoot, anchorSigned)
 
 	// 3. Initialize fork choice with anchor.
-	fc := forkchoice.New(anchorBlock.Slot, anchorRoot)
+	fc := forkchoice.New(anchorBlock.Slot, anchorRoot, anchorBlock.ParentRoot)
 
 	// Label -> root map for resolving blockRootLabel references.
 	labelRoots := make(map[string][32]byte)

--- a/types/xmss_signature.go
+++ b/types/xmss_signature.go
@@ -19,9 +19,9 @@ import "encoding/binary"
 // path starts at byte 36, hashes start at 36 + 1028 = 1064.
 // path's siblings list body starts at offset 4 within the path container.
 const (
-	signaturePathOffset           uint32 = 36
-	signatureHashesOffset         uint32 = 1064
-	signaturePathSiblingsOffset   uint32 = 4
+	signaturePathOffset         uint32 = 36
+	signatureHashesOffset       uint32 = 1064
+	signaturePathSiblingsOffset uint32 = 4
 )
 
 // BlankXMSSSignature returns an SSZ-structurally-valid placeholder XMSS


### PR DESCRIPTION
## Description

`forkchoice.New` discarded the anchor block's parent root by always storing `[32]byte{}` in the anchor `ProtoNode.ParentRoot`. For genesis (slot 0) this is correct — genesis has no parent. For **checkpoint sync**, the anchor is a mid-chain block with a real, non-zero `parent_root` from its header; discarding it caused `GET /lean/v0/fork_choice` to report `nodes[head].parent_root = 0x000…` instead of the real parent.

The hive test `reqresp/blocks_by_root/single_known_block` reads the head node's `parent_root` from `/fork_choice`, then requests that block via reqresp `BlocksByRoot`, then asserts they match. With the bug, `BlocksByRoot` returned the correct parent (`0xb7785e…` from the stored block) while `/fork_choice` reported zero. ream (the only client at 21/21 on this suite) does not have this bug; zeam (`pkgs/node/src/forkchoice.zig:344`) and ethlambda (`crates/storage/src/store.rs:572`) both preserve the anchor's parent_root in their equivalents.

### Fix

- `forkchoice.New(anchorSlot, anchorRoot, anchorParentRoot)` threads the parent through.
- `NewProtoArray(anchorSlot, anchorRoot, anchorParentRoot)` stores it in the anchor `ProtoNode`.
- `cmd/gean/main.go` passes `headHeader.ParentRoot` — zero on genesis, real on checkpoint sync.
- 4 test call sites updated: 2 pass `[32]byte{}` (genesis-equivalent), 2 pass `anchorBlock.ParentRoot` (generic).

## Associated Issue

Refs #264 — this PR closes 1 of gean's 4 dashboard `reqresp` failures (`blocks_by_root/single_known_block`). The remaining 3 (the `multiple_known_blocks` and `blocks_by_range` timeout cluster) are tracked separately in #264 since they appear to be a different bug shared with nlean and ethlambda.

## Test Plan

- New unit tests in `forkchoice/forkchoice_test.go`:
  - `TestAnchorParentRootPreserved` — slot-12 anchor with non-zero parent → asserts `nodes[0].ParentRoot` matches.
  - `TestGenesisAnchorParentRootZero` — slot-0 anchor with zero parent → asserts it stays zero.
- Existing `forkchoice.New(slot, root)` call sites updated to compile against the new signature; genesis cases preserved bit-for-bit.
- Expected hive dashboard delta after merge: `reqresp/blocks_by_root/single_known_block` FAIL → PASS, gean total 17/21 → 18/21.

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) (if applicable)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
