### PR TITLE
obs: real git commit in lean_node_info (#300) + spec-aligned aggregation buckets (#301)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ COPY . .
 ARG GIT_COMMIT=unknown
 ARG GIT_BRANCH=unknown
 RUN mkdir -p bin && \
-    go build -o bin/gean ./cmd/gean && \
+    go build -ldflags "-X github.com/geanlabs/gean/node.gitCommit=$GIT_COMMIT" -o bin/gean ./cmd/gean && \
     go build -o bin/keygen ./cmd/keygen
 
 # Runtime stage

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ffi: ## Build XMSS FFI glue libraries (hashsig-glue + multisig-glue)
 
 build: ffi ## Build gean and keygen binaries
 	@mkdir -p bin
-	@go build -o bin/gean ./cmd/gean
+	@go build -ldflags "-X github.com/geanlabs/gean/node.gitCommit=$(GIT_COMMIT)" -o bin/gean ./cmd/gean
 	@go build -o bin/keygen ./cmd/keygen
 
 test: ## Run unit tests (excludes crypto FFI and spec tests)

--- a/node/metrics.go
+++ b/node/metrics.go
@@ -139,9 +139,14 @@ var (
 		Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 1},
 	})
 	metricCommitteeAggregationTime = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name:    "lean_committee_signatures_aggregation_time_seconds",
-		Help:    "Time to aggregate committee signatures",
-		Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1},
+		Name: "lean_committee_signatures_aggregation_time_seconds",
+		Help: "Time to aggregate committee signatures",
+		// Values mirror leanSpec's STATE_TRANSITION_BUCKETS
+		// (leanSpec/src/lean_spec/subspecs/metrics/registry.py:42) —
+		// same shape as state-transition latency, the closest spec-named
+		// histogram. Measured aggregation lands in 300 ms-4 s; the prior
+		// 5 ms-1 s set bottomed out at 0 samples and clipped the tail.
+		Buckets: []float64{0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 4},
 	})
 	metricPqSigSigningTime = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "lean_pq_sig_attestation_signing_time_seconds",

--- a/node/node.go
+++ b/node/node.go
@@ -12,6 +12,11 @@ import (
 	"github.com/geanlabs/gean/xmss"
 )
 
+// gitCommit is injected at link time via -ldflags "-X .../node.gitCommit=$(GIT_COMMIT)"
+// from Makefile / Dockerfile, surfaced through the lean_node_info Prometheus gauge.
+// Defaults to "unknown" so builds outside a git checkout still produce a value.
+var gitCommit = "unknown"
+
 // Engine is the consensus coordination loop.
 // It owns Store, ForkChoice, and KeyManager as siblings,
 // rs L78-95).
