### PR TITLE
statetransition: gate latest_justified advance on slot monotonicity

### DIFF
--- a/statetransition/attestations.go
+++ b/statetransition/attestations.go
@@ -61,11 +61,8 @@ func ProcessAttestations(state *types.State, attestations []*types.AggregatedAtt
 		// Check supermajority: 3 * votes >= 2 * validators.
 		voteCount := countTrue(votes)
 		if 3*voteCount >= 2*validatorCount {
-			// Justify the target. Only advance latest_justified forward;
-			// multiple supermajority attestations in one block can resolve
-			// in non-monotonic target-slot order, and processing a smaller
-			// target after a larger one must not drag the checkpoint
-			// backward (leanSpec PR #781).
+			// Only advance latest_justified forward — a block's supermajority
+			// targets are not slot-ordered in body order (leanSpec PR #781).
 			if target.Slot > state.LatestJustified.Slot {
 				state.LatestJustified = target
 			}

--- a/statetransition/attestations.go
+++ b/statetransition/attestations.go
@@ -61,8 +61,14 @@ func ProcessAttestations(state *types.State, attestations []*types.AggregatedAtt
 		// Check supermajority: 3 * votes >= 2 * validators.
 		voteCount := countTrue(votes)
 		if 3*voteCount >= 2*validatorCount {
-			// Justify the target.
-			state.LatestJustified = target
+			// Justify the target. Only advance latest_justified forward;
+			// multiple supermajority attestations in one block can resolve
+			// in non-monotonic target-slot order, and processing a smaller
+			// target after a larger one must not drag the checkpoint
+			// backward (leanSpec PR #781).
+			if target.Slot > state.LatestJustified.Slot {
+				state.LatestJustified = target
+			}
 			setSlotJustified(state, state.LatestFinalized.Slot, target.Slot)
 
 			// Remove from pending (now justified).

--- a/statetransition/attestations_test.go
+++ b/statetransition/attestations_test.go
@@ -6,22 +6,14 @@ import (
 	"github.com/geanlabs/gean/types"
 )
 
-// TestLatestJustifiedDoesNotRegressWithinBlock is the Go port of ethlambda's
-// `latest_justified_does_not_regress_within_block` regression test
-// (ethlambda/crates/blockchain/state_transition/src/lib.rs:600-661) and the
-// regression scenario covered by leanSpec PR #781
-// (test_same_block_multi_target_attestations_advance_to_highest_slot).
+// TestLatestJustifiedDoesNotRegressWithinBlock ports ethlambda's
+// latest_justified_does_not_regress_within_block regression and covers
+// leanSpec PR #781.
 //
 // A single block carries three supermajority attestations targeting slots
 // 4, 9, 6 in body order — all justifiable from finalized genesis (Δ=4 ≤ 5,
 // Δ=9 = 3², Δ=6 = 2·3). With 4 validators, three votes is supermajority,
 // so each attestation crosses the threshold.
-//
-// Before the fix, the unconditional `state.LatestJustified = target` at
-// statetransition/attestations.go:65 let the slot-6 attestation processed
-// last drag LatestJustified from slot 9 back to slot 6. After the fix
-// (guard on target.Slot > state.LatestJustified.Slot), LatestJustified
-// stays at the highest justified slot regardless of body order.
 //
 // The per-slot justified_slots bitfield still records all three targets;
 // only the LatestJustified pointer is gated.

--- a/statetransition/attestations_test.go
+++ b/statetransition/attestations_test.go
@@ -38,8 +38,6 @@ func TestLatestJustifiedDoesNotRegressWithinBlock(t *testing.T) {
 	copy(hashes[9], r9[:])
 
 	state := makeGenesisState(numValidators)
-	state.Slot = 10
-	state.LatestBlockHeader.Slot = 9
 	state.LatestJustified = &types.Checkpoint{Slot: 3, Root: r3}
 	state.LatestFinalized = &types.Checkpoint{}
 	state.HistoricalBlockHashes = hashes

--- a/statetransition/attestations_test.go
+++ b/statetransition/attestations_test.go
@@ -46,11 +46,13 @@ func TestLatestJustifiedDoesNotRegressWithinBlock(t *testing.T) {
 
 	// Aggregation bits: 4-bit bitlist with validators 0/1/2 voted.
 	// Layout: data bits [1,1,1,0] + delimiter at position 4 → 0b00010111 = 0x17.
-	bits := func() []byte { return []byte{0x17} }
+	// ProcessAttestations only reads AggregationBits, so the three calls below
+	// can share one backing slice.
+	bits := []byte{0x17}
 
 	mkAtt := func(targetSlot uint64, targetRoot [types.RootSize]byte) *types.AggregatedAttestation {
 		return &types.AggregatedAttestation{
-			AggregationBits: bits(),
+			AggregationBits: bits,
 			Data: &types.AttestationData{
 				Slot:   targetSlot,
 				Head:   &types.Checkpoint{Slot: targetSlot, Root: targetRoot},

--- a/statetransition/attestations_test.go
+++ b/statetransition/attestations_test.go
@@ -1,0 +1,92 @@
+package statetransition
+
+import (
+	"testing"
+
+	"github.com/geanlabs/gean/types"
+)
+
+// TestLatestJustifiedDoesNotRegressWithinBlock is the Go port of ethlambda's
+// `latest_justified_does_not_regress_within_block` regression test
+// (ethlambda/crates/blockchain/state_transition/src/lib.rs:600-661) and the
+// regression scenario covered by leanSpec PR #781
+// (test_same_block_multi_target_attestations_advance_to_highest_slot).
+//
+// A single block carries three supermajority attestations targeting slots
+// 4, 9, 6 in body order — all justifiable from finalized genesis (Δ=4 ≤ 5,
+// Δ=9 = 3², Δ=6 = 2·3). With 4 validators, three votes is supermajority,
+// so each attestation crosses the threshold.
+//
+// Before the fix, the unconditional `state.LatestJustified = target` at
+// statetransition/attestations.go:65 let the slot-6 attestation processed
+// last drag LatestJustified from slot 9 back to slot 6. After the fix
+// (guard on target.Slot > state.LatestJustified.Slot), LatestJustified
+// stays at the highest justified slot regardless of body order.
+//
+// The per-slot justified_slots bitfield still records all three targets;
+// only the LatestJustified pointer is gated.
+func TestLatestJustifiedDoesNotRegressWithinBlock(t *testing.T) {
+	const numValidators = 4
+
+	var r3, r4, r6, r9 [types.RootSize]byte
+	r3[0] = 3
+	r4[0] = 4
+	r6[0] = 6
+	r9[0] = 9
+
+	// historical_block_hashes indexed by slot. Only 3/4/6/9 populated;
+	// other entries are zero (not referenced by any attestation here).
+	hashes := make([][]byte, 10)
+	for i := range hashes {
+		hashes[i] = make([]byte, types.RootSize)
+	}
+	copy(hashes[3], r3[:])
+	copy(hashes[4], r4[:])
+	copy(hashes[6], r6[:])
+	copy(hashes[9], r9[:])
+
+	state := makeGenesisState(numValidators)
+	state.Slot = 10
+	state.LatestBlockHeader.Slot = 9
+	state.LatestJustified = &types.Checkpoint{Slot: 3, Root: r3}
+	state.LatestFinalized = &types.Checkpoint{}
+	state.HistoricalBlockHashes = hashes
+	// Mark slot 3 as justified so source=(3, r3) passes isValidVote.
+	setSlotJustified(state, 0, 3)
+
+	// Aggregation bits: 4-bit bitlist with validators 0/1/2 voted.
+	// Layout: data bits [1,1,1,0] + delimiter at position 4 → 0b00010111 = 0x17.
+	bits := func() []byte { return []byte{0x17} }
+
+	mkAtt := func(targetSlot uint64, targetRoot [types.RootSize]byte) *types.AggregatedAttestation {
+		return &types.AggregatedAttestation{
+			AggregationBits: bits(),
+			Data: &types.AttestationData{
+				Slot:   targetSlot,
+				Head:   &types.Checkpoint{Slot: targetSlot, Root: targetRoot},
+				Target: &types.Checkpoint{Slot: targetSlot, Root: targetRoot},
+				Source: &types.Checkpoint{Slot: 3, Root: r3},
+			},
+		}
+	}
+
+	// Body order: 4 → 9 → 6. Slot-6 attestation is processed last;
+	// without the monotonic guard it would overwrite the slot-9 checkpoint.
+	atts := []*types.AggregatedAttestation{
+		mkAtt(4, r4),
+		mkAtt(9, r9),
+		mkAtt(6, r6),
+	}
+
+	if err := ProcessAttestations(state, atts); err != nil {
+		t.Fatalf("ProcessAttestations: %v", err)
+	}
+
+	if state.LatestJustified.Slot != 9 {
+		t.Fatalf("LatestJustified.Slot = %d, want 9 (monotonic guard violated — slot 6 dragged checkpoint back)",
+			state.LatestJustified.Slot)
+	}
+	if state.LatestJustified.Root != r9 {
+		t.Fatalf("LatestJustified.Root = %x, want %x", state.LatestJustified.Root, r9)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #314 — justification monotonicity bug surfaced by Mega from the ethlambda team and patched upstream in [leanSpec PR #781](https://github.com/leanEthereum/leanSpec/pull/781).

A block body can carry multiple supermajority attestations for distinct targets. `ProcessAttestations` previously did an unconditional assignment:

```go
if 3*voteCount >= 2*validatorCount {
    state.LatestJustified = target
    setSlotJustified(state, state.LatestFinalized.Slot, target.Slot)
    ...
}
```

If the supermajority attestations in one block resolve in non-monotonic target-slot order — e.g. body order targeting slots 4 → 9 → 6 — the slot-6 attestation processed last drags `LatestJustified` from slot 9 back to slot 6, violating the invariant that the latest justified checkpoint only advances forward.

The fix guards the assignment on `target.Slot > state.LatestJustified.Slot`. The per-slot `justified_slots` bitfield still records all three targets; only the `LatestJustified` pointer is gated. This matches:
- leanSpec PR #781: the same `if target.slot > state.latest_justified.slot:` guard
- ethlambda's fix at `state_transition/src/lib.rs:308-309`: `std::cmp::max_by_key(state.latest_justified, target, |c| c.slot)`

## Files

- `statetransition/attestations.go` — add the monotonic guard
- `statetransition/attestations_test.go` — new file; adds `TestLatestJustifiedDoesNotRegressWithinBlock`, the Go port of ethlambda's `latest_justified_does_not_regress_within_block` regression

## What this PR does NOT do

Per #314, this PR deliberately does **not** bump `LEAN_SPEC_COMMIT_HASH` or regenerate spec fixtures. leanSpec `main` is currently mid-devnet5 churn mixed with devnet4 patches, so we cherry-pick the fix into devnet-4 directly and defer the pin bump until devnet5 work begins.

## Test plan

- [x] `go test ./statetransition/...` — new regression passes
- [x] Negative check: temporarily reverted the guard and re-ran `TestLatestJustifiedDoesNotRegressWithinBlock` — observed `LatestJustified.Slot = 6, want 9` confirming the test catches the bug
- [x] `go test ./...` — full suite green
- [ ] CI green