### PR TITLE
fix(node): drop SyncSynced gate in maybePropose; rely on DutyGate

### DIFF
--- a/node/validator.go
+++ b/node/validator.go
@@ -21,15 +21,14 @@ func (e *Engine) maybePropose(slot, validatorID uint64) {
 		return
 	}
 
-	// Block production requires Synced. On SyncIdle/SyncSyncing we'd advance
-	// local fork-choice based only on our own block, divorced from the network.
-	if status := e.GetSyncStatus(); status != SyncSynced {
-		logger.Info(logger.Validator, "skipping block production slot=%d: sync status %s", slot, status)
-		return
-	}
-
-	// Sync-lag duty gate (leanSpec PR #708). Skip when the local view is
-	// too stale relative to a network that is otherwise making progress.
+	// Sync-lag duty gate (leanSpec PR #708) is the sole sync-state check.
+	// It closes when local lag > SyncLagThreshold against a producing
+	// network, and reopens automatically when the network itself stalls
+	// (maxStoredBlockSlot far behind wall-clock). This handles all three
+	// cases — synced, syncing-behind-a-live-network, isolated-stalling —
+	// in one place. Hive's single-client tests rely on the stall path:
+	// no helper mesh means maxStoredSlot stays at the anchor, the gate
+	// reopens, and the local validator produces.
 	if e.DutyGate != nil && !e.DutyGate.Decide("block", slot, e.Store.HeadSlot(), e.Store.MaxStoredBlockSlot()) {
 		IncBlocksSkippedLag()
 		return


### PR DESCRIPTION
## Summary

Removes a redundant `SyncSynced` gate in `maybePropose` that blocked block production on hive's single-client lean simulator runs. `DutyGate.Decide` already encodes the right policy for all three sync states via its `networkStalling` override.

Closes the three timeout failures in #264:
- `reqresp/blocks_by_root/multiple_known_blocks`
- `reqresp/blocks_by_range/single_known_block`
- `reqresp/blocks_by_range/multiple_known_blocks`

(Companion to PR #279, which merged in dimka90's `a4c31ab` to close the fourth #264 failure, `blocks_by_root/single_known_block`.)

## Why

Hive's lean simulator boots gean with `connect_client_to_lean_spec_mesh: false`. The only peer is a passive `MockNode` that does not gossip blocks. Wall-clock advances → gean's local head stays at the anchor → `computeSyncStatus` returns `SyncSyncing` → `maybePropose` short-circuits before reaching `DutyGate`. Gean never proposes, fork-choice never grows past the anchor, the three reqresp tests time out waiting for ≥2 fork-choice nodes within 180s.

`DutyGate.Decide` (sync_lag_gate.go:66-106, leanSpec PR #708) already has a `networkStalling` override: when `maxStoredBlockSlot` falls more than `NetworkStallThreshold` slots behind wall-clock, the gate reopens. For isolated boot, `maxStoredSlot` stays at the anchor (slot 0), `networkLag` becomes very large, the gate reopens, and the local validator produces. This is exactly the "I'm effectively the network" case the old `SyncSynced` check refused to consider.

The synced-behind-a-live-network case is still protected: DutyGate stays closed via its normal `SyncLagThreshold` + hysteresis path, so gean does not silently fork onto a one-validator chain divorced from a producing mesh.

## What changed

`node/validator.go` only — 8 lines added, 9 removed:

```diff
-	// Block production requires Synced. On SyncIdle/SyncSyncing we'd advance
-	// local fork-choice based only on our own block, divorced from the network.
-	if status := e.GetSyncStatus(); status != SyncSynced {
-		logger.Info(logger.Validator, "skipping block production slot=%d: sync status %s", slot, status)
-		return
-	}
-
-	// Sync-lag duty gate (leanSpec PR #708). Skip when the local view is
-	// too stale relative to a network that is otherwise making progress.
+	// Sync-lag duty gate (leanSpec PR #708) is the sole sync-state check.
+	// It closes when local lag > SyncLagThreshold against a producing
+	// network, and reopens automatically when the network itself stalls
+	// (maxStoredBlockSlot far behind wall-clock). This handles all three
+	// cases — synced, syncing-behind-a-live-network, isolated-stalling —
+	// in one place.
 	if e.DutyGate != nil && !e.DutyGate.Decide("block", slot, e.Store.HeadSlot(), e.Store.MaxStoredBlockSlot()) {
 		IncBlocksSkippedLag()
 		return
 	}
```

## Cross-client reference

ream passes 21/21 reqresp tests (per #264 dashboard standings). It produces unconditionally on its validator's proposer slot, with no sync-state gate — only its (lighter) per-slot proposer check. This PR moves gean toward ream's behavior while keeping the leanSpec PR #708 duty-gate as the local-lag safety net that nlean/ethlambda also share.

## Test plan

- [x] `go vet ./...` clean.
- [x] `make test` (excl. xmss / spectests / cmd) — all 9 packages green.
- [ ] Hive `reqresp` suite against gean rebuilt from this branch — expect the three timeout tests above to flip to pass.

## Related

- Closes #264 (the three timeout failures)
- Stacked on / base = `fix/test-driver-safe-target-refresh` (which already carries dimka90's `a4c31ab` from PR #279, fixing the fourth #264 failure)
