### PR TITLE
fix(genesis): accept leanchain config.yaml schema fields

### DIFF
--- a/internal/genesis/config.go
+++ b/internal/genesis/config.go
@@ -6,7 +6,9 @@ type GenesisValidatorEntry struct {
 }
 
 type GenesisConfig struct {
-	GenesisTime       uint64                  `yaml:"GENESIS_TIME"`
-	NumValidators     *uint64                 `yaml:"NUM_VALIDATORS,omitempty"`
-	GenesisValidators []GenesisValidatorEntry `yaml:"GENESIS_VALIDATORS"`
+	GenesisTime               uint64                  `yaml:"GENESIS_TIME"`
+	AttestationCommitteeCount *uint64                 `yaml:"ATTESTATION_COMMITTEE_COUNT,omitempty"`
+	ActiveEpoch               *uint64                 `yaml:"ACTIVE_EPOCH,omitempty"`
+	ValidatorCount            *uint64                 `yaml:"VALIDATOR_COUNT,omitempty"`
+	GenesisValidators         []GenesisValidatorEntry `yaml:"GENESIS_VALIDATORS"`
 }

--- a/internal/genesis/config.go
+++ b/internal/genesis/config.go
@@ -8,7 +8,7 @@ type GenesisValidatorEntry struct {
 type GenesisConfig struct {
 	GenesisTime               uint64                  `yaml:"GENESIS_TIME"`
 	AttestationCommitteeCount *uint64                 `yaml:"ATTESTATION_COMMITTEE_COUNT,omitempty"`
-	ActiveEpoch               *uint64                 `yaml:"ACTIVE_EPOCH,omitempty"`
+	ActiveEpoch               uint64                  `yaml:"ACTIVE_EPOCH,omitempty"`
 	ValidatorCount            *uint64                 `yaml:"VALIDATOR_COUNT,omitempty"`
 	GenesisValidators         []GenesisValidatorEntry `yaml:"GENESIS_VALIDATORS"`
 }

--- a/internal/genesis/genesis_test.go
+++ b/internal/genesis/genesis_test.go
@@ -123,29 +123,58 @@ GENESIS_VALIDATORS:
 	}
 }
 
