### PR TITLE
fix(node): loop BlocksByRange backfill within reservation (#290)

### DIFF
--- a/node/sync.go
+++ b/node/sync.go
@@ -130,17 +130,20 @@ func (sd *SyncDriver) pollPeer(ctx context.Context, peerID libp2ppeer.ID, ourSta
 	sd.checkAndBackfill(ctx, peerID, peerStatus)
 }
 
-// checkAndBackfill triggers a BlocksByRange fetch from peerID if their head is
-// ahead of ours by more than BlocksByRangeSyncThreshold slots. On range-fetch
-// failure, falls back to a head-by-root fetch (via any peer) so the reactive
+// checkAndBackfill triggers BlocksByRange fetches from peerID if their head is
+// ahead of ours by more than BlocksByRangeSyncThreshold slots. Loops within the
+// per-peer reservation until either the peer's advertised head slot has been
+// requested or the peer stops returning blocks — necessary for recovery from a
+// long pause where waiting one SyncPollInterval (32s) between fetches blows
+// the 180s catch-up budget the hive harness enforces. On range-fetch failure,
+// falls back to a head-by-root fetch (via any peer) so the reactive
 // missing-parent flow has something to chase.
 func (sd *SyncDriver) checkAndBackfill(ctx context.Context, peerID libp2ppeer.ID, peerStatus *p2p.StatusMessage) {
 	ourHead := sd.engine.Store.HeadSlot()
 	if peerStatus.HeadSlot <= ourHead {
 		return
 	}
-	gap := peerStatus.HeadSlot - ourHead
-	if gap <= p2p.BlocksByRangeSyncThreshold {
+	if peerStatus.HeadSlot-ourHead <= p2p.BlocksByRangeSyncThreshold {
 		// Below threshold: gossip + reactive missing-parent BlocksByRoot
 		// handles small gaps efficiently. Range-fetch would be wasteful.
 		return
@@ -151,35 +154,57 @@ func (sd *SyncDriver) checkAndBackfill(ctx context.Context, peerID libp2ppeer.ID
 	}
 	defer sd.release(peerID)
 
-	count := gap
-	if count > types.MaxRequestBlocks {
-		count = types.MaxRequestBlocks
-	}
 	startSlot := ourHead + 1
-
-	logger.Info(logger.Sync, "sync: peer %s ahead by %d slots, fetching range start_slot=%d count=%d",
-		peerID, gap, startSlot, count)
-
-	blocks, err := sd.p2p.FetchBlocksByRange(ctx, peerID, startSlot, count)
-	if err != nil {
-		logger.Warn(logger.Sync, "sync: blocks_by_range failed peer=%s err=%v; falling back to head-by-root",
-			peerID, err)
-		// Fallback: at least fetch the peer's head block by root via any
-		// peer. The reactive missing-parent flow can chase from there.
-		rootBlocks, _, ferr := sd.p2p.FetchBlocksByRootBatchWithRetry(ctx, [][32]byte{peerStatus.HeadRoot})
-		if ferr != nil {
-			logger.Warn(logger.Sync, "sync: head-by-root fallback also failed: %v", ferr)
+	for startSlot <= peerStatus.HeadSlot {
+		if err := ctx.Err(); err != nil {
 			return
 		}
-		for _, b := range rootBlocks {
-			sd.engine.OnBlock(b)
+		count := peerStatus.HeadSlot - startSlot + 1
+		if count > types.MaxRequestBlocks {
+			count = types.MaxRequestBlocks
 		}
-		return
-	}
 
-	logger.Info(logger.Sync, "sync: received %d blocks from peer %s, feeding to engine", len(blocks), peerID)
-	for _, block := range blocks {
-		sd.engine.OnBlock(block)
+		logger.Info(logger.Sync, "sync: fetching range from peer %s start_slot=%d count=%d peer_head=%d",
+			peerID, startSlot, count, peerStatus.HeadSlot)
+
+		blocks, err := sd.p2p.FetchBlocksByRange(ctx, peerID, startSlot, count)
+		if err != nil {
+			logger.Warn(logger.Sync, "sync: blocks_by_range failed peer=%s err=%v; falling back to head-by-root",
+				peerID, err)
+			rootBlocks, _, ferr := sd.p2p.FetchBlocksByRootBatchWithRetry(ctx, [][32]byte{peerStatus.HeadRoot})
+			if ferr != nil {
+				logger.Warn(logger.Sync, "sync: head-by-root fallback also failed: %v", ferr)
+				return
+			}
+			for _, b := range rootBlocks {
+				sd.engine.OnBlock(b)
+			}
+			return
+		}
+
+		if len(blocks) == 0 {
+			// Peer ran out of blocks below its advertised head — either it
+			// pruned the requested range or empty slots fill it. Either way,
+			// looping further against this peer is pointless; the next poll
+			// cycle picks up where we left off (or tries another peer).
+			logger.Info(logger.Sync, "sync: peer %s returned empty range at start_slot=%d, stopping", peerID, startSlot)
+			return
+		}
+
+		logger.Info(logger.Sync, "sync: received %d blocks from peer %s, feeding to engine", len(blocks), peerID)
+		for _, block := range blocks {
+			sd.engine.OnBlock(block)
+		}
+
+		// Advance past the highest slot the peer actually returned so the
+		// next iteration requests strictly forward, regardless of empty-slot
+		// gaps in the response.
+		lastSlot := blocks[len(blocks)-1].Block.Slot
+		if lastSlot < startSlot {
+			// Defensive: peer returned blocks below the requested start.
+			return
+		}
+		startSlot = lastSlot + 1
 	}
 }
 

--- a/node/sync_test.go
+++ b/node/sync_test.go
@@ -43,9 +43,10 @@ type mockSyncP2P struct {
 	statusResp *p2p.StatusMessage
 	statusErr  error
 
-	rangeBlocks []*types.SignedBlock
-	rangeErr    error
-	rangeCalls  atomic.Int32
+	rangeBlocks  []*types.SignedBlock     // legacy: returned on every call
+	rangeBatches [][]*types.SignedBlock   // preferred: popped one per call, empty when drained
+	rangeErr     error
+	rangeCalls   atomic.Int32
 
 	rootBlocks []*types.SignedBlock
 	rootErr    error
@@ -70,6 +71,16 @@ func (m *mockSyncP2P) FetchBlocksByRange(ctx context.Context, peerID libp2ppeer.
 	m.rangeCalls.Add(1)
 	if m.rangeBlock != nil {
 		<-m.rangeBlock
+	}
+	if m.rangeBatches != nil {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		if len(m.rangeBatches) == 0 {
+			return nil, m.rangeErr
+		}
+		batch := m.rangeBatches[0]
+		m.rangeBatches = m.rangeBatches[1:]
+		return batch, m.rangeErr
 	}
 	return m.rangeBlocks, m.rangeErr
 }
@@ -129,10 +140,14 @@ func TestSyncDriver_CheckAndBackfill_GapBelowThreshold(t *testing.T) {
 
 func TestSyncDriver_CheckAndBackfill_FetchesWhenAhead(t *testing.T) {
 	e := makeTestEngine()
+	// Peer returns blocks for the first request, then nothing — the loop
+	// inside checkAndBackfill should drain once and stop on the empty reply.
 	mock := &mockSyncP2P{
-		rangeBlocks: []*types.SignedBlock{
-			{Block: &types.Block{Slot: 1, Body: &types.BlockBody{}}},
-			{Block: &types.Block{Slot: 2, Body: &types.BlockBody{}}},
+		rangeBatches: [][]*types.SignedBlock{
+			{
+				{Block: &types.Block{Slot: 1, Body: &types.BlockBody{}}},
+				{Block: &types.Block{Slot: 2, Body: &types.BlockBody{}}},
+			},
 		},
 	}
 	sd := NewSyncDriver(context.Background(), e, mock)
@@ -141,13 +156,47 @@ func TestSyncDriver_CheckAndBackfill_FetchesWhenAhead(t *testing.T) {
 	peerStatus := &p2p.StatusMessage{HeadSlot: 100}
 	sd.checkAndBackfill(context.Background(), libp2ppeer.ID("p1"), peerStatus)
 
-	if got := mock.rangeCalls.Load(); got != 1 {
-		t.Errorf("expected 1 range call, got %d", got)
+	// One filled batch + one probe that gets the empty reply.
+	if got := mock.rangeCalls.Load(); got != 2 {
+		t.Errorf("expected 2 range calls (drain + empty probe), got %d", got)
 	}
 
 	got := drainBlockCh(t, e, 2, 100*time.Millisecond)
 	if len(got) != 2 {
 		t.Fatalf("expected 2 blocks fed to engine, got %d", len(got))
+	}
+}
+
+func TestSyncDriver_CheckAndBackfill_LoopsUntilCaughtUp(t *testing.T) {
+	e := makeTestEngine()
+	// Peer drip-feeds two batches that together close the gap, then returns
+	// empty. Drives the in-reservation loop instead of waiting one
+	// SyncPollInterval (32s) between batches.
+	mock := &mockSyncP2P{
+		rangeBatches: [][]*types.SignedBlock{
+			{
+				{Block: &types.Block{Slot: 1, Body: &types.BlockBody{}}},
+				{Block: &types.Block{Slot: 2, Body: &types.BlockBody{}}},
+			},
+			{
+				{Block: &types.Block{Slot: 3, Body: &types.BlockBody{}}},
+				{Block: &types.Block{Slot: 4, Body: &types.BlockBody{}}},
+			},
+		},
+	}
+	sd := NewSyncDriver(context.Background(), e, mock)
+
+	peerStatus := &p2p.StatusMessage{HeadSlot: 100}
+	sd.checkAndBackfill(context.Background(), libp2ppeer.ID("p1"), peerStatus)
+
+	// Two filled batches + one probe that returns empty.
+	if got := mock.rangeCalls.Load(); got != 3 {
+		t.Errorf("expected 3 range calls (2 batches + empty probe), got %d", got)
+	}
+
+	got := drainBlockCh(t, e, 4, 100*time.Millisecond)
+	if len(got) != 4 {
+		t.Fatalf("expected 4 blocks fed to engine, got %d", len(got))
 	}
 }
 


### PR DESCRIPTION
## Summary

Drains a multi-batch backfill in one continuous loop instead of waiting one `SyncPollInterval` (32s) between each batch. Lets gean catch back up within the hive harness's 180s budget after a container-level pause that spans a finalization boundary. Closes #290.

## Why

Hive test fails against `gean_devnet4`:

```
Test: sync: head behind finalized recovery
Error: Client under test never caught up to the local LeanSpec helper head slot
       within 180 seconds (allowed lag: 2 slots, helper-before head: 0x834a1e…)
Duration: 6min 5s
```

The pause is at the container level (gean exposes no in-node pause API; `api/server.go:29-30` mounts only `/lean/v0/admin/aggregator`). On unpause the wall clock has jumped forward; `node/tick.go:305-320` recomputes sync status and flips `SyncSynced → SyncSyncing`; `node/sync.go:80-82` (from PR #286) fires `refreshSyncFromPeers` immediately on that transition — so detection is correct.

The wedge: `checkAndBackfill` issued **one** `FetchBlocksByRange` per invocation, held the per-peer reservation only for that single round-trip, then returned. Subsequent fetches had to wait for the next `p2p.SyncPollInterval = 32 * time.Second` tick (`p2p/peers.go:36`). For a recovery gap that didn't fit in one response, the 180s budget evaporated 32s at a time.

(Mid-cascade prune theory ruled out: `PruneOnFinalization` runs **after** the `onBlock` cascade ends — `node/block.go:25-30` — and keeps `canonical[1:]` plus the new finalized root's state. Within a single cascade no parent states disappear; between cascades the just-imported block's state remains for the next block's parent lookup.)

## What changed

### `node/sync.go` — `checkAndBackfill` loops within reservation

```go
startSlot := ourHead + 1
for startSlot <= peerStatus.HeadSlot {
    if err := ctx.Err(); err != nil {
        return
    }
    count := peerStatus.HeadSlot - startSlot + 1
    if count > types.MaxRequestBlocks {
        count = types.MaxRequestBlocks
    }
    blocks, err := sd.p2p.FetchBlocksByRange(ctx, peerID, startSlot, count)
    if err != nil { /* … fallback to head-by-root … */ return }
    if len(blocks) == 0 {
        // peer ran out below its advertised head; next poll picks up
        return
    }
    for _, block := range blocks {
        sd.engine.OnBlock(block)
    }
    lastSlot := blocks[len(blocks)-1].Block.Slot
    if lastSlot < startSlot {
        return  // defensive: peer returned blocks below requested start
    }
    startSlot = lastSlot + 1
}
```

- `startSlot` advances based on the highest slot actually returned, so empty-slot gaps in the response don't cause re-requests for slots the peer already drained.
- Per-peer `tryReserve` dedup is unchanged — the loop holds the existing reservation, so it doesn't amplify request traffic to the same peer.
- Empty reply ends the loop; the regular polling cycle picks up later if the peer's head has advanced further.

### `node/sync_test.go` — coverage updates

- `mockSyncP2P` gained an optional `rangeBatches [][]*types.SignedBlock` queue so tests can return a distinct response per call. `rangeBlocks` legacy field preserved for `PerPeerDedup` and `FallsBackToRoot`.
- `TestSyncDriver_CheckAndBackfill_FetchesWhenAhead` now asserts 2 range calls (one filled batch + one empty probe) — reflects the new drain-loop semantics.
- New `TestSyncDriver_CheckAndBackfill_LoopsUntilCaughtUp` drip-feeds two batches followed by empty, verifies all 4 blocks are fed to the engine in a single `checkAndBackfill` invocation.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./node/...` — all green, including the rewritten `FetchesWhenAhead` and the new `LoopsUntilCaughtUp`.
- [ ] Hive `sync: head behind finalized recovery` against gean rebuilt from this branch — expect pass.

## Out of scope (future)

If the lean-spec helper prunes blocks below its finalized aggressively, the harness scenario where `peer.FinalizedSlot > our.HeadSlot` will still need proper checkpoint-sync semantics (jump to peer's finalized state via a new RPC, then range-forward). Worth verifying after this lands whether the test consistently passes; if not, that's the follow-up.

## Related

- Closes #290
- Companion PRs: #291 (rpc_compat eager-tick), #292 (equivocation fork-choice). All three are independent.