### PR TITLE
refactor(types): centralize slot % numValidators in ProposerIndex (#275)

### DIFF
--- a/statetransition/block.go
+++ b/statetransition/block.go
@@ -31,7 +31,7 @@ func ProcessBlockHeader(state *types.State, block *types.Block) error {
 	}
 
 	// Proposer must be correct: slot % num_validators.
-	expectedProposer := block.Slot % numValidators
+	expectedProposer := types.ProposerIndex(block.Slot, numValidators)
 	if block.ProposerIndex != expectedProposer {
 		return &InvalidProposerError{Expected: expectedProposer, Found: block.ProposerIndex}
 	}

--- a/types/helpers.go
+++ b/types/helpers.go
@@ -9,20 +9,18 @@ func IsZeroRoot(root [RootSize]byte) bool {
 	return root == ZeroRoot
 }
 
+// ProposerIndex returns the proposer index for a slot.
+// Caller must ensure numValidators > 0.
+func ProposerIndex(slot, numValidators uint64) uint64 {
+	return slot % numValidators
+}
+
 // IsProposer returns true if validatorIndex is the proposer for the given slot.
 func IsProposer(slot, validatorIndex, numValidators uint64) bool {
 	if numValidators == 0 {
 		return false
 	}
-	return slot%numValidators == validatorIndex
-}
-
-// ProposerIndex returns the proposer for a slot, or -1 if no validators.
-func ProposerIndex(slot, numValidators uint64) int64 {
-	if numValidators == 0 {
-		return -1
-	}
-	return int64(slot % numValidators)
+	return ProposerIndex(slot, numValidators) == validatorIndex
 }
 
 // ShortRoot returns the first 4 bytes of a root as hex for logging.

--- a/types/helpers_test.go
+++ b/types/helpers_test.go
@@ -29,9 +29,6 @@ func TestProposerIndex(t *testing.T) {
 	if ProposerIndex(7, 3) != 1 {
 		t.Fatal("expected proposer 1 for slot 7 with 3 validators")
 	}
-	if ProposerIndex(0, 0) != -1 {
-		t.Fatal("expected -1 for 0 validators")
-	}
 }
 
 func TestIsZeroRoot(t *testing.T) {


### PR DESCRIPTION
## Summary

Collapses `slot % num_validators` into a single helper so the rule cannot drift. Closes #275 (mirrors leanSpec PR [#732](https://github.com/leanEthereum/leanSpec/pull/732)).

## What changed

- `types/helpers.go` — `ProposerIndex` returns `uint64` directly (drops the `-1` sentinel; no callers depended on it). `IsProposer` delegates to `ProposerIndex`, so both share one formula in one place.
- `statetransition/block.go:34` — replaces the inline `block.Slot % numValidators` with `types.ProposerIndex(block.Slot, numValidators)`. The existing `numValidators == 0` guard at `block.go:18-19` protects the call.
- `types/helpers_test.go` — drops the obsolete `-1` sentinel assertion; the positive-case test remains.

Net: **+8 / -13**.

## Cross-client reference

ethlambda has no equivalent duplication — it reads `block.proposer_index` directly from the header. This PR brings gean closer to that shape by routing the only remaining arithmetic site through the existing helper.

## Stack notice

Opened against `fix/test-driver-safe-target-refresh` per request. The diff visible on the PR is just the three files above; commits unique to PRs #280 and #281 in the lineage are auto-deduped by GitHub (same as #281 did against this base).

## Test plan

- [x] `go vet ./...` clean.
- [x] `go test ./...` (excl. xmss / spectests / cmd) — all 9 packages green.
- [x] Existing `TestIsProposer` table-driven tests still pass — proves behavioral identity on the positive and zero-validator branches.

## Related

- Closes #275
- Stack root: PR #279 (fixes #278)
- Siblings: #280 (closes #273), #281 (closes #274)
