### PR TITLE
node: make ConsensusStore single-writer for aggregation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+`gean` is a Go consensus client for Lean Consensus devnet-4 with Rust XMSS FFI.
+
+- `node/`: consensus event loop, store, block/attestation processing, gossip ingress, aggregation, pruning, validator duties, and metrics.
+- `statetransition/`: deterministic state transition logic.
+- `forkchoice/`: fork-choice implementation.
+- `p2p/`: libp2p gossip, req/resp, discovery, and peer handling.
+- `xmss/`: Go bindings and Rust FFI glue for hash-based signatures and aggregation.
+- `types/`: SSZ containers and generated codecs.
+- `storage/`, `genesis/`, `checkpoint/`, `api/`: persistence, genesis setup, checkpoint utilities, and beacon API.
+- `spectests/` and `specfixtures/`: leanSpec fixture-based tests.
+
+## Build, Test, and Development Commands
+
+- `make build`: build Rust FFI libraries and Go binaries.
+- `make test`: run the standard Go unit suite.
+- `make test-ffi`: run XMSS FFI tests.
+- `make test-spec`: run leanSpec fixture tests.
+- `make test-all`: run the full test suite; this is slower.
+- `make fmt`: run `gofmt`.
+- `make lint`: run Go and Rust lint checks.
+- `go test ./node -run TestName -v -count=1`: run one focused node test.
+
+## Coding Style & Naming Conventions
+
+Use `gofmt` for Go and `cargo fmt` for Rust FFI code. Keep packages flat, direct, and readable. Prefer explicit data flow over clever abstractions, and keep changes scoped to the affected package.
+
+## Consensus Store Concurrency Rule
+
+`Engine.Run` owns `ConsensusStore` mutation. Worker goroutines may verify, aggregate, fetch, or compute from detached snapshots, but must return results over channels for the event loop to apply. Do not pass live store maps, mutable slices, or FFI-owned handles to workers.
+
+## Testing Guidelines
+
+Place Go tests beside code as `*_test.go`. For `node/` concurrency, run `go test -race ./node` when touching goroutines, snapshots, store buffers, or FFI handle ownership. Add regression tests for snapshot detachment whenever worker inputs include maps, slices, pointers, or handles.
+
+## Commit & Pull Request Guidelines
+
+Use short imperative commit subjects, preferably scoped, such as `fix(node): keep aggregation store mutations on event loop`. PRs should include a concise behavior summary, linked issue when relevant, and exact verification commands.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# CLAUDE.md
+
+This file gives Claude Code guidance for working in `gean`, the Go Lean Consensus client.
+
+## Project Map
+
+- `node/`: core runtime. `Engine.Run` drives the event loop; `consensus_store.go` and `store_*.go` hold store behavior by concern; aggregation, validator duties, pruning, block production, gossip ingress, and metrics live here.
+- `statetransition/`: pure state transition logic.
+- `forkchoice/`: fork-choice implementation.
+- `p2p/`: libp2p gossip, req/resp, discovery, and peer handling.
+- `xmss/`: XMSS and aggregation FFI boundary. Rust glue lives under `xmss/rust/`.
+- `types/`: SSZ types and generated codecs.
+- `storage/`, `genesis/`, `checkpoint/`, `api/`: persistence, bootstrapping, checkpoint support, and beacon API.
+- `spectests/` and `specfixtures/`: leanSpec fixture tests.
+
+## Commands
+
+```sh
+make build        # build Rust FFI libs and Go binaries
+make test         # standard unit tests
+make test-ffi     # XMSS FFI tests
+make test-spec    # leanSpec fixture tests
+make test-all     # full suite, slow
+make fmt          # gofmt
+make lint         # Go and Rust lint checks
+make sszgen       # regenerate SSZ codecs from struct tags
+```
+
+Run focused tests with `go test ./node -run TestName -v -count=1`.
+
+## Architecture Rules
+
+Keep the code flat, explicit, and local to the affected subsystem. Prefer readable control flow over abstractions that hide consensus behavior.
+
+`Engine.Run` is the single writer for `ConsensusStore` and its owned buffers. Background goroutines may do expensive verification, fetching, or aggregation only from detached snapshots, then send results back over channels for the event loop to apply. Never share live store maps, mutable slices, or FFI-owned handles with worker goroutines.
+
+FFI handle ownership must be explicit. If a worker needs signature handles, prefer giving it raw bytes and letting it parse/free its own temporary handles.
+
+## Testing Expectations
+
+Run targeted tests first, then the relevant package suite. When changing `node/` goroutines, snapshots, store buffers, or FFI handle ownership, run:
+
+```sh
+go test ./node
+go test -race ./node
+```
+
+Add regression tests for any snapshot that crosses a goroutine boundary.