-func TestLoadGenesisConfigNumValidatorsConsistent(t *testing.T) {
+func TestLoadGenesisConfigValidatorCountConsistent(t *testing.T) {
 	tmpFile := t.TempDir() + "/config.yaml"
-	writeGenesisConfig(t, tmpFile, "NUM_VALIDATORS: 3\n"+testConfigYAML)
+	writeGenesisConfig(t, tmpFile, "VALIDATOR_COUNT: 3\n"+testConfigYAML)
 
 	config, err := LoadGenesisConfig(tmpFile)
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
-	if config.NumValidators == nil {
-		t.Fatal("NumValidators should be parsed when NUM_VALIDATORS is set")
+	if config.ValidatorCount == nil {
+		t.Fatal("ValidatorCount should be parsed when VALIDATOR_COUNT is set")
 	}
-	if *config.NumValidators != 3 {
-		t.Fatalf("NumValidators: expected 3, got %d", *config.NumValidators)
+	if *config.ValidatorCount != 3 {
+		t.Fatalf("ValidatorCount: expected 3, got %d", *config.ValidatorCount)
 	}
 }
 
-func TestLoadGenesisConfigNumValidatorsMismatch(t *testing.T) {
+func TestLoadGenesisConfigValidatorCountMismatch(t *testing.T) {
 	tmpFile := t.TempDir() + "/config.yaml"
-	writeGenesisConfig(t, tmpFile, "NUM_VALIDATORS: 5\n"+testConfigYAML)
+	writeGenesisConfig(t, tmpFile, "VALIDATOR_COUNT: 5\n"+testConfigYAML)
 
 	_, err := LoadGenesisConfig(tmpFile)
 	if err == nil {
-		t.Fatal("expected error when NUM_VALIDATORS disagrees with len(GENESIS_VALIDATORS)")
+		t.Fatal("expected error when VALIDATOR_COUNT disagrees with len(GENESIS_VALIDATORS)")
+	}
+}
+
+// TestLoadGenesisConfigAcceptsLeanchainFields covers the shared leanchain
+// config.yaml schema other clients also consume (committee count, key lifetime,
+// validator count) — these must parse, not trip strict field checking.
+func TestLoadGenesisConfigAcceptsLeanchainFields(t *testing.T) {
+	tmpFile := t.TempDir() + "/config.yaml"
+	writeGenesisConfig(t, tmpFile,
+		"ATTESTATION_COMMITTEE_COUNT: 1\nACTIVE_EPOCH: 18\nVALIDATOR_COUNT: 3\n"+testConfigYAML)
+
+	config, err := LoadGenesisConfig(tmpFile)
+	if err != nil {
+		t.Fatalf("load leanchain config: %v", err)
+	}
+	if config.ActiveEpoch == nil || *config.ActiveEpoch != 18 {
+		t.Fatalf("ACTIVE_EPOCH not parsed: %v", config.ActiveEpoch)
+	}
+	if config.AttestationCommitteeCount == nil || *config.AttestationCommitteeCount != types.AttestationCommitteeCount {
+		t.Fatalf("ATTESTATION_COMMITTEE_COUNT not parsed: %v", config.AttestationCommitteeCount)
+	}
+}
+
+func TestLoadGenesisConfigRejectsWrongCommitteeCount(t *testing.T) {
+	tmpFile := t.TempDir() + "/config.yaml"
+	writeGenesisConfig(t, tmpFile, "ATTESTATION_COMMITTEE_COUNT: 2\n"+testConfigYAML)
+
+	if _, err := LoadGenesisConfig(tmpFile); err == nil {
+		t.Fatal("expected error when ATTESTATION_COMMITTEE_COUNT disagrees with gean's const")
 	}
 }
 

--- a/internal/genesis/genesis_test.go
+++ b/internal/genesis/genesis_test.go
@@ -161,8 +161,8 @@ func TestLoadGenesisConfigAcceptsLeanchainFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load leanchain config: %v", err)
 	}
-	if config.ActiveEpoch == nil || *config.ActiveEpoch != 18 {
-		t.Fatalf("ACTIVE_EPOCH not parsed: %v", config.ActiveEpoch)
+	if config.ActiveEpoch != 18 {
+		t.Fatalf("ACTIVE_EPOCH not parsed: %d", config.ActiveEpoch)
 	}
 	if config.AttestationCommitteeCount == nil || *config.AttestationCommitteeCount != types.AttestationCommitteeCount {
 		t.Fatalf("ATTESTATION_COMMITTEE_COUNT not parsed: %v", config.AttestationCommitteeCount)

--- a/internal/genesis/load.go
+++ b/internal/genesis/load.go
@@ -53,9 +53,13 @@ func (gc *GenesisConfig) validate() error {
 		return fmt.Errorf("GENESIS_VALIDATORS has %d validators (max %d)",
 			len(gc.GenesisValidators), types.ValidatorRegistryLimit)
 	}
-	if gc.NumValidators != nil && *gc.NumValidators != uint64(len(gc.GenesisValidators)) {
-		return fmt.Errorf("NUM_VALIDATORS=%d disagrees with len(GENESIS_VALIDATORS)=%d",
-			*gc.NumValidators, len(gc.GenesisValidators))
+	if gc.ValidatorCount != nil && *gc.ValidatorCount != uint64(len(gc.GenesisValidators)) {
+		return fmt.Errorf("VALIDATOR_COUNT=%d disagrees with len(GENESIS_VALIDATORS)=%d",
+			*gc.ValidatorCount, len(gc.GenesisValidators))
+	}
+	if gc.AttestationCommitteeCount != nil && *gc.AttestationCommitteeCount != types.AttestationCommitteeCount {
+		return fmt.Errorf("ATTESTATION_COMMITTEE_COUNT=%d disagrees with gean's %d",
+			*gc.AttestationCommitteeCount, types.AttestationCommitteeCount)
 	}
 
 	attestationPubkeys := make(map[[types.PubkeySize]byte]int, len(gc.GenesisValidators))


### PR DESCRIPTION
## What

Accept the shared leanchain `config.yaml` schema fields so gean can load genesis configs produced for the multi-client devnet without tripping strict YAML field checking.

`LoadGenesisConfig` decodes with `KnownFields(true)`, so any key not declared on `GenesisConfig` is a hard parse error. The shared leanchain config carries `ATTESTATION_COMMITTEE_COUNT`, `ACTIVE_EPOCH`, and `VALIDATOR_COUNT` (the latter replacing the old `NUM_VALIDATORS`), which previously failed to parse.

## Changes

- `internal/genesis/config.go` — rename `NumValidators` → `ValidatorCount` (`VALIDATOR_COUNT`); add `AttestationCommitteeCount` (`ATTESTATION_COMMITTEE_COUNT`) and `ActiveEpoch` (`ACTIVE_EPOCH`).
- `internal/genesis/load.go` — validate `VALIDATOR_COUNT` against `len(GENESIS_VALIDATORS)` and `ATTESTATION_COMMITTEE_COUNT` against gean's `types.AttestationCommitteeCount`. `ACTIVE_EPOCH` is accepted (gean has no constant to check it against).
- `internal/genesis/genesis_test.go` — rename existing `VALIDATOR_COUNT` tests; add coverage that the leanchain fields parse, and that a wrong committee count is rejected.
- lean-review pass: `ActiveEpoch` is `uint64` (not a pointer) since it is never presence-checked, keeping it distinct from the validated optional fields.

## Test

`go vet ./internal/genesis/ && go test ./internal/genesis/` — pass.
