### PR TITLE
chore(xmss): bump leanMultisig to f66d4a9 (devnet4)

### DIFF
--- a/xmss/aggregate_test.go
+++ b/xmss/aggregate_test.go
@@ -97,3 +97,86 @@ func TestAggregateSignaturesRoundtrip(t *testing.T) {
 
 	t.Log("aggregated verification succeeded")
 }
+
+// TestAggregateRejectsChildProofWithWrongMessage exercises the fallible
+// aggregation path: a structurally valid child proof bound to one message must
+// be rejected as a Go error when re-aggregated under a different message, rather
+// than panicking across the FFI boundary.
+func TestAggregateRejectsChildProofWithWrongMessage(t *testing.T) {
+	kpChild, err := GenerateKeyPair("agg-wrongmsg-child", 0, 1<<18)
+	if err != nil {
+		t.Fatalf("keygen child: %v", err)
+	}
+	defer kpChild.Close()
+	kpRaw, err := GenerateKeyPair("agg-wrongmsg-raw", 0, 1<<18)
+	if err != nil {
+		t.Fatalf("keygen raw: %v", err)
+	}
+	defer kpRaw.Close()
+
+	childPk, err := kpChild.PublicKeyBytes()
+	if err != nil {
+		t.Fatalf("child pubkey: %v", err)
+	}
+	rawPk, err := kpRaw.PublicKeyBytes()
+	if err != nil {
+		t.Fatalf("raw pubkey: %v", err)
+	}
+
+	var msgA, msgB [32]byte
+	msgA[0] = 0xaa
+	msgB[0] = 0xbb
+
+	EnsureProverReady()
+
+	// A valid single-signer child proof bound to msgA.
+	childSig, err := kpChild.Sign(0, msgA)
+	if err != nil {
+		t.Fatalf("sign child: %v", err)
+	}
+	cChildSig, err := ParseSignature(childSig[:])
+	if err != nil {
+		t.Fatalf("parse child sig: %v", err)
+	}
+	defer FreeSignature(cChildSig)
+	cChildPk, err := ParsePublicKey(childPk)
+	if err != nil {
+		t.Fatalf("parse child pk: %v", err)
+	}
+	defer FreePublicKey(cChildPk)
+
+	childProof, err := AggregateSignatures([]CPubKey{cChildPk}, []CSig{cChildSig}, msgA, 0)
+	if err != nil {
+		t.Fatalf("build child proof: %v", err)
+	}
+
+	// A raw signature bound to msgB.
+	rawSig, err := kpRaw.Sign(0, msgB)
+	if err != nil {
+		t.Fatalf("sign raw: %v", err)
+	}
+	cRawSig, err := ParseSignature(rawSig[:])
+	if err != nil {
+		t.Fatalf("parse raw sig: %v", err)
+	}
+	defer FreeSignature(cRawSig)
+	cRawPk, err := ParsePublicKey(rawPk)
+	if err != nil {
+		t.Fatalf("parse raw pk: %v", err)
+	}
+	defer FreePublicKey(cRawPk)
+
+	// Aggregate under msgB while feeding a child bound to msgA: the aggregator
+	// must reject it with an error, never panic.
+	_, err = AggregateWithChildren(
+		[]CPubKey{cRawPk},
+		[]CSig{cRawSig},
+		[]ChildProof{{Pubkeys: []CPubKey{cChildPk}, ProofData: childProof}},
+		msgB,
+		0,
+	)
+	if err == nil {
+		t.Fatal("expected error for child proof bound to a different message, got nil")
+	}
+	t.Logf("rejected mismatched child proof cleanly: %v", err)
+}

--- a/xmss/rust/Cargo.lock
+++ b/xmss/rust/Cargo.lock
@@ -288,7 +288,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 [[package]]
 name = "backend"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
@@ -1080,6 +1080,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,9 +1209,10 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lean_compiler"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
+ "include_dir",
  "lean_vm",
  "pest",
  "pest_derive",
