### PR TITLE
fix(node): run chain-match before source-justified in build_block (#276)

### DIFF
--- a/node/store_build.go
+++ b/node/store_build.go
@@ -151,10 +151,13 @@ func buildBlock(
 				// already be justified (genesis self-votes excepted for
 				// fork-choice bootstrapping).
 				finalizedSlot := headState.LatestFinalized.Slot
-				if !statetransition.IsSlotJustified(headState, finalizedSlot, item.entry.Data.Source.Slot) {
+				// Chain-match runs first (leanSpec PR #718): the bounded slot
+				// queries below assume source/target slots are within the
+				// chain view, which chain-match enforces.
+				if !attestationDataMatchesChain(headState, item.entry.Data) {
 					continue
 				}
-				if !attestationDataMatchesChain(headState, item.entry.Data) {
+				if !statetransition.IsSlotJustified(headState, finalizedSlot, item.entry.Data.Source.Slot) {
 					continue
 				}
 				isGenesisSelfVote := item.entry.Data.Source.Slot == 0 && item.entry.Data.Target.Slot == 0


### PR DESCRIPTION
## Summary

Swaps the two attestation filters in `build_block` so chain-match runs before source-justified, matching leanSpec PR [#718](https://github.com/leanEthereum/leanSpec/pull/718). Closes #276.

## What changed

`node/store_build.go:154-163`:

```diff
 finalizedSlot := headState.LatestFinalized.Slot
-if !statetransition.IsSlotJustified(headState, finalizedSlot, item.entry.Data.Source.Slot) {
+// Chain-match runs first (leanSpec PR #718): the bounded slot
+// queries below assume source/target slots are within the
+// chain view, which chain-match enforces.
+if !attestationDataMatchesChain(headState, item.entry.Data) {
     continue
 }
-if !attestationDataMatchesChain(headState, item.entry.Data) {
+if !statetransition.IsSlotJustified(headState, finalizedSlot, item.entry.Data.Source.Slot) {
     continue
 }
```

Behaviorally identical today — `attestationDataMatchesChain` (`store_build.go:445-460`) bounds-checks internally, so the previous order didn't trip an out-of-range. The swap aligns gean with the spec's defense-in-depth contract (chain-match keeps slot queries in range before they happen).

## Cross-client reference

Same gap in ethlambda at `crates/blockchain/src/store.rs:1116-1135` (source-justified runs first there too). Fixing here first; ethlambda can mirror.

## Test plan

- [x] `go vet ./...` clean.
- [x] `make test` (excl. xmss / spectests / cmd) — all 9 packages green.
- [ ] New fixture `test_block_attestation_limits` (from leanSpec `1589f87`) — verifies in CI after #280 regenerates fixtures.

## Related

- Closes #276
- Stack root: #279 (fixes #278)
- Siblings: #280 (#273), #281 (#274), #282 (#275)
