### PR TITLE
chore(spec): bump leanSpec pin 00556d8 → 1589f87 (#273)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ run-node2: build ## Run node2 on port 9002
 
 # --- leanSpec fixtures ---
 
-LEAN_SPEC_COMMIT_HASH := 00556d8
+LEAN_SPEC_COMMIT_HASH := 1589f87
 
 leanSpec: ## Clone leanSpec at pinned main commit (contains devnet-4 changes)
 	git clone https://github.com/leanEthereum/leanSpec.git --single-branch

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ gean targets **Lean Consensus devnet-4**.
 
 | Network | Status | Spec pin |
 |---------|--------|----------|
-| devnet-4 | Active | `leanSpec@70fc774` |
+| devnet-4 | Active | `leanSpec@1589f87` |
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Bump `LEAN_SPEC_COMMIT_HASH` and the README pin display from `00556d8` / `70fc774` to leanSpec main HEAD `1589f87`. Closes a 15-commit lag on the committed Makefile pin and a 25-commit lag on the README pin display. Fixes #273.

## Range covered

- Committed pin → HEAD: 15 commits (`00556d8` → `1589f87`)
- Devnet 3 → HEAD: 204 commits

leanSpec HEAD commit `1589f87` is PR [leanEthereum/leanSpec#732](https://github.com/leanEthereum/leanSpec/pull/732) "refactor(types): centralize proposer selection on ValidatorIndex" (2026-05-18).

## New fork-choice fixture categories the bump pulls in

Under `tests/consensus/lstar/fc/`:

- `test_attestation_source_divergence`
- `test_block_attestation_limits`
- `test_block_production`
- `test_checkpoint_sync`
- `test_duplicate_attestation_data`
- `test_equivocation`
- `test_finalization_mid_processing`
- `test_gossip_aggregated_attestation_validation`
- `test_safe_target`
- `test_store_pruning`
- `test_tick_system`

## Files changed

- `Makefile:106` — `LEAN_SPEC_COMMIT_HASH := 00556d8` → `1589f87`
- `README.md:23` — pin display `leanSpec@70fc774` → `leanSpec@1589f87`

No code changes. Fixture regeneration runs in CI via `make leanSpec/fixtures` (Makefile target unchanged; same `uv run fill --fork lstar --scheme=prod`).

## Stack notice

This PR is stacked on `fix/test-driver-safe-target-refresh` (PR #279, fixes #278) so the new `test_safe_target` fixtures actually pass when CI runs the spec suite. Once #279 merges, this PR will retarget to `devnet-4` automatically (GitHub) or via a one-time rebase.

If you prefer to merge this independently and have #279 follow, retargeting this PR to `devnet-4` and rebasing onto it is safe — the two PRs touch disjoint files.

## Test plan

- [x] `go vet ./...` clean.
- [x] All three pin sources aligned: `Makefile`, `README.md`, and the local `leanSpec/` working copy all at `1589f87`.
- [ ] CI runs `make leanSpec/fixtures` → confirms the 11 new lstar/fc categories materialize.
- [ ] CI runs `go test -tags spectests ./spectests/...` → captures baseline. Any new failures attributable to conformance gaps already have follow-up issues filed:
    - #275 — proposer-index dedup (leanSpec #732)
    - #276 — `build_block` filter reorder (leanSpec #718)
    - #277 — `start_root` assertion in LMD-GHOST head walk (leanSpec #727)
    - #278 — stale `safeTarget` in `/fork_choice/step` (this PR's parent, #279)

## Related

- Closes #273
- Stacked on / depends on: #279 (fixes #278)
- Follow-up conformance issues that may surface in the regenerated fixture suite: #275, #276, #277