--- a/node/aggregation_pool.go
+++ b/node/aggregation_pool.go
@@ -17,14 +17,14 @@ var (
 	rawIDsPool      = sync.Pool{New: func() any { s := make([]uint64, 0, 32); return &s }}
 )
 
-func getChildProofsBuf() *[]xmss.ChildProof { return childProofsPool.Get().(*[]xmss.ChildProof) }
+func getChildProofsBuf() *[]xmss.ChildProof  { return childProofsPool.Get().(*[]xmss.ChildProof) }
 func putChildProofsBuf(b *[]xmss.ChildProof) { *b = (*b)[:0]; childProofsPool.Put(b) }
 
-func getRawPubkeysBuf() *[]xmss.CPubKey { return rawPubkeysPool.Get().(*[]xmss.CPubKey) }
+func getRawPubkeysBuf() *[]xmss.CPubKey  { return rawPubkeysPool.Get().(*[]xmss.CPubKey) }
 func putRawPubkeysBuf(b *[]xmss.CPubKey) { *b = (*b)[:0]; rawPubkeysPool.Put(b) }
 
-func getRawSigsBuf() *[]xmss.CSig { return rawSigsPool.Get().(*[]xmss.CSig) }
+func getRawSigsBuf() *[]xmss.CSig  { return rawSigsPool.Get().(*[]xmss.CSig) }
 func putRawSigsBuf(b *[]xmss.CSig) { *b = (*b)[:0]; rawSigsPool.Put(b) }
 
-func getRawIDsBuf() *[]uint64 { return rawIDsPool.Get().(*[]uint64) }
+func getRawIDsBuf() *[]uint64  { return rawIDsPool.Get().(*[]uint64) }
 func putRawIDsBuf(b *[]uint64) { *b = (*b)[:0]; rawIDsPool.Put(b) }

--- a/node/consensus_store_test.go
+++ b/node/consensus_store_test.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"testing"
+	"unsafe"
 
 	"github.com/geanlabs/gean/storage"
 	"github.com/geanlabs/gean/types"
@@ -227,6 +228,36 @@ func TestAttestationSignatureInsertAndDelete(t *testing.T) {
 	}
 }
 
