### PR TITLE
metric: replace 10 duplicated bucket literals with leanSpec-named constants (#303)

### DIFF
--- a/node/metrics.go
+++ b/node/metrics.go
@@ -127,29 +127,39 @@ var (
 
 // --- Histograms ---
 
+// Bucket sets mirror leanSpec's named constants in
+// lean_spec/subspecs/metrics/registry.py:36-45. Defined here once so the
+// histograms that share these shapes don't each carry a duplicated literal
+// that can drift out of spec alignment silently. Histograms whose latency
+// shape doesn't fit any of the four spec constants use their own hand-rolled
+// bucket array inline and note that fact in a comment.
+var (
+	forkChoiceBlockBuckets       = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 1, 1.25, 1.5, 2, 4}
+	attestationValidationBuckets = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 1}
+	stateTransitionBuckets       = []float64{0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 4}
+	reorgDepthBuckets            = []float64{1, 2, 3, 5, 7, 10, 20, 30, 50, 100}
+)
+
 var (
 	metricBlockProcessingTime = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "lean_fork_choice_block_processing_time_seconds",
 		Help:    "Time to process a block",
-		Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 1, 1.25, 1.5, 2, 4},
+		Buckets: forkChoiceBlockBuckets,
 	})
 	metricAttestationValidationTime = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "lean_attestation_validation_time_seconds",
 		Help:    "Time to validate attestation data",
-		Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 1},
+		Buckets: attestationValidationBuckets,
 	})
 	metricCommitteeAggregationTime = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name: "lean_committee_signatures_aggregation_time_seconds",
-		Help: "Time to aggregate committee signatures",
-		// Mirrors leanSpec's STATE_TRANSITION_BUCKETS (lean_spec/subspecs/
-		// metrics/registry.py:42) — the closest spec-named bucket constant
-		// for state-transition-shaped latency.
-		Buckets: []float64{0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 4},
+		Name:    "lean_committee_signatures_aggregation_time_seconds",
+		Help:    "Time to aggregate committee signatures",
+		Buckets: stateTransitionBuckets,
 	})
 	metricPqSigSigningTime = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "lean_pq_sig_attestation_signing_time_seconds",
 		Help:    "Time to sign an attestation",
-		Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 1},
+		Buckets: attestationValidationBuckets,
 	})
 	metricAttestationsProductionTime = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "lean_attestations_production_time_seconds",
@@ -159,7 +169,7 @@ var (
 	metricPqSigVerificationTime = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "lean_pq_sig_attestation_verification_time_seconds",
 		Help:    "Time to verify an individual attestation signature",
-		Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 1},
+		Buckets: attestationValidationBuckets,
 	})
 	metricPqSigAggBuildingTime = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "lean_pq_sig_aggregated_signatures_building_time_seconds",
@@ -179,27 +189,27 @@ var (
 	metricForkChoiceReorgDepth = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "lean_fork_choice_reorg_depth",
 		Help:    "Depth of fork choice reorgs",
-		Buckets: []float64{1, 2, 3, 5, 7, 10, 20, 30, 50, 100},
+		Buckets: reorgDepthBuckets,
 	})
 	metricSTFTime = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "lean_state_transition_time_seconds",
 		Help:    "Time to process full state transition",
-		Buckets: []float64{0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 4},
+		Buckets: stateTransitionBuckets,
 	})
 	metricSTFSlotsTime = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "lean_state_transition_slots_processing_time_seconds",
 		Help:    "Time to process slots",
-		Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 1},
+		Buckets: attestationValidationBuckets,
 	})
 	metricSTFBlockTime = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "lean_state_transition_block_processing_time_seconds",
 		Help:    "Time to process block in state transition",
-		Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 1},
+		Buckets: attestationValidationBuckets,
 	})
 	metricSTFAttestationsTime = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "lean_state_transition_attestations_processing_time_seconds",
 		Help:    "Time to process attestations",
-		Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 1},
+		Buckets: attestationValidationBuckets,
 	})
 	metricBlockBuildingTime = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "lean_block_building_time_seconds",


### PR DESCRIPTION
## Summary

