### PR TITLE
fix(forkchoice): error on missing start_root in LMD-GHOST head (#277)

### DIFF
--- a/forkchoice/forkchoice_test.go
+++ b/forkchoice/forkchoice_test.go
@@ -70,7 +70,7 @@ func TestSpecLMDGhostLinearChain(t *testing.T) {
 		0: makeAttData(rootC, 2),
 	}
 
-	head, _ := SpecComputeLMDGhostHead(rootA, blocks, attestations, 0)
+	head, _, _ := SpecComputeLMDGhostHead(rootA, blocks, attestations, 0)
 	if head != rootC {
 		t.Fatalf("expected rootC, got %x", head[:4])
 	}
@@ -90,7 +90,7 @@ func TestSpecLMDGhostForkHeavier(t *testing.T) {
 		2: makeAttData(rootC, 1),
 	}
 
-	head, _ := SpecComputeLMDGhostHead(rootA, blocks, attestations, 0)
+	head, _, _ := SpecComputeLMDGhostHead(rootA, blocks, attestations, 0)
 	if head != rootB {
 		t.Fatalf("expected rootB (heavier), got %x", head[:4])
 	}
@@ -111,7 +111,7 @@ func TestSpecLMDGhostTiebreakLexicographic(t *testing.T) {
 		1: makeAttData(rootC, 1),
 	}
 
-	head, _ := SpecComputeLMDGhostHead(rootA, blocks, attestations, 0)
+	head, _, _ := SpecComputeLMDGhostHead(rootA, blocks, attestations, 0)
 	if head != rootC {
 		t.Fatalf("expected rootC (lexicographic tiebreak), got %x", head[:4])
 	}
@@ -254,7 +254,7 @@ func TestDebugOracleLinearChain(t *testing.T) {
 		0: makeAttData(rootC, 2),
 		1: makeAttData(rootB, 1),
 	}
-	specHead, _ := SpecComputeLMDGhostHead(rootA, blocks, attestations, 0)
+	specHead, _, _ := SpecComputeLMDGhostHead(rootA, blocks, attestations, 0)
 
 	// Proto-array
 	fc := New(0, rootA)
@@ -282,7 +282,7 @@ func TestDebugOracleFork(t *testing.T) {
 		1: makeAttData(rootB, 1),
 		2: makeAttData(rootC, 1),
 	}
-	specHead, _ := SpecComputeLMDGhostHead(rootA, blocks, attestations, 0)
+	specHead, _, _ := SpecComputeLMDGhostHead(rootA, blocks, attestations, 0)
 
 	fc := New(0, rootA)
 	fc.OnBlock(1, rootB, rootA)
@@ -311,7 +311,7 @@ func TestDebugOracleTiebreak(t *testing.T) {
 		0: makeAttData(rootB, 1),
 		1: makeAttData(rootC, 1),
 	}
-	specHead, _ := SpecComputeLMDGhostHead(rootA, blocks, attestations, 0)
+	specHead, _, _ := SpecComputeLMDGhostHead(rootA, blocks, attestations, 0)
 
 	fc := New(0, rootA)
 	fc.OnBlock(1, rootB, rootA)

--- a/forkchoice/spec.go
+++ b/forkchoice/spec.go
@@ -1,6 +1,10 @@
 package forkchoice
 
-import "github.com/geanlabs/gean/types"
+import (
+	"fmt"
+
+	"github.com/geanlabs/gean/types"
+)
 
 // Spec-compliant LMD GHOST implementation for testing.
 // Used as debug oracle to validate proto-array produces identical results.
@@ -31,14 +35,17 @@ func SpecComputeBlockWeights(
 }
 
 // SpecComputeLMDGhostHead computes the LMD GHOST head.
+// Returns an error when startRoot is not in blocks, matching leanSpec PR #727
+// which replaced a silent fallback with a hard assertion so malformed stores
+// fail loudly rather than masking the bug downstream.
 func SpecComputeLMDGhostHead(
 	startRoot [32]byte,
 	blocks map[[32]byte]BlockInfo,
 	attestations map[uint64]*types.AttestationData,
 	minScore uint64,
-) ([32]byte, map[[32]byte]uint64) {
+) ([32]byte, map[[32]byte]uint64, error) {
 	if len(blocks) == 0 {
-		return startRoot, nil
+		return startRoot, nil, nil
 	}
 
 	// If start root is zero, use the block with the lowest slot.
@@ -54,7 +61,7 @@ func SpecComputeLMDGhostHead(
 
 	startInfo, ok := blocks[startRoot]
 	if !ok {
-		return startRoot, nil
+		return [32]byte{}, nil, fmt.Errorf("start_root %x not in store.blocks", startRoot)
 	}
 	startSlot := startInfo.Slot
 
@@ -100,7 +107,7 @@ func SpecComputeLMDGhostHead(
 		head = best
 	}
 
-	return head, weights
+	return head, weights, nil
 }
 
 // BlockInfo is the minimal block data for spec fork choice.


### PR DESCRIPTION
## Summary

Adds an error return to `SpecComputeLMDGhostHead` so a missing `start_root` fails loudly instead of silently returning the input root with a nil weights map. Mirrors leanSpec PR [#727](https://github.com/leanEthereum/leanSpec/pull/727). Closes #277.

## What changed

`forkchoice/spec.go`:
- Signature: `([32]byte, map[[32]byte]uint64)` → `([32]byte, map[[32]byte]uint64, error)`.
- The `startRoot not in blocks` branch at `:55-61` now returns `fmt.Errorf("start_root %x not in store.blocks", startRoot)`.
- The empty-blocks early return at `:40-43` stays a no-op success (returns `nil` error) — "blocks is empty" is a distinct condition from "start_root absent from a non-empty store".
- Final happy return at `:107` returns `nil` error.

`forkchoice/forkchoice_test.go`:
- Six call sites updated from `_, _ :=` to `_, _, _ :=` (lines 73, 93, 114, 257, 285, 314).

Net: **+18 / −11**.

## Production-caller note

The issue body recommended updating "the production caller in `forkchoice/forkchoice.go`" to propagate or log the error. While implementing I found there is **no production caller** — `SpecComputeLMDGhostHead` is documented at `forkchoice/spec.go:6` as:

> Spec-compliant LMD GHOST implementation for testing.
> Used as debug oracle to validate proto-array produces identical results.

The real fork-choice path uses the proto-array implementation (`FC.Array.FindHead`). This function exists only so tests can cross-check proto-array output against a straightforward spec port. The 4th acceptance criterion in #277 is therefore N/A.

## Cross-client reference

Same gap in ethlambda at `crates/blockchain/fork_choice/src/lib.rs:37-54` (`return (start_root, HashMap::new())` when missing). Fixing in gean first; ethlambda can mirror.

## Test plan

- [x] `go vet ./...` clean.
- [x] `go test ./forkchoice/...` — all existing tests pass with the new signature.
- [x] `make test` (excl. xmss / spectests / cmd) — all 9 packages green.

## Related

- Closes #277
- Stack root: #279 (fixes #278)
- Siblings: #280 (#273), #281 (#274), #282 (#275), #283 (#276)
