### PR TITLE
feat(genesis): accept optional NUM_VALIDATORS with consistency check (#274)

### DIFF
--- a/genesis/config.go
+++ b/genesis/config.go
@@ -19,7 +19,14 @@ type GenesisValidatorEntry struct {
 
 // GenesisConfig is parsed from config.yaml.
 type GenesisConfig struct {
-	GenesisTime       uint64                  `yaml:"GENESIS_TIME"`
+	GenesisTime uint64 `yaml:"GENESIS_TIME"`
+	// NumValidators mirrors the spec's optional NUM_VALIDATORS field
+	// (Uint64 | None). When present, it must equal len(GenesisValidators);
+	// LoadGenesisConfig rejects the config otherwise. Absent in standard
+	// lean-quickstart configs, so cross-client configs that include it
+	// fail loudly rather than silently disagreeing on validator count.
+	// Spec: lean_spec/subspecs/genesis/config.py num_validators
+	NumValidators     *uint64                 `yaml:"NUM_VALIDATORS,omitempty"`
 	GenesisValidators []GenesisValidatorEntry `yaml:"GENESIS_VALIDATORS"`
 }
 
@@ -90,6 +97,10 @@ func LoadGenesisConfig(path string) (*GenesisConfig, error) {
 	}
 	if len(config.GenesisValidators) == 0 {
 		return nil, fmt.Errorf("GENESIS_VALIDATORS is empty")
+	}
+	if config.NumValidators != nil && *config.NumValidators != uint64(len(config.GenesisValidators)) {
+		return nil, fmt.Errorf("NUM_VALIDATORS=%d disagrees with len(GENESIS_VALIDATORS)=%d",
+			*config.NumValidators, len(config.GenesisValidators))
 	}
 	return &config, nil
 }

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -89,3 +89,35 @@ func TestLoadGenesisConfigMissing(t *testing.T) {
 		t.Fatal("should error on missing file")
 	}
 }
+
+// TestLoadGenesisConfigNumValidatorsConsistent verifies that an optional
+// NUM_VALIDATORS field equal to len(GENESIS_VALIDATORS) is accepted and
+// surfaces on the parsed struct.
+func TestLoadGenesisConfigNumValidatorsConsistent(t *testing.T) {
+	tmpFile := t.TempDir() + "/config.yaml"
+	os.WriteFile(tmpFile, []byte("NUM_VALIDATORS: 3\n"+testConfigYAML), 0644)
+
+	config, err := LoadGenesisConfig(tmpFile)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if config.NumValidators == nil {
+		t.Fatal("NumValidators should be parsed when NUM_VALIDATORS is set")
+	}
+	if *config.NumValidators != 3 {
+		t.Fatalf("NumValidators: expected 3, got %d", *config.NumValidators)
+	}
+}
+
+// TestLoadGenesisConfigNumValidatorsMismatch verifies that a mismatched
+// NUM_VALIDATORS rejects the config rather than silently dropping it.
+// Matches the spec's assertion behavior — see leanSpec subspecs/genesis/config.py.
+func TestLoadGenesisConfigNumValidatorsMismatch(t *testing.T) {
+	tmpFile := t.TempDir() + "/config.yaml"
+	os.WriteFile(tmpFile, []byte("NUM_VALIDATORS: 5\n"+testConfigYAML), 0644)
+
+	_, err := LoadGenesisConfig(tmpFile)
+	if err == nil {
+		t.Fatal("expected error when NUM_VALIDATORS disagrees with len(GENESIS_VALIDATORS)")
+	}
+}


### PR DESCRIPTION
## Summary

Adds an optional `NumValidators *uint64` field to `GenesisConfig` with a consistency check in `LoadGenesisConfig`. Closes the spec-conformance gap reported in #274 — gean previously dropped `NUM_VALIDATORS` from cross-client configs silently.

leanSpec's `GenesisConfig` declares `num_validators: Uint64 | None` and asserts `num_validators == len(genesis_validators)` when set. This PR mirrors that semantics for gean.

## What changed

`genesis/config.go`:
- Adds `NumValidators *uint64` field with `yaml:"NUM_VALIDATORS,omitempty"` tag.
- Adds one validation in `LoadGenesisConfig` returning an error when the field is present and disagrees with `len(GenesisValidators)`.

`genesis/genesis_test.go`:
- `TestLoadGenesisConfigNumValidatorsConsistent` — verifies the happy path (`NUM_VALIDATORS: 3` with 3 validators) parses and surfaces on the struct.
- `TestLoadGenesisConfigNumValidatorsMismatch` — verifies a mismatch (`NUM_VALIDATORS: 5` with 3 validators) is rejected.

Behavior on the standard lean-quickstart `config.yaml` is unchanged — that config has no `NUM_VALIDATORS`, so the new pointer stays nil and validation is skipped.

## Stack notice

This PR is opened against `fix/test-driver-safe-target-refresh` per request. Its head branch (`feat/genesis-num-validators`) is two commits ahead of the base:

```
fix/test-driver-safe-target-refresh
   ├─ cdca06e  chore(spec): bump leanSpec pin 00556d8 → 1589f87 (#273)   ← also in PR #280
   └─ caff369  feat(genesis): accept optional NUM_VALIDATORS … (#274)    ← unique to this PR
```

So the PR diff shows **both** commits. Once PR #280 merges into `fix/test-driver-safe-target-refresh`, the diff here collapses to the single `caff369` commit. Alternative: retarget this PR to `chore/bump-leanspec-pin-1589f87` for a clean single-commit diff. Either way the final merged state is identical.

## Test plan

- [x] `gofmt` clean.
- [x] `go vet ./...` clean.
- [x] `go test ./genesis/...` — all 4 existing tests + 2 new tests pass.
- [x] `make test` (full unit suite excluding xmss / spectests / cmd) — all 9 packages green.

## Cross-client reference

ethlambda has the same gap at `crates/common/types/src/genesis.rs:14-20` (only `GENESIS_TIME` and `GENESIS_VALIDATORS`; no `NUM_VALIDATORS`). This PR closes the gap for gean first; ethlambda can mirror the pattern.

## Related

- Closes #274
- Stacked on / base depends on: #279 (fixes #278), #280 (closes #273)
- Spec reference: `leanSpec/src/lean_spec/subspecs/genesis/config.py:82-112`
