### PR TITLE
fix(node): suppress maybePropose on eager pre-loop tick (#288)

### DIFF
--- a/forkchoice/forkchoice_test.go
+++ b/forkchoice/forkchoice_test.go
@@ -178,23 +178,58 @@ func TestProtoArrayNoAttestations(t *testing.T) {
 }
 
 func TestProtoArrayVoteChange(t *testing.T) {
-	rootA, rootB, rootC := root(1), root(2), root(3)
+	rootA, rootB, rootC, rootD := root(1), root(2), root(3), root(4)
 	fc := New(0, rootA, [32]byte{})
 	fc.OnBlock(1, rootB, rootA)
 	fc.OnBlock(1, rootC, rootA)
+	fc.OnBlock(2, rootD, rootC)
 
-	// Initially vote for rootB
+	// Initially vote for rootB at slot 1.
 	fc.Votes.SetKnown(0, fc.NodeIndex(rootB), 1, makeAttData(rootB, 1))
 	head := fc.UpdateHead(rootA)
 	if head != rootB {
 		t.Fatalf("expected rootB initially, got %x", head[:4])
 	}
 
-	// Change vote to rootC
+	// Vote-change at a later slot is a normal target update — should move
+	// the head. (Same-slot re-vote with a different target is equivocation
+	// and is dropped; see TestProtoArrayEquivocation.)
+	fc.Votes.SetKnown(0, fc.NodeIndex(rootD), 2, makeAttData(rootD, 2))
+	head = fc.UpdateHead(rootA)
+	if head != rootD {
+		t.Fatalf("expected rootD after vote change, got %x", head[:4])
+	}
+}
+
+func TestProtoArrayEquivocation(t *testing.T) {
+	// Same-slot, different-target re-vote from one validator must be ignored
+	// (first-wins). Mirrors the spec fork-choice equivocation rule covered
+	// by the hive fixture test_same_slot_equivocating_attesters_count_once.
+	rootA, rootB, rootC := root(1), root(2), root(3)
+	fc := New(0, rootA, [32]byte{})
+	fc.OnBlock(1, rootB, rootA)
+	fc.OnBlock(1, rootC, rootA)
+
+	// First vote: validator 0 → rootB at slot 1.
+	fc.Votes.SetKnown(0, fc.NodeIndex(rootB), 1, makeAttData(rootB, 1))
+	head := fc.UpdateHead(rootA)
+	if head != rootB {
+		t.Fatalf("expected rootB after first vote, got %x", head[:4])
+	}
+
+	// Equivocating second vote: validator 0 → rootC at the same slot.
+	// Must be dropped; head stays on rootB.
 	fc.Votes.SetKnown(0, fc.NodeIndex(rootC), 1, makeAttData(rootC, 1))
 	head = fc.UpdateHead(rootA)
-	if head != rootC {
-		t.Fatalf("expected rootC after vote change, got %x", head[:4])
+	if head != rootB {
+		t.Fatalf("expected rootB to persist after equivocating vote, got %x", head[:4])
+	}
+
+	// Same equivocation rule on the SetNew (gossip) path.
+	fc.Votes.SetNew(1, fc.NodeIndex(rootB), 1, makeAttData(rootB, 1))
+	fc.Votes.SetNew(1, fc.NodeIndex(rootC), 1, makeAttData(rootC, 1))
+	if fc.Votes.Votes[1].LatestNew == nil || fc.Votes.Votes[1].LatestNew.Index != fc.NodeIndex(rootB) {
+		t.Fatalf("validator 1 LatestNew should pin to rootB, got %+v", fc.Votes.Votes[1].LatestNew)
 	}
 }
 

--- a/forkchoice/votes.go
+++ b/forkchoice/votes.go
@@ -28,15 +28,33 @@ func NewVoteStore() *VoteStore {
 }
 
 // SetKnown records a known (on-chain) attestation for a validator.
+// Equivocation: if either pool already holds a vote at this slot for a
+// different target, the new write is dropped — equivocating attesters
+// count exactly once and the first observed target wins.
 func (vs *VoteStore) SetKnown(validatorID uint64, nodeIndex int, slot uint64, data *types.AttestationData) {
 	tracker := vs.getOrCreate(validatorID)
+	if sameSlotConflict(tracker.LatestKnown, slot, nodeIndex) ||
+		sameSlotConflict(tracker.LatestNew, slot, nodeIndex) {
+		return
+	}
 	tracker.LatestKnown = &VoteTarget{Index: nodeIndex, Slot: slot, Data: data}
 }
 
 // SetNew records a new (gossip-received) attestation for a validator.
+// Same equivocation rule as SetKnown.
 func (vs *VoteStore) SetNew(validatorID uint64, nodeIndex int, slot uint64, data *types.AttestationData) {
 	tracker := vs.getOrCreate(validatorID)
+	if sameSlotConflict(tracker.LatestKnown, slot, nodeIndex) ||
+		sameSlotConflict(tracker.LatestNew, slot, nodeIndex) {
+		return
+	}
 	tracker.LatestNew = &VoteTarget{Index: nodeIndex, Slot: slot, Data: data}
+}
+
+// sameSlotConflict reports whether an existing vote at the same slot points
+// to a different proto-array node — i.e. the incoming write would equivocate.
+func sameSlotConflict(existing *VoteTarget, slot uint64, nodeIndex int) bool {
+	return existing != nil && existing.Slot == slot && existing.Index != nodeIndex
 }
 
 // PromoteNewToKnown moves all new votes to known.

--- a/forkchoice/votes.go
+++ b/forkchoice/votes.go
@@ -27,10 +27,8 @@ func NewVoteStore() *VoteStore {
 	return &VoteStore{Votes: make(map[uint64]*VoteTracker)}
 }
 
-// SetKnown records a known (on-chain) attestation for a validator.
-// Equivocation: if either pool already holds a vote at this slot for a
-// different target, the new write is dropped — equivocating attesters
-// count exactly once and the first observed target wins.
+// SetKnown records a known (on-chain) attestation. Same-slot writes
+// pointing to a different target are dropped (see sameSlotConflict).
 func (vs *VoteStore) SetKnown(validatorID uint64, nodeIndex int, slot uint64, data *types.AttestationData) {
 	tracker := vs.getOrCreate(validatorID)
 	if sameSlotConflict(tracker.LatestKnown, slot, nodeIndex) ||
@@ -40,8 +38,8 @@ func (vs *VoteStore) SetKnown(validatorID uint64, nodeIndex int, slot uint64, da
 	tracker.LatestKnown = &VoteTarget{Index: nodeIndex, Slot: slot, Data: data}
 }
 
-// SetNew records a new (gossip-received) attestation for a validator.
-// Same equivocation rule as SetKnown.
+// SetNew records a new (gossip-received) attestation. Same equivocation
+// guard as SetKnown.
 func (vs *VoteStore) SetNew(validatorID uint64, nodeIndex int, slot uint64, data *types.AttestationData) {
 	tracker := vs.getOrCreate(validatorID)
 	if sameSlotConflict(tracker.LatestKnown, slot, nodeIndex) ||

--- a/node/store_payloads.go
+++ b/node/store_payloads.go
@@ -96,9 +96,16 @@ func (pb *PayloadBuffer) TotalProofs() int {
 }
 
 // ExtractLatestAttestations returns per-validator latest attestations from participation bits.
+// Iterates by insertion order (pb.order) so same-slot ties resolve to the
+// first-inserted entry, mirroring the spec's insertion-ordered dict and
+// making equivocation handling deterministic (Go map iteration order is not).
 func (pb *PayloadBuffer) ExtractLatestAttestations() map[uint64]*types.AttestationData {
 	result := make(map[uint64]*types.AttestationData)
-	for _, entry := range pb.data {
+	for _, dataRoot := range pb.order {
+		entry, ok := pb.data[dataRoot]
+		if !ok {
+			continue
+		}
 		for _, proof := range entry.Proofs {
 			participantLen := types.BitlistLen(proof.Participants)
 			for vid := uint64(0); vid < participantLen; vid++ {

--- a/node/sync.go
+++ b/node/sync.go
@@ -130,13 +130,11 @@ func (sd *SyncDriver) pollPeer(ctx context.Context, peerID libp2ppeer.ID, ourSta
 	sd.checkAndBackfill(ctx, peerID, peerStatus)
 }
 
-// checkAndBackfill triggers BlocksByRange fetches from peerID if their head is
-// ahead of ours by more than BlocksByRangeSyncThreshold slots. Loops within the
-// per-peer reservation until either the peer's advertised head slot has been
-// requested or the peer stops returning blocks — necessary for recovery from a
-// long pause where waiting one SyncPollInterval (32s) between fetches blows
-// the 180s catch-up budget the hive harness enforces. On range-fetch failure,
-// falls back to a head-by-root fetch (via any peer) so the reactive
+// checkAndBackfill triggers BlocksByRange fetches from peerID if their head
+// is ahead of ours by more than BlocksByRangeSyncThreshold slots. Loops
+// within the per-peer reservation until either the peer's advertised head
+// slot has been requested or the peer stops returning blocks. On range-fetch
+// failure, falls back to a head-by-root fetch (via any peer) so the reactive
 // missing-parent flow has something to chase.
 func (sd *SyncDriver) checkAndBackfill(ctx context.Context, peerID libp2ppeer.ID, peerStatus *p2p.StatusMessage) {
 	ourHead := sd.engine.Store.HeadSlot()

--- a/node/sync.go
+++ b/node/sync.go
@@ -130,17 +130,20 @@ func (sd *SyncDriver) pollPeer(ctx context.Context, peerID libp2ppeer.ID, ourSta
 	sd.checkAndBackfill(ctx, peerID, peerStatus)
 }
 
-// checkAndBackfill triggers a BlocksByRange fetch from peerID if their head is
-// ahead of ours by more than BlocksByRangeSyncThreshold slots. On range-fetch
-// failure, falls back to a head-by-root fetch (via any peer) so the reactive
+// checkAndBackfill triggers BlocksByRange fetches from peerID if their head is
+// ahead of ours by more than BlocksByRangeSyncThreshold slots. Loops within the
+// per-peer reservation until either the peer's advertised head slot has been
+// requested or the peer stops returning blocks — necessary for recovery from a
+// long pause where waiting one SyncPollInterval (32s) between fetches blows
+// the 180s catch-up budget the hive harness enforces. On range-fetch failure,
+// falls back to a head-by-root fetch (via any peer) so the reactive
 // missing-parent flow has something to chase.
 func (sd *SyncDriver) checkAndBackfill(ctx context.Context, peerID libp2ppeer.ID, peerStatus *p2p.StatusMessage) {
 	ourHead := sd.engine.Store.HeadSlot()
 	if peerStatus.HeadSlot <= ourHead {
 		return
 	}
-	gap := peerStatus.HeadSlot - ourHead
-	if gap <= p2p.BlocksByRangeSyncThreshold {
+	if peerStatus.HeadSlot-ourHead <= p2p.BlocksByRangeSyncThreshold {
 		// Below threshold: gossip + reactive missing-parent BlocksByRoot
 		// handles small gaps efficiently. Range-fetch would be wasteful.
 		return
@@ -151,35 +154,57 @@ func (sd *SyncDriver) checkAndBackfill(ctx context.Context, peerID libp2ppeer.ID
 	}
 	defer sd.release(peerID)
 
-	count := gap
-	if count > types.MaxRequestBlocks {
-		count = types.MaxRequestBlocks
-	}
 	startSlot := ourHead + 1
-
-	logger.Info(logger.Sync, "sync: peer %s ahead by %d slots, fetching range start_slot=%d count=%d",
-		peerID, gap, startSlot, count)
-
-	blocks, err := sd.p2p.FetchBlocksByRange(ctx, peerID, startSlot, count)
-	if err != nil {
-		logger.Warn(logger.Sync, "sync: blocks_by_range failed peer=%s err=%v; falling back to head-by-root",
-			peerID, err)
-		// Fallback: at least fetch the peer's head block by root via any
-		// peer. The reactive missing-parent flow can chase from there.
-		rootBlocks, _, ferr := sd.p2p.FetchBlocksByRootBatchWithRetry(ctx, [][32]byte{peerStatus.HeadRoot})
-		if ferr != nil {
-			logger.Warn(logger.Sync, "sync: head-by-root fallback also failed: %v", ferr)
+	for startSlot <= peerStatus.HeadSlot {
+		if err := ctx.Err(); err != nil {
 			return
 		}
-		for _, b := range rootBlocks {
-			sd.engine.OnBlock(b)
+		count := peerStatus.HeadSlot - startSlot + 1
+		if count > types.MaxRequestBlocks {
+			count = types.MaxRequestBlocks
 		}
-		return
-	}
 
-	logger.Info(logger.Sync, "sync: received %d blocks from peer %s, feeding to engine", len(blocks), peerID)
-	for _, block := range blocks {
-		sd.engine.OnBlock(block)
+		logger.Info(logger.Sync, "sync: fetching range from peer %s start_slot=%d count=%d peer_head=%d",
+			peerID, startSlot, count, peerStatus.HeadSlot)
+
+		blocks, err := sd.p2p.FetchBlocksByRange(ctx, peerID, startSlot, count)
+		if err != nil {
+			logger.Warn(logger.Sync, "sync: blocks_by_range failed peer=%s err=%v; falling back to head-by-root",
+				peerID, err)
+			rootBlocks, _, ferr := sd.p2p.FetchBlocksByRootBatchWithRetry(ctx, [][32]byte{peerStatus.HeadRoot})
+			if ferr != nil {
+				logger.Warn(logger.Sync, "sync: head-by-root fallback also failed: %v", ferr)
+				return
+			}
+			for _, b := range rootBlocks {
+				sd.engine.OnBlock(b)
+			}
+			return
+		}
+
+		if len(blocks) == 0 {
+			// Peer ran out of blocks below its advertised head — either it
+			// pruned the requested range or empty slots fill it. Either way,
+			// looping further against this peer is pointless; the next poll
+			// cycle picks up where we left off (or tries another peer).
+			logger.Info(logger.Sync, "sync: peer %s returned empty range at start_slot=%d, stopping", peerID, startSlot)
+			return
+		}
+
+		logger.Info(logger.Sync, "sync: received %d blocks from peer %s, feeding to engine", len(blocks), peerID)
+		for _, block := range blocks {
+			sd.engine.OnBlock(block)
+		}
+
+		// Advance past the highest slot the peer actually returned so the
+		// next iteration requests strictly forward, regardless of empty-slot
+		// gaps in the response.
+		lastSlot := blocks[len(blocks)-1].Block.Slot
+		if lastSlot < startSlot {
+			// Defensive: peer returned blocks below the requested start.
+			return
+		}
+		startSlot = lastSlot + 1
 	}
 }
 

--- a/node/sync_test.go
+++ b/node/sync_test.go
@@ -43,8 +43,7 @@ type mockSyncP2P struct {
 	statusResp *p2p.StatusMessage
 	statusErr  error
 
-	rangeBlocks  []*types.SignedBlock     // legacy: returned on every call
-	rangeBatches [][]*types.SignedBlock   // preferred: popped one per call, empty when drained
+	rangeBatches [][]*types.SignedBlock // popped one per call; empty/nil returns (nil, rangeErr)
 	rangeErr     error
 	rangeCalls   atomic.Int32
 
@@ -72,17 +71,14 @@ func (m *mockSyncP2P) FetchBlocksByRange(ctx context.Context, peerID libp2ppeer.
 	if m.rangeBlock != nil {
 		<-m.rangeBlock
 	}
-	if m.rangeBatches != nil {
-		m.mu.Lock()
-		defer m.mu.Unlock()
-		if len(m.rangeBatches) == 0 {
-			return nil, m.rangeErr
-		}
-		batch := m.rangeBatches[0]
-		m.rangeBatches = m.rangeBatches[1:]
-		return batch, m.rangeErr
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.rangeBatches) == 0 {
+		return nil, m.rangeErr
 	}
-	return m.rangeBlocks, m.rangeErr
+	batch := m.rangeBatches[0]
+	m.rangeBatches = m.rangeBatches[1:]
+	return batch, m.rangeErr
 }
 
 func (m *mockSyncP2P) FetchBlocksByRootBatchWithRetry(ctx context.Context, roots [][32]byte) ([]*types.SignedBlock, [][32]byte, error) {
@@ -232,8 +228,8 @@ func TestSyncDriver_CheckAndBackfill_PerPeerDedup(t *testing.T) {
 	e := makeTestEngine()
 	rangeBlock := make(chan struct{})
 	mock := &mockSyncP2P{
-		rangeBlocks: []*types.SignedBlock{
-			{Block: &types.Block{Slot: 1, Body: &types.BlockBody{}}},
+		rangeBatches: [][]*types.SignedBlock{
+			{{Block: &types.Block{Slot: 1, Body: &types.BlockBody{}}}},
 		},
 		rangeBlock: rangeBlock,
 	}

--- a/node/sync_test.go
+++ b/node/sync_test.go
@@ -43,9 +43,10 @@ type mockSyncP2P struct {
 	statusResp *p2p.StatusMessage
 	statusErr  error
 
-	rangeBlocks []*types.SignedBlock
-	rangeErr    error
-	rangeCalls  atomic.Int32
+	rangeBlocks  []*types.SignedBlock     // legacy: returned on every call
+	rangeBatches [][]*types.SignedBlock   // preferred: popped one per call, empty when drained
+	rangeErr     error
+	rangeCalls   atomic.Int32
 
 	rootBlocks []*types.SignedBlock
 	rootErr    error
@@ -70,6 +71,16 @@ func (m *mockSyncP2P) FetchBlocksByRange(ctx context.Context, peerID libp2ppeer.
 	m.rangeCalls.Add(1)
 	if m.rangeBlock != nil {
 		<-m.rangeBlock
+	}
+	if m.rangeBatches != nil {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		if len(m.rangeBatches) == 0 {
+			return nil, m.rangeErr
+		}
+		batch := m.rangeBatches[0]
+		m.rangeBatches = m.rangeBatches[1:]
+		return batch, m.rangeErr
 	}
 	return m.rangeBlocks, m.rangeErr
 }
@@ -129,10 +140,14 @@ func TestSyncDriver_CheckAndBackfill_GapBelowThreshold(t *testing.T) {
 
 func TestSyncDriver_CheckAndBackfill_FetchesWhenAhead(t *testing.T) {
 	e := makeTestEngine()
+	// Peer returns blocks for the first request, then nothing — the loop
+	// inside checkAndBackfill should drain once and stop on the empty reply.
 	mock := &mockSyncP2P{
-		rangeBlocks: []*types.SignedBlock{
-			{Block: &types.Block{Slot: 1, Body: &types.BlockBody{}}},
-			{Block: &types.Block{Slot: 2, Body: &types.BlockBody{}}},
+		rangeBatches: [][]*types.SignedBlock{
+			{
+				{Block: &types.Block{Slot: 1, Body: &types.BlockBody{}}},
+				{Block: &types.Block{Slot: 2, Body: &types.BlockBody{}}},
+			},
 		},
 	}
 	sd := NewSyncDriver(context.Background(), e, mock)
@@ -141,13 +156,47 @@ func TestSyncDriver_CheckAndBackfill_FetchesWhenAhead(t *testing.T) {
 	peerStatus := &p2p.StatusMessage{HeadSlot: 100}
 	sd.checkAndBackfill(context.Background(), libp2ppeer.ID("p1"), peerStatus)
 
-	if got := mock.rangeCalls.Load(); got != 1 {
-		t.Errorf("expected 1 range call, got %d", got)
+	// One filled batch + one probe that gets the empty reply.
+	if got := mock.rangeCalls.Load(); got != 2 {
+		t.Errorf("expected 2 range calls (drain + empty probe), got %d", got)
 	}
 
 	got := drainBlockCh(t, e, 2, 100*time.Millisecond)
 	if len(got) != 2 {
 		t.Fatalf("expected 2 blocks fed to engine, got %d", len(got))
+	}
+}
+
+func TestSyncDriver_CheckAndBackfill_LoopsUntilCaughtUp(t *testing.T) {
+	e := makeTestEngine()
+	// Peer drip-feeds two batches that together close the gap, then returns
+	// empty. Drives the in-reservation loop instead of waiting one
+	// SyncPollInterval (32s) between batches.
+	mock := &mockSyncP2P{
+		rangeBatches: [][]*types.SignedBlock{
+			{
+				{Block: &types.Block{Slot: 1, Body: &types.BlockBody{}}},
+				{Block: &types.Block{Slot: 2, Body: &types.BlockBody{}}},
+			},
+			{
+				{Block: &types.Block{Slot: 3, Body: &types.BlockBody{}}},
+				{Block: &types.Block{Slot: 4, Body: &types.BlockBody{}}},
+			},
+		},
+	}
+	sd := NewSyncDriver(context.Background(), e, mock)
+
+	peerStatus := &p2p.StatusMessage{HeadSlot: 100}
+	sd.checkAndBackfill(context.Background(), libp2ppeer.ID("p1"), peerStatus)
+
+	// Two filled batches + one probe that returns empty.
+	if got := mock.rangeCalls.Load(); got != 3 {
+		t.Errorf("expected 3 range calls (2 batches + empty probe), got %d", got)
+	}
+
+	got := drainBlockCh(t, e, 4, 100*time.Millisecond)
+	if len(got) != 4 {
+		t.Fatalf("expected 4 blocks fed to engine, got %d", len(got))
 	}
 }
 

--- a/node/tick.go
+++ b/node/tick.go
@@ -12,7 +12,8 @@ import (
 // onTick processes an 800ms tick event.
 func (e *Engine) onTick() {
 	now := time.Now()
-	if !e.lastTick.IsZero() {
+	firstTick := e.lastTick.IsZero()
+	if !firstTick {
 		ObserveTickIntervalDuration(now.Sub(e.lastTick).Seconds())
 	}
 	e.lastTick = now
@@ -31,10 +32,13 @@ func (e *Engine) onTick() {
 	// values (store_tick relies on the bool being stable for the tick).
 	isAgg := e.AggCtl.Get()
 
-	// Check if we're the proposer for this slot.
+	// Check if we're the proposer for this slot. Suppress on the eager
+	// pre-ticker tick in Run(): that call warms head/sync/metrics, but a
+	// brand-new node must not advance its forkchoice tree (insert a slot-N
+	// block, move head off genesis) before any RPC poll or peer observation.
 	hasProposal := false
 	var proposerValidatorID uint64
-	if currentInterval == 0 && currentSlot > 0 {
+	if currentInterval == 0 && currentSlot > 0 && !firstTick {
 		proposerValidatorID, hasProposal = e.getOurProposer(currentSlot)
 	}
 

--- a/node/tick.go
+++ b/node/tick.go
@@ -32,10 +32,9 @@ func (e *Engine) onTick() {
 	// values (store_tick relies on the bool being stable for the tick).
 	isAgg := e.AggCtl.Get()
 
-	// Check if we're the proposer for this slot. Suppress on the eager
-	// pre-ticker tick in Run(): that call warms head/sync/metrics, but a
-	// brand-new node must not advance its forkchoice tree (insert a slot-N
-	// block, move head off genesis) before any RPC poll or peer observation.
+	// Check if we're the proposer for this slot. Suppressed on the eager
+	// pre-ticker tick (Run() at node.go:159) so a fresh node doesn't grow
+	// its proto-array before any RPC poll or peer observation.
 	hasProposal := false
 	var proposerValidatorID uint64
 	if currentInterval == 0 && currentSlot > 0 && !firstTick {


### PR DESCRIPTION
## Summary

Stops gean's brand-new node from producing a slot-1 block before the rpc_compat hive baseline can poll. Closes #288.

## Why

Three rpc_compat tests fail against `gean_devnet4` on a fresh boot:

| Test | Failure |
|---|---|
| `forkchoice no finalized` | `finalized root should remain at the genesis head` (left/right roots differ) |
| `forkchoice zero validator count when head state missing` | `fresh forkchoice should still be on the genesis-only tree` (left=2, right=1) |
| `forkchoice includes expected node fields` | Same root cause — nodes-array length mismatch surfaces as "fields differ" |

The eager `e.onTick()` call at `node/node.go:159` (added to warm head/sync/metrics so they don't lag a tick at boot) also dispatches `maybePropose` whenever `currentInterval == 0 && currentSlot > 0`. With wall-clock past genesis at boot, the eager tick inserts a slot-1 block via `node/validator.go:81 e.FC.OnBlock(...)`, growing the proto-array from 1 node to 2 and moving `Head` off genesis. `LatestFinalized` stays at genesis (`store_block.go:116-118` only advances on strict slot increase), so the baseline observes 2 nodes and `finalized.root ≠ head.root`.

The RPC handler (`api/server.go:166-208`), proto-array seeding (`forkchoice/protoarray.go:23-38`), and per-node schema all match the spec. Only the boot-time race needs fixing.

## What changed

`node/tick.go` — 7 inserts, 3 deletes:

```diff
 func (e *Engine) onTick() {
 	now := time.Now()
-	if !e.lastTick.IsZero() {
+	firstTick := e.lastTick.IsZero()
+	if !firstTick {
 		ObserveTickIntervalDuration(now.Sub(e.lastTick).Seconds())
 	}
 	e.lastTick = now
@@ -31,10 +32,13 @@
 	isAgg := e.AggCtl.Get()

-	// Check if we're the proposer for this slot.
+	// Check if we're the proposer for this slot. Suppress on the eager
+	// pre-ticker tick in Run(): that call warms head/sync/metrics, but a
+	// brand-new node must not advance its forkchoice tree (insert a slot-N
+	// block, move head off genesis) before any RPC poll or peer observation.
 	hasProposal := false
 	var proposerValidatorID uint64
-	if currentInterval == 0 && currentSlot > 0 {
+	if currentInterval == 0 && currentSlot > 0 && !firstTick {
 		proposerValidatorID, hasProposal = e.getOurProposer(currentSlot)
 	}
```

Sync-status warm-up, gossip-mesh refresh, store tick, and metrics still run on the eager tick — only block production is suppressed. The regular ticker fires the proper proposal path 800ms later.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./node/...` — all green.
- [ ] Hive rpc_compat suite against gean rebuilt from this branch — expect the three failures above to flip to pass.

## Related

- Closes #288
- Companion PRs: #289 (equivocation fork-choice), #290 (sync backfill loop) — all three are independent.