@@ -122,7 +127,7 @@ func (e *Engine) Run(ctx context.Context) {
 	// Initialize static metrics.
 	// lean_is_aggregator is kept in sync via AggregatorController.Set on
 	// every transition; NewAggregatorController already seeded it at boot.
-	SetNodeInfo("gean", "dev")
+	SetNodeInfo("gean", gitCommit)
 	SetNodeStartTime(float64(time.Now().Unix()))
 	SetAttestationCommitteeCount(e.CommitteeCount)
 	if e.Keys != nil {


### PR DESCRIPTION
## Summary

Two observability gaps surfaced when measuring PR #299's aggregation perf on a live devnet. Both are gean-internal — zero spec-mandated surface touched. Closes #300 and #301.

| Fix | Issue | Files | Lines |
|---|---|---|---|
| Real git commit in lean_node_info instead of "dev" literal | #300 | Makefile, Dockerfile, node/node.go | +8/-3 |
| Aggregation histogram buckets adopt leanSpec STATE_TRANSITION_BUCKETS values | #301 | node/metrics.go | +8/-3 |

## Why these two together

Both surfaced from the same live-scrape session post-PR #299. They're independent (different files, different mechanisms), but small enough that one combined PR avoids ping-ponging through two reviews for ~16 LOC total.

## Fix 1 — #300: lean_node_info shows real commit

Cross-client snapshot from today's devnet scrape:

| Client | `version` label |
|---|---|
| ethlambda_0 | `ethlambda/v0.1.0-main-955c160/aarch64-…` |
| ream_0 | `869ef91` |
| zeam_0 | `b6ea869` |
| **gean_0 (pre-fix)** | **`dev`** |

`node/node.go:125` had `SetNodeInfo("gean", "dev")` — a placeholder. The Makefile already extracts `GIT_COMMIT` and passes it as a Docker build-arg; Dockerfile uses it for OCI image LABELs. **Never threaded into the Go binary.**

Fix:
- New package var `node.gitCommit = "unknown"` (default value preserved for builds outside git).
- `go build -ldflags "-X github.com/geanlabs/gean/node.gitCommit=$(GIT_COMMIT)"` in Makefile and Dockerfile for the `gean` binary only (keygen is a CLI, no runtime metrics).
- `SetNodeInfo("gean", gitCommit)` swaps the literal.

`runtime/debug.BuildInfo` was considered: rejected because `.git` is in `.dockerignore` (intentional for build-context size) so `vcs.*` settings would be absent inside Docker. `-ldflags` reuses the existing build-arg flow without bloating the build context.

Verified locally: `go build -ldflags "-X .../node.gitCommit=test123" -o /tmp/g ./cmd/gean && strings /tmp/g | grep test123` returns `test123`.

## Fix 2 — #301: aggregation buckets match spec STATE_TRANSITION_BUCKETS

Live scrape after PR #299 (`gean:fe3d25a`, 365 samples):

```
<= 5 ms    cumulative=0      ┐
<= 10 ms   cumulative=0      │
<= 25 ms   cumulative=0      │  6 dead lower buckets
<= 50 ms   cumulative=0      │  (sized for some other workload)
<= 100 ms  cumulative=0      │
<= 250 ms  cumulative=0      ┘
<= 500 ms  cumulative=110   (30%)
<= 750 ms  cumulative=226   (32% in bucket)
<= 1000 ms cumulative=329   (28% in bucket)
<= +Inf    cumulative=365   (10% tail invisible — p99 clipped to 1000 ms)
```

leanSpec's `subspecs/metrics/registry.py:42` defines:

```python
STATE_TRANSITION_BUCKETS = (0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 4)
```

State-transition latency is the closest spec-named shape (single-pass timing of moderately heavy work). Bucket vocabulary in gean now matches.

**Spec compliance**: the metric `lean_committee_signatures_aggregation_time_seconds` is gean-specific — `grep` of the leanSpec registry returns zero hits on this name. gean owns the bucket choice. Adopting the spec's named constant's values is convention alignment, not divergence.

Net: drops 6 dead lower buckets, adds 5 useful upper buckets, +/-1 LOC.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -count=1 ./node/...` green (covers metric registration)
- [x] `go test ./...` full suite green
- [x] Manual ldflags verification on the gean binary (`strings` confirms baked-in string)
- [ ] Live devnet scrape: confirm `lean_node_info{client="gean_0"}` reports a real short-hash (~7 chars) and `lean_committee_signatures_aggregation_time_seconds` reports honest p90/p99 (not clipped to a boundary)

## Lean-review pass

Single combined run during implementation:

- `dead-code`: ✅ removes 6 zero-sample histogram buckets that were never hit
- `comment-bloat`: package-var docstring on `gitCommit` is 3 lines but earns its keep (explains ldflags wiring + default fallback); bucket-array comment cross-references spec constant for future maintainers
- `premature-abstraction`: no new helper, interface, or wrapper added — direct ldflags + direct bucket array swap
- `duplicates-existing-util`: N/A
- `defensive-bloat`: N/A
- `over-validated-boundary`: N/A

## Spec compliance pass

Cross-referenced both changes against `leanSpec/src/lean_spec/subspecs/metrics/registry.py`:

| Surface | Spec-defined? | Compliance effect |
|---|---|---|
| `lean_node_info` metric name + label set | Yes | Unchanged (we only fill the value, not redefine the schema) |
| `version` label VALUE | No (impl-specific; clients diverge) | Improvement |
| `lean_committee_signatures_aggregation_time_seconds` name | No (gean-specific) | Unchanged |
| Histogram bucket boundaries | No (gean-specific metric) — but we adopt spec's STATE_TRANSITION_BUCKETS values | Net spec-positive (convention alignment) |

No spec divergence introduced. Previous `/spec-compliant devnet3 head` baseline unchanged.

## Related

- Stacked on PR #299 (`perf/multisig-release-profile`) — base branch
- Closes #300 (version label)
- Closes #301 (histogram buckets)