### PR TITLE
fix(node): loop BlocksByRange backfill within reservation (#290)

### DIFF
--- a/node/sync.go
+++ b/node/sync.go
@@ -130,17 +130,20 @@ func (sd *SyncDriver) pollPeer(ctx context.Context, peerID libp2ppeer.ID, ourSta
 	sd.checkAndBackfill(ctx, peerID, peerStatus)
 }
 
-// checkAndBackfill triggers a BlocksByRange fetch from peerID if their head is
-// ahead of ours by more than BlocksByRangeSyncThreshold slots. On range-fetch
-// failure, falls back to a head-by-root fetch (via any peer) so the reactive
+// checkAndBackfill triggers BlocksByRange fetches from peerID if their head is
+// ahead of ours by more than BlocksByRangeSyncThreshold slots. Loops within the
+// per-peer reservation until either the peer's advertised head slot has been
+// requested or the peer stops returning blocks — necessary for recovery from a
+// long pause where waiting one SyncPollInterval (32s) between fetches blows
+// the 180s catch-up budget the hive harness enforces. On range-fetch failure,
+// falls back to a head-by-root fetch (via any peer) so the reactive
 // missing-parent flow has something to chase.
 func (sd *SyncDriver) checkAndBackfill(ctx context.Context, peerID libp2ppeer.ID, peerStatus *p2p.StatusMessage) {
 	ourHead := sd.engine.Store.HeadSlot()
 	if peerStatus.HeadSlot <= ourHead {
 		return
 	}
-	gap := peerStatus.HeadSlot - ourHead
-	if gap <= p2p.BlocksByRangeSyncThreshold {
+	if peerStatus.HeadSlot-ourHead <= p2p.BlocksByRangeSyncThreshold {
 		// Below threshold: gossip + reactive missing-parent BlocksByRoot
 		// handles small gaps efficiently. Range-fetch would be wasteful.
 		return
@@ -151,35 +154,57 @@ func (sd *SyncDriver) checkAndBackfill(ctx context.Context, peerID libp2ppeer.ID
 	}
 	defer sd.release(peerID)
 
-	count := gap
-	if count > types.MaxRequestBlocks {
-		count = types.MaxRequestBlocks
-	}
 	startSlot := ourHead + 1
-
-	logger.Info(logger.Sync, "sync: peer %s ahead by %d slots, fetching range start_slot=%d count=%d",
-		peerID, gap, startSlot, count)
-
-	blocks, err := sd.p2p.FetchBlocksByRange(ctx, peerID, startSlot, count)
-	if err != nil {
-		logger.Warn(logger.Sync, "sync: blocks_by_range failed peer=%s err=%v; falling back to head-by-root",
-			peerID, err)
-		// Fallback: at least fetch the peer's head block by root via any
-		// peer. The reactive missing-parent flow can chase from there.
-		rootBlocks, _, ferr := sd.p2p.FetchBlocksByRootBatchWithRetry(ctx, [][32]byte{peerStatus.HeadRoot})
-		if ferr != nil {
-			logger.Warn(logger.Sync, "sync: head-by-root fallback also failed: %v", ferr)
+	for startSlot <= peerStatus.HeadSlot {
+		if err := ctx.Err(); err != nil {
 			return
 		}
-		for _, b := range rootBlocks {
-			sd.engine.OnBlock(b)
+		count := peerStatus.HeadSlot - startSlot + 1
+		if count > types.MaxRequestBlocks {
+			count = types.MaxRequestBlocks
 		}
-		return
-	}
 
-	logger.Info(logger.Sync, "sync: received %d blocks from peer %s, feeding to engine", len(blocks), peerID)
-	for _, block := range blocks {
-		sd.engine.OnBlock(block)
+		logger.Info(logger.Sync, "sync: fetching range from peer %s start_slot=%d count=%d peer_head=%d",
+			peerID, startSlot, count, peerStatus.HeadSlot)
+
+		blocks, err := sd.p2p.FetchBlocksByRange(ctx, peerID, startSlot, count)
+		if err != nil {
+			logger.Warn(logger.Sync, "sync: blocks_by_range failed peer=%s err=%v; falling back to head-by-root",
+				peerID, err)
+			rootBlocks, _, ferr := sd.p2p.FetchBlocksByRootBatchWithRetry(ctx, [][32]byte{peerStatus.HeadRoot})
+			if ferr != nil {
+				logger.Warn(logger.Sync, "sync: head-by-root fallback also failed: %v", ferr)
+				return
+			}
+			for _, b := range rootBlocks {
+				sd.engine.OnBlock(b)
+			}
+			return
+		}
+
+		if len(blocks) == 0 {
+			// Peer ran out of blocks below its advertised head — either it
+			// pruned the requested range or empty slots fill it. Either way,
+			// looping further against this peer is pointless; the next poll
+			// cycle picks up where we left off (or tries another peer).
+			logger.Info(logger.Sync, "sync: peer %s returned empty range at start_slot=%d, stopping", peerID, startSlot)
+			return
+		}
+
+		logger.Info(logger.Sync, "sync: received %d blocks from peer %s, feeding to engine", len(blocks), peerID)
+		for _, block := range blocks {
+			sd.engine.OnBlock(block)
+		}
+
+		// Advance past the highest slot the peer actually returned so the
+		// next iteration requests strictly forward, regardless of empty-slot
+		// gaps in the response.
+		lastSlot := blocks[len(blocks)-1].Block.Slot
+		if lastSlot < startSlot {
+			// Defensive: peer returned blocks below the requested start.
+			return
+		}
+		startSlot = lastSlot + 1
 	}
 }
 

--- a/node/sync_test.go
+++ b/node/sync_test.go
@@ -43,9 +43,10 @@ type mockSyncP2P struct {
 	statusResp *p2p.StatusMessage
 	statusErr  error
 
-	rangeBlocks []*types.SignedBlock
-	rangeErr    error
-	rangeCalls  atomic.Int32
+	rangeBlocks  []*types.SignedBlock     // legacy: returned on every call
+	rangeBatches [][]*types.SignedBlock   // preferred: popped one per call, empty when drained
+	rangeErr     error
+	rangeCalls   atomic.Int32
 
 	rootBlocks []*types.SignedBlock
 	rootErr    error
@@ -70,6 +71,16 @@ func (m *mockSyncP2P) FetchBlocksByRange(ctx context.Context, peerID libp2ppeer.
 	m.rangeCalls.Add(1)
 	if m.rangeBlock != nil {
 		<-m.rangeBlock
+	}
+	if m.rangeBatches != nil {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		if len(m.rangeBatches) == 0 {
+			return nil, m.rangeErr
+		}
+		batch := m.rangeBatches[0]
+		m.rangeBatches = m.rangeBatches[1:]
+		return batch, m.rangeErr
 	}
 	return m.rangeBlocks, m.rangeErr
 }
@@ -129,10 +140,14 @@ func TestSyncDriver_CheckAndBackfill_GapBelowThreshold(t *testing.T) {
 
 func TestSyncDriver_CheckAndBackfill_FetchesWhenAhead(t *testing.T) {
 	e := makeTestEngine()
+	// Peer returns blocks for the first request, then nothing — the loop
+	// inside checkAndBackfill should drain once and stop on the empty reply.
 	mock := &mockSyncP2P{
-		rangeBlocks: []*types.SignedBlock{
-			{Block: &types.Block{Slot: 1, Body: &types.BlockBody{}}},
-			{Block: &types.Block{Slot: 2, Body: &types.BlockBody{}}},
+		rangeBatches: [][]*types.SignedBlock{
+			{
+				{Block: &types.Block{Slot: 1, Body: &types.BlockBody{}}},
+				{Block: &types.Block{Slot: 2, Body: &types.BlockBody{}}},
+			},
 		},
 	}
 	sd := NewSyncDriver(context.Background(), e, mock)
@@ -141,13 +156,47 @@ func TestSyncDriver_CheckAndBackfill_FetchesWhenAhead(t *testing.T) {
 	peerStatus := &p2p.StatusMessage{HeadSlot: 100}
 	sd.checkAndBackfill(context.Background(), libp2ppeer.ID("p1"), peerStatus)
 
-	if got := mock.rangeCalls.Load(); got != 1 {
-		t.Errorf("expected 1 range call, got %d", got)
+	// One filled batch + one probe that gets the empty reply.
+	if got := mock.rangeCalls.Load(); got != 2 {
+		t.Errorf("expected 2 range calls (drain + empty probe), got %d", got)
 	}
 
 	got := drainBlockCh(t, e, 2, 100*time.Millisecond)
 	if len(got) != 2 {
 		t.Fatalf("expected 2 blocks fed to engine, got %d", len(got))
+	}
+}
+
+func TestSyncDriver_CheckAndBackfill_LoopsUntilCaughtUp(t *testing.T) {
+	e := makeTestEngine()
+	// Peer drip-feeds two batches that together close the gap, then returns
+	// empty. Drives the in-reservation loop instead of waiting one
+	// SyncPollInterval (32s) between batches.
+	mock := &mockSyncP2P{
+		rangeBatches: [][]*types.SignedBlock{
+			{
+				{Block: &types.Block{Slot: 1, Body: &types.BlockBody{}}},
+				{Block: &types.Block{Slot: 2, Body: &types.BlockBody{}}},
+			},
+			{
+				{Block: &types.Block{Slot: 3, Body: &types.BlockBody{}}},
+				{Block: &types.Block{Slot: 4, Body: &types.BlockBody{}}},
+			},
+		},
+	}
+	sd := NewSyncDriver(context.Background(), e, mock)
+
+	peerStatus := &p2p.StatusMessage{HeadSlot: 100}
+	sd.checkAndBackfill(context.Background(), libp2ppeer.ID("p1"), peerStatus)
+
+	// Two filled batches + one probe that returns empty.
+	if got := mock.rangeCalls.Load(); got != 3 {
+		t.Errorf("expected 3 range calls (2 batches + empty probe), got %d", got)
+	}
+
+	got := drainBlockCh(t, e, 4, 100*time.Millisecond)
+	if len(got) != 4 {
+		t.Fatalf("expected 4 blocks fed to engine, got %d", len(got))
 	}
 }
 


### PR DESCRIPTION
After a long container-level pause (hive harness uses docker pause / SIGSTOP — gean has no in-node pause API), the helper mesh finalizes beyond gean's paused head. On unpause, gean has 180s to catch up; PR #286 added an eager Synced→Syncing poll so the first fetch fires without waiting on the 32s SyncPollInterval, but checkAndBackfill still issued exactly one FetchBlocksByRange and returned. Every subsequent batch then had to wait one full SyncPollInterval, blowing the 180s budget for any gap that didn't fit in a single response.

checkAndBackfill now loops inside its per-peer reservation until either the peer's advertised head is reached or the peer returns an empty batch. Each iteration advances startSlot to the last received block's slot + 1, handling empty-slot gaps naturally and avoiding re-requests for slots already drained.

Per-peer tryReserve dedup is unchanged, so the loop does not amplify request traffic — it only removes idle waits between batches.

Test updates:

- TestSyncDriver_CheckAndBackfill_FetchesWhenAhead now asserts 2 range calls (one filled batch + one empty probe) instead of 1.
- New TestSyncDriver_CheckAndBackfill_LoopsUntilCaughtUp drip-feeds two batches followed by empty, verifying the loop drains both.
- mockSyncP2P gained an optional rangeBatches []*[]Block queue so tests can return a distinct response per call; rangeBlocks is preserved for back-compat with PerPeerDedup / FallsBackToRoot.

Closes #290.

## Description
<!-- Provide a brief summary of your changes -->

## Associated Issue
<!-- PRs targeting main or devnet-N must be linked to an issue. Use Closes #123 / Fixes #123, or link it from the Development sidebar. -->
Closes #

## Test Plan
<!-- Describe how you verified your changes -->

## Checklist
- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