Ten of gean's 21 histograms in \`node/metrics.go\` had inline \`[]float64\` bucket literals whose values already matched one of the four named bucket constants leanSpec defines in \`subspecs/metrics/registry.py:36-45\`. Same bucket boundaries copy-pasted 2-6 times per latency shape. Replaces them with 4 named package-private vars that mirror the spec.

Closes #303.

## What changed

Single file, \`node/metrics.go\`: +25 / -15.

### Added (4 vars at top of histograms block)

\`\`\`go
// Bucket sets mirror leanSpec's named constants in
// lean_spec/subspecs/metrics/registry.py:36-45. Defined here once so the
// histograms that share these shapes don't each carry a duplicated literal
// that can drift out of spec alignment silently. Histograms whose latency
// shape doesn't fit any of the four spec constants use their own hand-rolled
// bucket array inline and note that fact in a comment.
var (
    forkChoiceBlockBuckets       = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 1, 1.25, 1.5, 2, 4}
    attestationValidationBuckets = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 1}
    stateTransitionBuckets       = []float64{0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 4}
    reorgDepthBuckets            = []float64{1, 2, 3, 5, 7, 10, 20, 30, 50, 100}
)
\`\`\`

### Replaced (10 histograms)

| Histogram | Now uses |
|---|---|
| \`lean_fork_choice_block_processing_time_seconds\` | \`forkChoiceBlockBuckets\` |
| \`lean_attestation_validation_time_seconds\` | \`attestationValidationBuckets\` |
| \`lean_committee_signatures_aggregation_time_seconds\` | \`stateTransitionBuckets\` |
| \`lean_pq_sig_attestation_signing_time_seconds\` | \`attestationValidationBuckets\` |
| \`lean_pq_sig_attestation_verification_time_seconds\` | \`attestationValidationBuckets\` |
| \`lean_fork_choice_reorg_depth\` | \`reorgDepthBuckets\` |
| \`lean_state_transition_time_seconds\` | \`stateTransitionBuckets\` |
| \`lean_state_transition_slots_processing_time_seconds\` | \`attestationValidationBuckets\` |
| \`lean_state_transition_block_processing_time_seconds\` | \`attestationValidationBuckets\` |
| \`lean_state_transition_attestations_processing_time_seconds\` | \`attestationValidationBuckets\` |

### Out of scope (11 histograms left hand-rolled)

These either don't measure time at all (byte sizes, payload counts, coverage ratios) or measure a time shape no spec bucket constant covers (\`block_building\`, \`attestations_production\`, aggregated-sig building/verification, full-block sig verification). Left alone.

## Zero behavior change

Each replaced literal had the same values byte-for-byte as the named constant it now points to. Verified by reading the leanSpec file side-by-side and by:
- [x] \`go test -count=1 ./node/...\` green
- [x] No new buckets, no removed buckets, no reordering

A \`/metrics\` scrape post-merge will produce byte-identical bucket boundaries for the 10 affected histograms.

## Spec compliance

Addresses the standing ⚠️ from the previous \`/spec-compliant devnet3 head\` audit:

> "Histogram bucket boundaries should be cross-checked vs spec constants. Possible drift — worth verifying."

After this PR + #301, all gean histograms whose latency shape matches a spec-named bucket constant traceably reference it. The 11 hand-rolled ones are honestly hand-rolled (no spec constant covers them) and don't pretend otherwise.

## Lean-review

Single subtraction-oriented pass during implementation:

- \`duplicates-existing-util\`: ✅ collapses 10 duplicated bucket arrays into 4 named refs
- \`comment-bloat\`: header comment is 6 lines but earns its keep (explains the spec cross-reference + the policy for hand-rolled histograms — both non-obvious to a future reader)
- \`premature-abstraction\`: 4 named vars used 2-6 times each; threshold for naming clearly met
- All other categories: 0 findings

## Related

- Stacked on PR #299 (\`perf/multisig-release-profile\`) — base branch.
- Closes #303
- Builds on #301 (which adopted \`STATE_TRANSITION_BUCKETS\` values for one histogram); this PR extracts those values to a named constant + applies the same alignment to 9 other histograms.