### PR TITLE
fix(forkchoice): same-slot equivocation first-wins guard (#289)

### DIFF
--- a/forkchoice/forkchoice_test.go
+++ b/forkchoice/forkchoice_test.go
@@ -178,23 +178,58 @@ func TestProtoArrayNoAttestations(t *testing.T) {
 }
 
 func TestProtoArrayVoteChange(t *testing.T) {
-	rootA, rootB, rootC := root(1), root(2), root(3)
+	rootA, rootB, rootC, rootD := root(1), root(2), root(3), root(4)
 	fc := New(0, rootA, [32]byte{})
 	fc.OnBlock(1, rootB, rootA)
 	fc.OnBlock(1, rootC, rootA)
+	fc.OnBlock(2, rootD, rootC)
 
-	// Initially vote for rootB
+	// Initially vote for rootB at slot 1.
 	fc.Votes.SetKnown(0, fc.NodeIndex(rootB), 1, makeAttData(rootB, 1))
 	head := fc.UpdateHead(rootA)
 	if head != rootB {
 		t.Fatalf("expected rootB initially, got %x", head[:4])
 	}
 
-	// Change vote to rootC
+	// Vote-change at a later slot is a normal target update — should move
+	// the head. (Same-slot re-vote with a different target is equivocation
+	// and is dropped; see TestProtoArrayEquivocation.)
+	fc.Votes.SetKnown(0, fc.NodeIndex(rootD), 2, makeAttData(rootD, 2))
+	head = fc.UpdateHead(rootA)
+	if head != rootD {
+		t.Fatalf("expected rootD after vote change, got %x", head[:4])
+	}
+}
+
+func TestProtoArrayEquivocation(t *testing.T) {
+	// Same-slot, different-target re-vote from one validator must be ignored
+	// (first-wins). Mirrors the spec fork-choice equivocation rule covered
+	// by the hive fixture test_same_slot_equivocating_attesters_count_once.
+	rootA, rootB, rootC := root(1), root(2), root(3)
+	fc := New(0, rootA, [32]byte{})
+	fc.OnBlock(1, rootB, rootA)
+	fc.OnBlock(1, rootC, rootA)
+
+	// First vote: validator 0 → rootB at slot 1.
+	fc.Votes.SetKnown(0, fc.NodeIndex(rootB), 1, makeAttData(rootB, 1))
+	head := fc.UpdateHead(rootA)
+	if head != rootB {
+		t.Fatalf("expected rootB after first vote, got %x", head[:4])
+	}
+
+	// Equivocating second vote: validator 0 → rootC at the same slot.
+	// Must be dropped; head stays on rootB.
 	fc.Votes.SetKnown(0, fc.NodeIndex(rootC), 1, makeAttData(rootC, 1))
 	head = fc.UpdateHead(rootA)
-	if head != rootC {
-		t.Fatalf("expected rootC after vote change, got %x", head[:4])
+	if head != rootB {
+		t.Fatalf("expected rootB to persist after equivocating vote, got %x", head[:4])
+	}
+
+	// Same equivocation rule on the SetNew (gossip) path.
+	fc.Votes.SetNew(1, fc.NodeIndex(rootB), 1, makeAttData(rootB, 1))
+	fc.Votes.SetNew(1, fc.NodeIndex(rootC), 1, makeAttData(rootC, 1))
+	if fc.Votes.Votes[1].LatestNew == nil || fc.Votes.Votes[1].LatestNew.Index != fc.NodeIndex(rootB) {
+		t.Fatalf("validator 1 LatestNew should pin to rootB, got %+v", fc.Votes.Votes[1].LatestNew)
 	}
 }
 

--- a/forkchoice/votes.go
+++ b/forkchoice/votes.go
@@ -28,15 +28,33 @@ func NewVoteStore() *VoteStore {
 }
 
 // SetKnown records a known (on-chain) attestation for a validator.
+// Equivocation: if either pool already holds a vote at this slot for a
+// different target, the new write is dropped — equivocating attesters
+// count exactly once and the first observed target wins.
 func (vs *VoteStore) SetKnown(validatorID uint64, nodeIndex int, slot uint64, data *types.AttestationData) {
 	tracker := vs.getOrCreate(validatorID)
+	if sameSlotConflict(tracker.LatestKnown, slot, nodeIndex) ||
+		sameSlotConflict(tracker.LatestNew, slot, nodeIndex) {
+		return
+	}
 	tracker.LatestKnown = &VoteTarget{Index: nodeIndex, Slot: slot, Data: data}
 }
 
 // SetNew records a new (gossip-received) attestation for a validator.
+// Same equivocation rule as SetKnown.
 func (vs *VoteStore) SetNew(validatorID uint64, nodeIndex int, slot uint64, data *types.AttestationData) {
 	tracker := vs.getOrCreate(validatorID)
+	if sameSlotConflict(tracker.LatestKnown, slot, nodeIndex) ||
+		sameSlotConflict(tracker.LatestNew, slot, nodeIndex) {
+		return
+	}
 	tracker.LatestNew = &VoteTarget{Index: nodeIndex, Slot: slot, Data: data}
+}
+
+// sameSlotConflict reports whether an existing vote at the same slot points
+// to a different proto-array node — i.e. the incoming write would equivocate.
+func sameSlotConflict(existing *VoteTarget, slot uint64, nodeIndex int) bool {
+	return existing != nil && existing.Slot == slot && existing.Index != nodeIndex
 }
 
 // PromoteNewToKnown moves all new votes to known.

--- a/forkchoice/votes.go
+++ b/forkchoice/votes.go
@@ -27,10 +27,8 @@ func NewVoteStore() *VoteStore {
 	return &VoteStore{Votes: make(map[uint64]*VoteTracker)}
 }
 
-// SetKnown records a known (on-chain) attestation for a validator.
-// Equivocation: if either pool already holds a vote at this slot for a
-// different target, the new write is dropped — equivocating attesters
-// count exactly once and the first observed target wins.
+// SetKnown records a known (on-chain) attestation. Same-slot writes
+// pointing to a different target are dropped (see sameSlotConflict).
 func (vs *VoteStore) SetKnown(validatorID uint64, nodeIndex int, slot uint64, data *types.AttestationData) {
 	tracker := vs.getOrCreate(validatorID)
 	if sameSlotConflict(tracker.LatestKnown, slot, nodeIndex) ||
@@ -40,8 +38,8 @@ func (vs *VoteStore) SetKnown(validatorID uint64, nodeIndex int, slot uint64, da
 	tracker.LatestKnown = &VoteTarget{Index: nodeIndex, Slot: slot, Data: data}
 }
 
-// SetNew records a new (gossip-received) attestation for a validator.
-// Same equivocation rule as SetKnown.
+// SetNew records a new (gossip-received) attestation. Same equivocation
+// guard as SetKnown.
 func (vs *VoteStore) SetNew(validatorID uint64, nodeIndex int, slot uint64, data *types.AttestationData) {
 	tracker := vs.getOrCreate(validatorID)
 	if sameSlotConflict(tracker.LatestKnown, slot, nodeIndex) ||

--- a/node/store_payloads.go
+++ b/node/store_payloads.go
@@ -96,9 +96,16 @@ func (pb *PayloadBuffer) TotalProofs() int {
 }
 
 // ExtractLatestAttestations returns per-validator latest attestations from participation bits.
+// Iterates by insertion order (pb.order) so same-slot ties resolve to the
+// first-inserted entry, mirroring the spec's insertion-ordered dict and
+// making equivocation handling deterministic (Go map iteration order is not).
 func (pb *PayloadBuffer) ExtractLatestAttestations() map[uint64]*types.AttestationData {
 	result := make(map[uint64]*types.AttestationData)
-	for _, entry := range pb.data {
+	for _, dataRoot := range pb.order {
+		entry, ok := pb.data[dataRoot]
+		if !ok {
+			continue
+		}
 		for _, proof := range entry.Proofs {
 			participantLen := types.BitlistLen(proof.Participants)
 			for vid := uint64(0); vid < participantLen; vid++ {


### PR DESCRIPTION
## Summary

Two attestations from the same validator in the same slot on conflicting forks must each count exactly once (first observed target wins). Gean was letting the second attestation overwrite the first, flipping fork-choice head onto the equivocating branch. Closes #289.

## Why

Hive fixture `test_same_slot_equivocating_attesters_count_once` fails:

```
client gean_devnet4: assertion `left == right` failed: step 6 headSlot mismatch
  left: 3      ← gean head (fork_b, weight 4 = 2 honest + V0/V1 overwrites)
  right: 2     ← spec head (fork_a, weight 3 = 2 honest + V0/V1 first vote)
```

ethlambda and zeam pass. The fixture exercises V0/V1 sending attestations on fork_a, then later sending equivocating attestations on fork_b at the same slot.

Two layers were missing the same-slot, different-target first-wins rule:

**1. `forkchoice/votes.go:31, 37`** — `VoteStore.SetKnown` and `SetNew` unconditionally overwrote `LatestKnown` / `LatestNew`. The hive test driver path at `api/test_driver.go:524-528` calls `SetNew` for every participant in every incoming aggregate, so the second aggregate clobbered V0/V1's first vote.

**2. `node/store_payloads.go:99-115`** — `ExtractLatestAttestations` iterated `pb.data` (a Go map). Same-slot ties resolved to whatever the randomized iteration visited last. The buffer already maintained an insertion-ordered `pb.order` slice for FIFO eviction (`store_payloads.go:16, 45`) but did not use it for reads. The spec uses an insertion-ordered Python dict and the `if vid not in latest_attestations` idiom.

## What changed

### `forkchoice/votes.go`

Added an equivocation guard on both vote-write paths:

```go
func (vs *VoteStore) SetKnown(...) {
    tracker := vs.getOrCreate(validatorID)
    if sameSlotConflict(tracker.LatestKnown, slot, nodeIndex) ||
        sameSlotConflict(tracker.LatestNew, slot, nodeIndex) {
        return
    }
    tracker.LatestKnown = &VoteTarget{...}
}

func sameSlotConflict(existing *VoteTarget, slot uint64, nodeIndex int) bool {
    return existing != nil && existing.Slot == slot && existing.Index != nodeIndex
}
```

Cross-pool check covers the case where `LatestKnown` is set (e.g. via `PromoteNewToKnown`) and a later equivocating `SetNew` arrives.

### `node/store_payloads.go`

Switch `ExtractLatestAttestations` to iterate `pb.order` (insertion order) instead of `pb.data` (map order):

```diff
-for _, entry := range pb.data {
+for _, dataRoot := range pb.order {
+    entry, ok := pb.data[dataRoot]
+    if !ok {
+        continue
+    }
```

Strict `<` comparator preserved — same-slot ties now deterministically resolve to the first-inserted entry, matching spec semantics.

### `forkchoice/forkchoice_test.go`

- `TestProtoArrayVoteChange` was encoding the buggy "second SetKnown at same slot overwrites target" behaviour. Rewritten to test a legitimate cross-slot vote change.
- New `TestProtoArrayEquivocation` locks the same-slot first-wins rule on both `SetKnown` and `SetNew`.

## Fixture status

Python source: `leanSpec/tests/consensus/lstar/fc/test_equivocation.py:257`. Compiled JSON is not currently in `leanSpec/fixtures/consensus/fork_choice/devnet/fc/`. To reproduce locally, run `uv run fill --fork=lstar --clean -n auto` from the leanSpec dir.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./forkchoice/... ./node/...` — green, including the rewritten `TestProtoArrayVoteChange` and the new `TestProtoArrayEquivocation`.
- [ ] Hive fixture `test_same_slot_equivocating_attesters_count_once` against gean rebuilt from this branch — expect pass.

## Related

- Closes #289
- Companion PRs: #291 (rpc_compat eager-tick), and a third for the sync-backfill loop. All three are independent.