@@ -1205,7 +1225,7 @@ dependencies = [
 [[package]]
 name = "lean_prover"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -1214,6 +1234,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "rand 0.10.1",
+ "serde",
  "sub_protocols",
  "tracing",
  "utils",
@@ -1222,7 +1243,7 @@ dependencies = [
 [[package]]
 name = "lean_vm"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -1298,7 +1319,7 @@ dependencies = [
 [[package]]
 name = "leansig_wrapper"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
  "ethereum_ssz",
@@ -1374,7 +1395,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 [[package]]
 name = "mt-air"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "mt-field",
  "mt-poly",
@@ -1383,7 +1404,7 @@ dependencies = [
 [[package]]
 name = "mt-fiat-shamir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
@@ -1391,12 +1412,13 @@ dependencies = [
  "mt-utils",
  "rayon",
  "serde",
+ "tracing",
 ]
 
 [[package]]
 name = "mt-field"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "itertools 0.14.0",
  "mt-utils",
@@ -1411,7 +1433,7 @@ dependencies = [
 [[package]]
 name = "mt-koala-bear"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
@@ -1427,7 +1449,7 @@ dependencies = [
 [[package]]
 name = "mt-poly"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
@@ -1435,12 +1457,13 @@ dependencies = [
  "rand 0.10.1",
  "rayon",
  "serde",
+ "system-info",
 ]
 
 [[package]]
 name = "mt-sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
@@ -1453,7 +1476,7 @@ dependencies = [
 [[package]]
 name = "mt-symetric"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
@@ -1463,7 +1486,7 @@ dependencies = [
 [[package]]
 name = "mt-utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "serde",
 ]
@@ -1471,7 +1494,7 @@ dependencies = [
 [[package]]
 name = "mt-whir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "itertools 0.14.0",
  "mt-fiat-shamir",
@@ -1483,6 +1506,7 @@ dependencies = [
  "mt-utils",
  "rand 0.10.1",
  "rayon",
+ "system-info",
  "tracing",
 ]
 
@@ -1531,6 +1555,31 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -2052,14 +2101,17 @@ dependencies = [
 [[package]]
 name = "rec_aggregation"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
+ "include_dir",
  "lean_compiler",
  "lean_prover",
  "lean_vm",
  "leansig_wrapper",
  "lz4_flex",
+ "objc2",
+ "objc2-foundation",
  "postcard",
  "rand 0.10.1",
  "serde",
@@ -2067,6 +2119,7 @@ dependencies = [
  "sub_protocols",
  "tracing",
  "utils",
+ "zk-alloc",
 ]
 
 [[package]]
@@ -2451,7 +2504,7 @@ checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 [[package]]
 name = "sub_protocols"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
  "lean_vm",
@@ -2485,6 +2538,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "system-info"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+dependencies = [
+ "libc",
+ "rayon",
 ]
 
 [[package]]
@@ -2706,7 +2768,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 [[package]]
 name = "utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
  "tracing",
@@ -2980,6 +3042,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zk-alloc"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+dependencies = [
+ "libc",
+ "system-info",
 ]
 
 [[package]]

--- a/xmss/rust/multisig-glue/Cargo.toml
+++ b/xmss/rust/multisig-glue/Cargo.toml
@@ -4,9 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rec_aggregation = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "5eba3b1" }
-leansig_wrapper = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "5eba3b1" }
-backend = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "5eba3b1" }
+# Pinned to devnet4 f66d4a9. leanMultisig ships an experimental zk-alloc allocator,
+# but it is opt-in (a consumer must install #[global_allocator] itself). We deliberately
+# do NOT, so the staticlib stays on the system allocator — zk-alloc can corrupt memory.
+rec_aggregation = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "f66d4a9" }
+leansig_wrapper = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "f66d4a9" }
+backend = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "f66d4a9" }
 
 [lib]
 # Built as an rlib so its `#[no_mangle] pub extern "C"` symbols can be

--- a/xmss/rust/multisig-glue/src/lib.rs
+++ b/xmss/rust/multisig-glue/src/lib.rs
@@ -131,7 +131,7 @@ pub unsafe extern "C" fn xmss_aggregate(
                 return std::ptr::null();
             }
             let proof_bytes = slice::from_raw_parts(proof_ptrs[i], proof_lens[i]);
-            let proof = match AggregatedXMSS::deserialize(proof_bytes) {
+            let proof = match AggregatedXMSS::decompress(proof_bytes) {
                 Some(p) => p,
                 None => return std::ptr::null(),
             };
@@ -156,8 +156,10 @@ pub unsafe extern "C" fn xmss_aggregate(
             log_inv_rate,
         )
     })) {
-        Ok((_pub_keys, agg_sig)) => Box::into_raw(Box::new(agg_sig)),
-        Err(_) => std::ptr::null(), // panic caught
+        // xmss_aggregate is fallible: Result<(signers, sig), AggregationError>.
+        Ok(Ok((_pub_keys, agg_sig))) => Box::into_raw(Box::new(agg_sig)),
+        Ok(Err(_)) => std::ptr::null(), // aggregation rejected the inputs
+        Err(_) => std::ptr::null(),     // panic caught (unwinding across FFI is UB)
     }
 }
 