+func TestAttestationSignatureSnapshotDetachesEntries(t *testing.T) {
+	gsm := NewAttestationSignatureMap()
+	var dr [32]byte
+	dr[0] = 1
+	data := &types.AttestationData{Slot: 5}
+	var sig [types.SignatureSize]byte
+	sig[0] = 9
+	var handleMarker byte
+
+	gsm.InsertWithHandle(dr, data, 7, sig, unsafe.Pointer(&handleMarker), nil)
+	snap := gsm.Snapshot()
+
+	data.Slot = 99
+	gsm.Insert(dr, data, 8, sig)
+
+	entry := snap[dr]
+	if entry == nil {
+		t.Fatal("expected snapshot entry")
+	}
+	if entry.Data == data || entry.Data.Slot != 5 {
+		t.Fatalf("snapshot should own attestation data copy, got %#v", entry.Data)
+	}
+	if len(entry.Signatures) != 1 {
+		t.Fatalf("snapshot should not share signatures slice, got %d", len(entry.Signatures))
+	}
+	if entry.Signatures[0].SigHandle != nil {
+		t.Fatal("snapshot must not share live C signature handles")
+	}
+}
+
 func TestAttestationSignaturePruneBelow(t *testing.T) {
 	gsm := NewAttestationSignatureMap()
 	var sig [types.SignatureSize]byte
@@ -242,6 +273,75 @@ func TestAttestationSignaturePruneBelow(t *testing.T) {
 	}
 	if gsm.Len() != 2 {
 		t.Fatalf("expected 2 remaining, got %d", gsm.Len())
+	}
+}
+
+func TestAggregationSnapshotDetachesPayloadEntries(t *testing.T) {
+	s := makeTestStore()
+	headRoot := [32]byte{0x01}
+	targetRoot := [32]byte{0x02}
+	s.SetHead(headRoot)
+	state := &types.State{
+		Config:                   &types.ChainConfig{GenesisTime: 1000},
+		Slot:                     10,
+		LatestBlockHeader:        &types.BlockHeader{},
+		LatestJustified:          &types.Checkpoint{},
+		LatestFinalized:          &types.Checkpoint{},
+		JustifiedSlots:           types.NewBitlistSSZ(0),
+		JustificationsValidators: types.NewBitlistSSZ(0),
+	}
+	s.InsertState(headRoot, state)
+	s.InsertState(targetRoot, state)
+
+	data := &types.AttestationData{
+		Slot:   5,
+		Head:   &types.Checkpoint{Root: headRoot, Slot: 5},
+		Target: &types.Checkpoint{Root: targetRoot, Slot: 4},
+		Source: &types.Checkpoint{Root: headRoot, Slot: 3},
+	}
+	dataRoot, _ := data.HashTreeRoot()
+	newProof := &types.AggregatedSignatureProof{
+		Participants: []byte{0x01},
+		ProofData:    []byte{0x02},
+	}
+	knownProof := &types.AggregatedSignatureProof{
+		Participants: []byte{0x03},
+		ProofData:    []byte{0x04},
+	}
+	s.NewPayloads.Push(dataRoot, data, newProof)
+	s.KnownPayloads.Push(dataRoot, data, knownProof)
+
+	snap := snapshotAggregationInputs(s)
+	if snap == nil {
+		t.Fatal("expected aggregation snapshot")
+	}
+
+	data.Slot = 99
+	newProof.Participants[0] = 0xff
+	newProof.ProofData[0] = 0xfe
+	knownProof.Participants[0] = 0xfd
+	s.NewPayloads.Push(dataRoot, data, &types.AggregatedSignatureProof{Participants: []byte{0x05}})
+
+	newEntry := snap.newEntries[dataRoot]
+	if newEntry == nil {
+		t.Fatal("expected new payload snapshot entry")
+	}
+	if newEntry.Data == data || newEntry.Data.Slot != 5 {
+		t.Fatalf("snapshot should own payload data copy, got %#v", newEntry.Data)
+	}
+	if len(newEntry.Proofs) != 1 {
+		t.Fatalf("snapshot should not share proof slice, got %d proofs", len(newEntry.Proofs))
+	}
+	if newEntry.Proofs[0].Participants[0] != 0x01 || newEntry.Proofs[0].ProofData[0] != 0x02 {
+		t.Fatal("snapshot should own proof byte slices")
+	}
+
+	knownEntry := snap.knownEntries[dataRoot]
+	if knownEntry == nil {
+		t.Fatal("expected known payload snapshot entry")
+	}
+	if knownEntry.Proofs[0].Participants[0] != 0x03 {
+		t.Fatal("snapshot should own known payload proof bytes")
 	}
 }
 

--- a/node/metrics.go
+++ b/node/metrics.go
@@ -141,7 +141,7 @@ var (
 		Help:    "Time to validate attestation data",
 		Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 1},
 	})
