### PR TITLE
perf(node): pool aggregation prep vectors to cut GC pressure (#309)

### DIFF
--- a/node/aggregation_pool.go
+++ b/node/aggregation_pool.go
@@ -1,0 +1,35 @@
+package node
+
+import (
+	"sync"
+
+	"github.com/geanlabs/gean/xmss"
+)
+
+// Per-aggregate scratch slices reused across calls via sync.Pool. Cuts the
+// young-gen GC pressure from re-allocating these four slices per data root
+// (~5-20 per pass × every interval-2 tick). Initial capacities are first-fit
+// guesses; pool reuse grows them to the working set and preserves the
+// capacity across passes.
+//
+// Same pattern as xmss/proof_pool.go: pool stores *[]T, get/put wrappers
+// reset length on return so callers always see an empty slice.
+
+var (
+	childProofsPool = sync.Pool{New: func() any { s := make([]xmss.ChildProof, 0, 8); return &s }}
+	rawPubkeysPool  = sync.Pool{New: func() any { s := make([]xmss.CPubKey, 0, 32); return &s }}
+	rawSigsPool     = sync.Pool{New: func() any { s := make([]xmss.CSig, 0, 32); return &s }}
+	rawIDsPool      = sync.Pool{New: func() any { s := make([]uint64, 0, 32); return &s }}
+)
+
+func getChildProofsBuf() *[]xmss.ChildProof { return childProofsPool.Get().(*[]xmss.ChildProof) }
+func putChildProofsBuf(b *[]xmss.ChildProof) { *b = (*b)[:0]; childProofsPool.Put(b) }
+
+func getRawPubkeysBuf() *[]xmss.CPubKey { return rawPubkeysPool.Get().(*[]xmss.CPubKey) }
+func putRawPubkeysBuf(b *[]xmss.CPubKey) { *b = (*b)[:0]; rawPubkeysPool.Put(b) }
+
+func getRawSigsBuf() *[]xmss.CSig { return rawSigsPool.Get().(*[]xmss.CSig) }
+func putRawSigsBuf(b *[]xmss.CSig) { *b = (*b)[:0]; rawSigsPool.Put(b) }
+
+func getRawIDsBuf() *[]uint64 { return rawIDsPool.Get().(*[]uint64) }
+func putRawIDsBuf(b *[]uint64) { *b = (*b)[:0]; rawIDsPool.Put(b) }

--- a/node/store_aggregate.go
+++ b/node/store_aggregate.go
@@ -127,138 +127,145 @@ func aggregateFromSnapshot(snap *AggregationSnapshot, cache *xmss.PubKeyCache) (
 	}
 
 	for dataRoot := range dataRoots {
-		prepStart := time.Now()
-		gossipEntry := snap.attSigs[dataRoot]
-		newEntry := snap.newEntries[dataRoot]
-		knownEntry := snap.knownEntries[dataRoot]
+		// Anonymous func per iteration so pooled scratch slices (and the
+		// defer xmss.FreeSignature inside the sig loop) release per data
+		// root rather than accumulating until aggregateFromSnapshot returns.
+		func() {
+			childProofsBuf := getChildProofsBuf()
+			defer putChildProofsBuf(childProofsBuf)
+			rawPubkeysBuf := getRawPubkeysBuf()
+			defer putRawPubkeysBuf(rawPubkeysBuf)
+			rawSigsBuf := getRawSigsBuf()
+			defer putRawSigsBuf(rawSigsBuf)
+			rawIDsBuf := getRawIDsBuf()
+			defer putRawIDsBuf(rawIDsBuf)
 
-		// Need attestation data from any available source.
-		var attData *types.AttestationData
-		if gossipEntry != nil {
-			attData = gossipEntry.Data
-		} else if newEntry != nil {
-			attData = newEntry.Data
-		} else if knownEntry != nil {
-			attData = knownEntry.Data
-		}
-		if attData == nil {
-			continue
-		}
+			prepStart := time.Now()
+			gossipEntry := snap.attSigs[dataRoot]
+			newEntry := snap.newEntries[dataRoot]
+			knownEntry := snap.knownEntries[dataRoot]
 
-		targetState := snap.targetStates[attData.Target.Root]
-		if targetState == nil {
-			continue
-		}
+			// Need attestation data from any available source.
+			var attData *types.AttestationData
+			if gossipEntry != nil {
+				attData = gossipEntry.Data
+			} else if newEntry != nil {
+				attData = newEntry.Data
+			} else if knownEntry != nil {
+				attData = knownEntry.Data
+			}
+			if attData == nil {
+				return
+			}
 
-		// Phase 1: Select — greedy pick existing child proofs.
-		var childProofs []xmss.ChildProof
-		covered := make(map[uint64]bool)
+			targetState := snap.targetStates[attData.Target.Root]
+			if targetState == nil {
+				return
+			}
 
-		selectChildProofs(newEntry, targetState, &childProofs, covered, cache)
-		selectChildProofs(knownEntry, targetState, &childProofs, covered, cache)
+			// Phase 1: Select — greedy pick existing child proofs.
+			covered := make(map[uint64]bool)
+			selectChildProofs(newEntry, targetState, childProofsBuf, covered, cache)
+			selectChildProofs(knownEntry, targetState, childProofsBuf, covered, cache)
 
-		// Phase 2: Fill — collect raw gossip signatures for uncovered validators.
-		var rawPubkeys []xmss.CPubKey
-		var rawSigs []xmss.CSig
-		var rawIDs []uint64
+			// Phase 2: Fill — collect raw gossip signatures for uncovered validators.
+			if gossipEntry != nil && len(gossipEntry.Signatures) > 0 {
+				sortedSigs := make([]AttestationSignatureEntry, len(gossipEntry.Signatures))
+				copy(sortedSigs, gossipEntry.Signatures)
+				sort.Slice(sortedSigs, func(i, j int) bool {
+					return sortedSigs[i].ValidatorID < sortedSigs[j].ValidatorID
+				})
 
-		if gossipEntry != nil && len(gossipEntry.Signatures) > 0 {
-			sortedSigs := make([]AttestationSignatureEntry, len(gossipEntry.Signatures))
-			copy(sortedSigs, gossipEntry.Signatures)
-			sort.Slice(sortedSigs, func(i, j int) bool {
-				return sortedSigs[i].ValidatorID < sortedSigs[j].ValidatorID
-			})
+				for _, sigEntry := range sortedSigs {
+					if covered[sigEntry.ValidatorID] {
+						continue
+					}
+					if sigEntry.ValidatorID >= uint64(len(targetState.Validators)) {
+						continue
+					}
 
-			for _, sigEntry := range sortedSigs {
-				if covered[sigEntry.ValidatorID] {
-					continue
-				}
-				if sigEntry.ValidatorID >= uint64(len(targetState.Validators)) {
-					continue
-				}
+					sigHandle := sigEntry.SigHandle
+					if sigHandle == nil {
+						parsed, err := xmss.ParseSignature(sigEntry.Signature[:])
+						if err != nil {
+							continue
+						}
+						defer xmss.FreeSignature(parsed)
+						sigHandle = parsed
+					}
 
-				sigHandle := sigEntry.SigHandle
-				if sigHandle == nil {
-					parsed, err := xmss.ParseSignature(sigEntry.Signature[:])
+					pk, err := cache.Get(targetState.Validators[sigEntry.ValidatorID].AttestationPubkey)
 					if err != nil {
 						continue
 					}
-					defer xmss.FreeSignature(parsed)
-					sigHandle = parsed
+
+					*rawPubkeysBuf = append(*rawPubkeysBuf, pk)
+					*rawSigsBuf = append(*rawSigsBuf, sigHandle)
+					*rawIDsBuf = append(*rawIDsBuf, sigEntry.ValidatorID)
 				}
+			}
 
-				pk, err := cache.Get(targetState.Validators[sigEntry.ValidatorID].AttestationPubkey)
-				if err != nil {
-					continue
+			// Prover requires at least 2 total inputs.
+			if len(*rawIDsBuf)+len(*childProofsBuf) < 2 {
+				return
+			}
+
+			// Phase 3: Aggregate — produce recursive proof.
+			dataRootHash, _ := attData.HashTreeRoot()
+			slot := uint32(attData.Slot)
+
+			ObserveAggregationPrepTime(time.Since(prepStart).Seconds())
+
+			aggStart := time.Now()
+			proofBytes, err := xmss.AggregateWithChildren(*rawPubkeysBuf, *rawSigsBuf, *childProofsBuf, dataRootHash, slot)
+			aggDuration := time.Since(aggStart)
+			if err != nil {
+				logger.Error(logger.Signature, "aggregate: failed slot=%d raw=%d children=%d duration=%v: %v",
+					slot, len(*rawIDsBuf), len(*childProofsBuf), aggDuration, err)
+				return
+			}
+
+			allIDs := make([]uint64, 0, len(*rawIDsBuf)+len(covered))
+			allIDs = append(allIDs, (*rawIDsBuf)...)
+			for vid := range covered {
+				allIDs = append(allIDs, vid)
+			}
+
+			participants := AggregationBitsFromIndices(allIDs)
+			proof := &types.AggregatedSignatureProof{
+				Participants: participants,
+				ProofData:    proofBytes,
+			}
+
+			logger.Info(logger.Signature, "aggregate: slot=%d raw=%d children=%d total=%d proof=%d bytes duration=%v",
+				slot, len(*rawIDsBuf), len(*childProofsBuf), len(allIDs), len(proofBytes), aggDuration)
+
+			if AggregateMetricsFunc != nil {
+				AggregateMetricsFunc(aggDuration.Seconds(), len(allIDs))
+			}
+
+			postStart := time.Now()
+			newAggregates = append(newAggregates, &types.SignedAggregatedAttestation{
+				Data:  attData,
+				Proof: proof,
+			})
+
+			mut.PayloadEntries = append(mut.PayloadEntries, PayloadKV{
+				DataRoot: dataRoot,
+				Data:     attData,
+				Proof:    proof,
+			})
+
+			if gossipEntry != nil {
+				for _, sig := range gossipEntry.Signatures {
+					mut.KeysToDelete = append(mut.KeysToDelete, AttestationDeleteKey{
+						ValidatorID: sig.ValidatorID,
+						DataRoot:    dataRoot,
+					})
 				}
-
-				rawPubkeys = append(rawPubkeys, pk)
-				rawSigs = append(rawSigs, sigHandle)
-				rawIDs = append(rawIDs, sigEntry.ValidatorID)
 			}
-		}
-
-		// Prover requires at least 2 total inputs.
-		totalInputs := len(rawIDs) + len(childProofs)
-		if totalInputs < 2 {
-			continue
-		}
-
-		// Phase 3: Aggregate — produce recursive proof.
-		dataRootHash, _ := attData.HashTreeRoot()
-		slot := uint32(attData.Slot)
-
-		ObserveAggregationPrepTime(time.Since(prepStart).Seconds())
-
-		aggStart := time.Now()
-		proofBytes, err := xmss.AggregateWithChildren(rawPubkeys, rawSigs, childProofs, dataRootHash, slot)
-		aggDuration := time.Since(aggStart)
-		if err != nil {
-			logger.Error(logger.Signature, "aggregate: failed slot=%d raw=%d children=%d duration=%v: %v",
-				slot, len(rawIDs), len(childProofs), aggDuration, err)
-			continue
-		}
-
-		allIDs := make([]uint64, 0, len(rawIDs))
-		allIDs = append(allIDs, rawIDs...)
-		for vid := range covered {
-			allIDs = append(allIDs, vid)
-		}
-
-		participants := AggregationBitsFromIndices(allIDs)
-		proof := &types.AggregatedSignatureProof{
-			Participants: participants,
-			ProofData:    proofBytes,
-		}
-
-		logger.Info(logger.Signature, "aggregate: slot=%d raw=%d children=%d total=%d proof=%d bytes duration=%v",
-			slot, len(rawIDs), len(childProofs), len(allIDs), len(proofBytes), aggDuration)
-
-		if AggregateMetricsFunc != nil {
-			AggregateMetricsFunc(aggDuration.Seconds(), len(allIDs))
-		}
-
-		postStart := time.Now()
-		newAggregates = append(newAggregates, &types.SignedAggregatedAttestation{
-			Data:  attData,
-			Proof: proof,
-		})
-
-		mut.PayloadEntries = append(mut.PayloadEntries, PayloadKV{
-			DataRoot: dataRoot,
-			Data:     attData,
-			Proof:    proof,
-		})
-
-		if gossipEntry != nil {
-			for _, sig := range gossipEntry.Signatures {
-				mut.KeysToDelete = append(mut.KeysToDelete, AttestationDeleteKey{
-					ValidatorID: sig.ValidatorID,
-					DataRoot:    dataRoot,
-				})
-			}
-		}
-		ObserveAggregationPostTime(time.Since(postStart).Seconds())
+			ObserveAggregationPostTime(time.Since(postStart).Seconds())
+		}()
 	}
 
 	return newAggregates, mut


### PR DESCRIPTION
## Summary

Adds `sync.Pool` reuse + capacity hints for the four prep slices used per data root in `aggregateFromSnapshot` (`childProofs`, `rawPubkeys`, `rawSigs`, `rawIDs`). Reduces young-gen GC pressure during the long-running FFI window — the suspected dominant source of gean's p99 tail above 1 s. Closes #309.

## Why

Pre-PR: each iteration allocated 4 slices nil-initialised, grew them via `append` doubling, then discarded. At 5-20 data roots per pass, that's 20-80 allocations per pass × every interval-2 tick. The 400 ms FFI window is a generous opening for the runtime to schedule a 10-30 ms STW GC pause inside.

ethlambda pays nothing equivalent — Rust ownership, stack-allocated buffers dropped at scope exit (`ethlambda/crates/blockchain/src/aggregation.rs:238` uses `Vec::with_capacity`).

## What changed

### New: `node/aggregation_pool.go` (+35 LOC)

Four `sync.Pool`s, one per prep slice type, with first-fit capacity hints (8 children, 32 raw sigs). Typed `get*Buf`/`put*Buf` wrappers identical in shape to the existing `xmss/proof_pool.go` pattern. Put resets length to 0 preserving capacity.

### Modified: `node/store_aggregate.go` (+116 / -109 LOC, net +7)

Refactor of `aggregateFromSnapshot`'s per-data-root loop:

- Wraps loop body in `func(){}()` so `defer` pool-Put fires per iteration (not per function-return — the latter would defeat reuse).
- Replaces `continue` with `return` inside the anonymous func.
- Slice access via `*bufPtr`; appends via `*bufPtr = append(*bufPtr, x)`.
- Capacity hint added to `allIDs` (was 0, now `rawIDs + covered` size).

### Secondary win

`defer xmss.FreeSignature(parsed)` inside the inner sig loop now fires per data root rather than accumulating across the whole pass to function return. Tighter C-side handle lifetime; previously all parsed sig handles from all data roots in a pass leaked until `aggregateFromSnapshot` returned.

## Behavior change

None. Same FFI calls in the same order, same store mutations (via `*AggregationMutations` from #307), same broadcast set. Only the lifetime of internal scratch slices and one C-handle defer batch changes — both shorter, both correct.

## Expected impact

Per the gean-vs-ethlambda analysis: 20-40 ms p50 recovery, more on p99 (GC pauses are tail-dominant). Real numbers come from #305's phase-attribution histograms post-merge — if `prep` isn't where the gap lives, this PR's measured impact will be small and we'd refocus on `post` or `commit`.

## Spec compliance

Zero impact. No spec-mapped function or container modified.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -count=1 ./node/...` green
- [ ] Post-merge: `lean_aggregation_prep_time_seconds` p99 should drop measurably vs the post-#306 baseline; rate of Go GC pauses (via Go runtime metrics) should decline

## Lean-review

- `dead-code`: N/A
- `premature-abstraction`: 4 pools, 8 helpers — sized to current need; no speculative pool surface
- `defensive-bloat`: N/A
- `duplicates-existing-util`: ✅ followed existing `xmss/proof_pool.go` pattern; no parallel pool helper invented
- `comment-bloat`: header on `aggregation_pool.go` is 8 lines explaining the why + the existing-pattern cross-reference; earns its keep
- `over-validated-boundary`: N/A

## Stack

Originally stacked on PR #308 (snapshot refactor), which has now merged into `perf/instrument-aggregation-phases`. Rebased trivially; this PR now diffs cleanly against `perf/instrument-aggregation-phases` head with just the one Phase C commit.