@@ -190,7 +192,7 @@ pub unsafe extern "C" fn xmss_verify_aggregated(
     }
 
     let proof_bytes = slice::from_raw_parts(agg_sig_bytes, agg_sig_len);
-    let agg_sig = match AggregatedXMSS::deserialize(proof_bytes) {
+    let agg_sig = match AggregatedXMSS::decompress(proof_bytes) {
         Some(sig) => sig,
         None => return false,
     };
@@ -218,7 +220,7 @@ pub unsafe extern "C" fn xmss_aggregate_signature_to_bytes(
         return 0;
     }
     let agg_sig_ref = &*agg_sig;
-    let ssz_bytes = agg_sig_ref.serialize();
+    let ssz_bytes = agg_sig_ref.compress();
     if ssz_bytes.len() > buffer_len {
         return 0;
     }
@@ -236,7 +238,7 @@ pub unsafe extern "C" fn xmss_aggregate_signature_from_bytes(
         return std::ptr::null_mut();
     }
     let input_slice = slice::from_raw_parts(bytes, bytes_len);
-    match AggregatedXMSS::deserialize(input_slice) {
+    match AggregatedXMSS::decompress(input_slice) {
         Some(agg_sig) => Box::into_raw(Box::new(agg_sig)),
         None => std::ptr::null_mut(),
     }


### PR DESCRIPTION
## What

Bumps the leanMultisig dependency (`rec_aggregation`/`leansig_wrapper`/`backend`) from `5eba3b1` to **`f66d4a9`** (devnet4, 180 commits ahead) and adapts the FFI glue to the breaking API + proof-system changes. Upstream: leanEthereum/leanMultisig#325.

## Changes
- **`multisig-glue/src/lib.rs`**: `xmss_aggregate` is now fallible (`Result<(_, AggregatedXMSS), AggregationError>`) — map `Err` → null so Go surfaces `ErrAggregationFailed`; `catch_unwind` retained (unwinding across the C boundary is UB). Serialization moved from `serialize()`/`deserialize()` to **`compress()`/`decompress()`** (lz4+postcard).
- **`Cargo.toml` / `Cargo.lock`**: rev bump (lock regenerated via cargo, not hand-edited). `hashsig-glue`'s leansig left on the `devnet4` branch — matches leanMultisig's pinned leansig, and the two-leansig setup already works.
- **Test**: added `TestAggregateRejectsChildProofWithWrongMessage` exercising the new fallible path (mismatched child → Go error, not a panic).

## Memory safety
`zk-alloc` (the experimental allocator with a documented memory-corruption risk) is **opt-in** — the staticlib declares no `#[global_allocator]`, so it stays on the system allocator (consistent with ream/zeam; ethlambda uses jemalloc). Verified: no `#[global_allocator]`/`ZkAllocator` wiring under `xmss/rust/`.

## Verification
- `make ffi` ✓ (0 warnings) · `make test-ffi` ✓ (23 tests, incl. reject paths) · xmss suite clean under `-race` ✓
- `make test` ✓ (23 pkgs incl. aggregation/attestation/blockprocessor/forkchoice/node — proofs are opaque downstream)
- `make lint` ✓ (go vet + cargo fmt --check + clippy -D warnings)
- Proof size ~155–182 KiB, well under the 1 MiB cap → no Go constant / SSZ changes.

## Known: spec-fixture coordination
`make test-spec` fails **only** `TestSpecForkChoice`, and **every** failure is `aggregated signature verification failed`. The local fixtures were generated by **leanSpec@`1589f87`**, which embeds aggregated proofs from the *old* leanMultisig that f66d4a9 correctly rejects. gean's own aggregate→verify round-trip passes, so this is a cross-version fixture incompatibility, not a serialization bug. All non-aggregated-proof suites pass (state transition, SSZ, individual signatures, slot clock, sync, api, justifiability, networking codec). Making these pass requires regenerating fixtures from a f66d4a9-compatible leanSpec — a separate coordination step.