-metricPqSigSigningTime = promauto.NewHistogram(prometheus.HistogramOpts{
+	metricPqSigSigningTime = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "lean_pq_sig_attestation_signing_time_seconds",
 		Help:    "Time to sign an attestation",
 		Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 1},
@@ -336,9 +336,11 @@ func ObserveAttestationsProductionTime(seconds float64) {
 }
 func ObservePqSigVerificationTime(seconds float64) { metricPqSigVerificationTime.Observe(seconds) }
 func ObservePqSigAggBuildingTime(seconds float64)  { metricPqSigAggBuildingTime.Observe(seconds) }
-func ObserveAggregationPrepTime(seconds float64)        { metricAggregationPrepTime.Observe(seconds) }
-func ObserveAggregationWorkerTotalTime(seconds float64) { metricAggregationWorkerTotalTime.Observe(seconds) }
-func IncAggregationDispatchDropped()                    { metricAggregationDispatchDropped.Inc() }
+func ObserveAggregationPrepTime(seconds float64)   { metricAggregationPrepTime.Observe(seconds) }
+func ObserveAggregationWorkerTotalTime(seconds float64) {
+	metricAggregationWorkerTotalTime.Observe(seconds)
+}
+func IncAggregationDispatchDropped() { metricAggregationDispatchDropped.Inc() }
 func ObservePqSigAggVerificationTime(seconds float64) {
 	metricPqSigAggVerificationTime.Observe(seconds)
 }

--- a/node/node.go
+++ b/node/node.go
@@ -60,6 +60,7 @@ type Engine struct {
 	// to delaying the next tick. Drops are spec-permissible (aggregation is
 	// best-effort per slot) and surface via lean_aggregation_dispatch_dropped_total.
 	AggregationDispatchCh chan AggregationDispatch
+	AggregationResultCh   chan AggregationResult
 
 	// lastTick holds the wall time of the previous onTick invocation. Zero
 	// means no prior tick — the very first tick records no observation
@@ -77,23 +78,24 @@ func New(
 	committeeCount uint64,
 ) *Engine {
 	return &Engine{
-		Store:               s,
-		FC:                  fc,
-		P2P:                 p2pHost,
-		Keys:                keys,
-		AggCtl:              aggCtl,
-		DutyGate:            NewDutyGate(),
-		CommitteeCount:      committeeCount,
-		PendingBlocks:       make(map[[32]byte]map[[32]byte]bool),
-		PendingBlockParents: make(map[[32]byte][32]byte),
-		PendingBlockDepths:  make(map[[32]byte]int),
-		PendingAttestations: NewPendingAttestationBuffer(PendingAttestationsPerRootCap, PendingAttestationsTotalCap),
+		Store:                 s,
+		FC:                    fc,
+		P2P:                   p2pHost,
+		Keys:                  keys,
+		AggCtl:                aggCtl,
+		DutyGate:              NewDutyGate(),
+		CommitteeCount:        committeeCount,
+		PendingBlocks:         make(map[[32]byte]map[[32]byte]bool),
+		PendingBlockParents:   make(map[[32]byte][32]byte),
+		PendingBlockDepths:    make(map[[32]byte]int),
+		PendingAttestations:   NewPendingAttestationBuffer(PendingAttestationsPerRootCap, PendingAttestationsTotalCap),
 		BlockCh:               make(chan *types.SignedBlock, 64),
 		AttestationCh:         make(chan *types.SignedAttestation, 256),
 		AggregationCh:         make(chan *types.SignedAggregatedAttestation, 64),
 		FailedRootCh:          make(chan [32]byte, 64),
 		FetchRootCh:           make(chan [32]byte, 256),
 		AggregationDispatchCh: make(chan AggregationDispatch, 1),
+		AggregationResultCh:   make(chan AggregationResult, 1),
 	}
 }
 
@@ -190,6 +192,9 @@ func (e *Engine) Run(ctx context.Context) {
 
 		case agg := <-e.AggregationCh:
 			e.onGossipAggregatedAttestation(agg)
+
+		case result := <-e.AggregationResultCh:
+			e.onAggregationResult(result)
 
 		case root := <-e.FailedRootCh:
 			e.onFailedRoot(root)

--- a/node/store_aggregate.go
+++ b/node/store_aggregate.go
@@ -19,10 +19,20 @@ type AggregationDispatch struct {
 	slot     uint64
 }
 
-// runAggregationWorker drains AggregationDispatchCh and runs the prove +
-// publish + apply phases off the tick loop. Mirrors ethlambda's
-// tokio::spawn_blocking pattern (aggregation.rs:395-462) and zeam's worker
-// threads — the consensus tick never blocks on the FFI.
+// AggregationResult carries completed aggregation work back to the event loop.
+// Store mutations and publish side effects are applied by the single-writer
+// goroutine, not by the worker.
+type AggregationResult struct {
+	slot     uint64
+	aggs     []*types.SignedAggregatedAttestation
+	payloads []PayloadKV
+	deletes  []AttestationDeleteKey
+	duration time.Duration
+}
+
+// runAggregationWorker drains AggregationDispatchCh and runs the prove phase
+// off the tick loop. Completed mutations are returned to the event loop so the
+// consensus store remains single-writer.
 //
 // One worker; AggregationDispatchCh is buffered to 1. If a new dispatch
 // arrives while the worker is mid-prove the tick-thread send drops it via
@@ -36,17 +46,32 @@ func (e *Engine) runAggregationWorker(ctx context.Context) {
 		case dispatch := <-e.AggregationDispatchCh:
 			workerStart := time.Now()
 			aggs, payloads, deletes := aggregateFromSnapshot(dispatch.snapshot, e.Store.PubKeyCache)
-			applyAggregationMutations(e.Store, payloads, deletes)
-			for _, agg := range aggs {
-				if e.P2P != nil {
-					e.P2P.PublishAggregatedAttestation(context.Background(), agg)
-				}
+			result := AggregationResult{
+				slot:     dispatch.slot,
+				aggs:     aggs,
+				payloads: payloads,
+				deletes:  deletes,
+				duration: time.Since(workerStart),
 			}
-			ObserveAggregationWorkerTotalTime(time.Since(workerStart).Seconds())
-			logger.Info(logger.Signature, "aggregation worker: slot=%d produced=%d duration=%v",
-				dispatch.slot, len(aggs), time.Since(workerStart))
+			select {
+			case e.AggregationResultCh <- result:
+			case <-ctx.Done():
+				return
+			}
 		}
 	}
+}
+
+func (e *Engine) onAggregationResult(result AggregationResult) {
+	applyAggregationMutations(e.Store, result.payloads, result.deletes)
+	for _, agg := range result.aggs {
+		if e.P2P != nil {
+			e.P2P.PublishAggregatedAttestation(context.Background(), agg)
+		}
+	}
+	ObserveAggregationWorkerTotalTime(result.duration.Seconds())
+	logger.Info(logger.Signature, "aggregation worker: slot=%d produced=%d duration=%v",
+		result.slot, len(result.aggs), result.duration)
 }
 
 // AggregationSnapshot captures all store reads aggregation needs in one pass,
@@ -90,11 +115,11 @@ func snapshotAggregationInputs(s *ConsensusStore) *AggregationSnapshot {
 	}
 	for dr, entry := range s.NewPayloads.data {
 		dataRoots[dr] = true
-		snap.newEntries[dr] = entry
+		snap.newEntries[dr] = clonePayloadEntry(entry)
 	}
 	for dr := range dataRoots {
 		if entry := s.KnownPayloads.data[dr]; entry != nil {
-			snap.knownEntries[dr] = entry
+			snap.knownEntries[dr] = clonePayloadEntry(entry)
 		}
 	}
 

--- a/node/store_gossip.go
+++ b/node/store_gossip.go
@@ -118,14 +118,15 @@ func (m *AttestationSignatureMap) Len() int {
 	return len(m.data)
 }
 
-// Snapshot returns a copy of the internal map for iteration.
-// Used by the aggregator to read without holding the lock during slow ZK proving.
+// Snapshot returns a detached copy of the internal map for iteration.
+// C signature handles stay owned by the live map; snapshot readers parse their
+// own temporary handles from Signature bytes when needed.
 func (m *AttestationSignatureMap) Snapshot() map[[32]byte]*AttestationDataEntry {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	snap := make(map[[32]byte]*AttestationDataEntry, len(m.data))
 	for k, v := range m.data {
-		snap[k] = v
+		snap[k] = cloneAttestationDataEntry(v)
 	}
 	return snap
 }

--- a/node/store_snapshot.go
+++ b/node/store_snapshot.go
@@ -1,0 +1,64 @@
+package node
+
+import "github.com/geanlabs/gean/types"
+
+func cloneCheckpoint(cp *types.Checkpoint) *types.Checkpoint {
+	if cp == nil {
+		return nil
+	}
+	clone := *cp
+	return &clone
+}
+
+func cloneAttestationData(data *types.AttestationData) *types.AttestationData {
+	if data == nil {
+		return nil
+	}
+	return &types.AttestationData{
+		Slot:   data.Slot,
+		Head:   cloneCheckpoint(data.Head),
+		Target: cloneCheckpoint(data.Target),
+		Source: cloneCheckpoint(data.Source),
+	}
+}
+
+func cloneAggregatedSignatureProof(proof *types.AggregatedSignatureProof) *types.AggregatedSignatureProof {
+	if proof == nil {
+		return nil
+	}
+	return &types.AggregatedSignatureProof{
+		Participants: append([]byte(nil), proof.Participants...),
+		ProofData:    append([]byte(nil), proof.ProofData...),
+	}
+}
+
+func clonePayloadEntry(entry *PayloadEntry) *PayloadEntry {
+	if entry == nil {
+		return nil
+	}
+	clone := &PayloadEntry{
+		Data:   cloneAttestationData(entry.Data),
+		Proofs: make([]*types.AggregatedSignatureProof, 0, len(entry.Proofs)),
+	}
+	for _, proof := range entry.Proofs {
+		clone.Proofs = append(clone.Proofs, cloneAggregatedSignatureProof(proof))
+	}
+	return clone
+}
+
+func cloneAttestationDataEntry(entry *AttestationDataEntry) *AttestationDataEntry {
+	if entry == nil {
+		return nil
+	}
+	clone := &AttestationDataEntry{
+		Data:       cloneAttestationData(entry.Data),
+		Signatures: make([]AttestationSignatureEntry, len(entry.Signatures)),
+	}
+	for i, sig := range entry.Signatures {
+		clone.Signatures[i] = AttestationSignatureEntry{
+			ValidatorID: sig.ValidatorID,
+			Signature:   sig.Signature,
+		}
+	}
+	return clone
+}


### PR DESCRIPTION
## Problem

The aggregation worker goroutine mutated `ConsensusStore` buffers concurrently with the event loop, violating the intended single-writer design:

- **Concurrent map writes → hard crash.** `PayloadBuffer` (`node/store_payloads.go`) has no lock, yet the worker wrote `KnownPayloads`/`NewPayloads` via `applyAggregationMutations` while the event loop wrote the same buffers (`PromoteNewToKnown`, `processBlockAttestations`, prune) and read them (`tick.go`). Go's runtime detects this as an unrecoverable `fatal error: concurrent map writes` — a shippable node crash, not a theoretical race.
- **Shallow snapshot → data race + use-after-free.** `snapshotAggregationInputs` shared live `*PayloadEntry` and signature slices with the worker, including FFI-owned `SigHandle` C pointers. A concurrent prune/eviction could free a handle the worker was still dereferencing across the cgo boundary.

## Fix

Restore single-writer discipline structurally rather than with locks:

- The worker no longer touches the store. It returns an `AggregationResult` over a new `AggregationResultCh`; `onAggregationResult` applies the store mutations and publishes the aggregates **from the event loop**.
- Aggregation snapshots are now **detached**: payload and signature entries are deep-copied (`node/store_snapshot.go`), and live C `SigHandle` pointers are dropped. The worker re-parses its own temporary handles from the signature bytes and frees them per data root.

## Tests

- New regression tests for payload-entry and signature-entry snapshot detachment (including assertions that snapshots own their byte slices and never carry live C handles).
- `go build ./node`, `go vet ./node`, `go test ./node`, and `go test -race ./node` all pass.

## Notes

- Also documents the single-writer / FFI-handle-ownership invariants in `gean/CLAUDE.md` so the pattern isn't reintroduced.
- Aggregate publishing now runs on the event loop (it doesn't touch the store); if tick-time latency ever matters it could move back to the worker while still returning only mutations.