### PR TITLE
feat(metrics): restore dropped metrics + add leanSpec coverage gauges

### DIFF
--- a/internal/aggregation/aggregate.go
+++ b/internal/aggregation/aggregate.go
@@ -131,6 +131,7 @@ func aggregateFromSnapshot(snap *Snapshot, cache *xmss.PubKeyCache) ([]*types.Si
 				slot, len(*rawIDsBuf), len(*childProofsBuf), len(allIDs), len(proofBytes), aggDuration)
 
 			metrics.ObservePqSigAggBuildingTime(aggDuration.Seconds())
+			metrics.ObserveCommitteeSignaturesAggregationTime(aggDuration.Seconds())
 			metrics.IncPqSigAggregatedTotal()
 			metrics.IncPqSigAttestationsInAggregated(len(allIDs))
 

--- a/internal/blockbuilder/build.go
+++ b/internal/blockbuilder/build.go
@@ -2,7 +2,9 @@ package blockbuilder
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/geanlabs/gean/internal/metrics"
 	"github.com/geanlabs/gean/internal/types"
 )
 
@@ -12,7 +14,9 @@ func Build(input Input) (*Result, error) {
 	}
 	required := requiredCheckpoint(input.RequiredJustified)
 
+	aggStart := time.Now()
 	plan, err := planAttestations(input)
+	metrics.ObserveBlockBuildingPayloadAggregationTime(time.Since(aggStart).Seconds())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/blockprocessor/state.go
+++ b/internal/blockprocessor/state.go
@@ -1,6 +1,9 @@
 package blockprocessor
 
 import (
+	"time"
+
+	"github.com/geanlabs/gean/internal/metrics"
 	"github.com/geanlabs/gean/internal/statetransition"
 	"github.com/geanlabs/gean/internal/types"
 )
@@ -10,7 +13,37 @@ func transitionState(parentState *types.State, block *types.Block) (*types.State
 	if err != nil {
 		return nil, err
 	}
-	if err := statetransition.StateTransition(state, block); err != nil {
+	if block == nil {
+		return nil, statetransition.StateTransition(state, block)
+	}
+
+	// Phase-by-phase to record per-phase state-transition metrics. The
+	// composition mirrors statetransition.StateTransition; the spec logic
+	// itself stays in the (pure) statetransition package.
+	slotsBefore := state.Slot
+	slotsStart := time.Now()
+	if err := statetransition.ProcessSlots(state, block.Slot); err != nil {
+		return nil, err
+	}
+	metrics.ObserveSTFSlotsTime(time.Since(slotsStart).Seconds())
+	if block.Slot > slotsBefore {
+		metrics.IncSTFSlotsProcessed(block.Slot - slotsBefore)
+	}
+
+	blockStart := time.Now()
+	if err := statetransition.ProcessBlockHeader(state, block); err != nil {
+		return nil, err
+	}
+	attestations := block.Body.Attestations
+	attStart := time.Now()
+	if err := statetransition.ProcessAttestations(state, attestations); err != nil {
+		return nil, err
+	}
+	metrics.ObserveSTFAttestationsTime(time.Since(attStart).Seconds())
+	metrics.IncSTFAttestationsProcessed(len(attestations))
+	metrics.ObserveSTFBlockTime(time.Since(blockStart).Seconds())
+
+	if err := statetransition.VerifyStateRoot(state, block); err != nil {
 		return nil, err
 	}
 	return state, nil

--- a/internal/metrics/counters.go
+++ b/internal/metrics/counters.go
@@ -28,6 +28,18 @@ var (
 	metricPqSigAggregatedSignaturesTotal = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "lean_pq_sig_aggregated_signatures_total", Help: "Total aggregated signature proofs produced",
 	})
+	metricPqSigAggregatedValid = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "lean_pq_sig_aggregated_signatures_valid_total", Help: "Total valid aggregated signature verifications",
+	})
+	metricPqSigAggregatedInvalid = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "lean_pq_sig_aggregated_signatures_invalid_total", Help: "Total invalid aggregated signature verifications",
+	})
+	metricSTFSlotsProcessed = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "lean_state_transition_slots_processed_total", Help: "Total number of processed slots",
+	})
+	metricSTFAttestationsProcessed = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "lean_state_transition_attestations_processed_total", Help: "Total number of processed attestations",
+	})
 	metricPqSigAttestationsInAggregated = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "lean_pq_sig_attestations_in_aggregated_signatures_total", Help: "Total attestations included in aggregated proofs",
 	})

--- a/internal/metrics/gauges.go
+++ b/internal/metrics/gauges.go
@@ -21,6 +21,12 @@ var (
 	metricLatestFinalizedSlot = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "lean_latest_finalized_slot", Help: "Latest finalized checkpoint slot",
 	})
+	metricJustifiedSlot = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "lean_justified_slot", Help: "Current justified checkpoint slot",
+	})
+	metricFinalizedSlot = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "lean_finalized_slot", Help: "Current finalized checkpoint slot",
+	})
 	metricValidatorsCount = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "lean_validators_count", Help: "Number of validators managed by this node",
 	})
@@ -60,4 +66,16 @@ var (
 	metricNodeSyncStatus = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "lean_node_sync_status", Help: "Node sync status",
 	}, []string{"status"})
+	metricAttestationAggregateCoverageValidators = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "lean_attestation_aggregate_coverage_validators",
+		Help: "Validator coverage in attestation aggregate reports, by section and subnet (subnet=combined is the section total)",
+	}, []string{"section", "subnet"})
+	metricAttestationAggregateCoverageSubnets = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "lean_attestation_aggregate_coverage_subnets",
+		Help: "Number of covered subnets in attestation aggregate reports, by section",
+	}, []string{"section"})
+	metricAttestationAggregateCoverageDiffValidators = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "lean_attestation_aggregate_coverage_diff_validators",
+		Help: "Validator coverage delta between block payloads and timely pre-merge payloads, by direction",
+	}, []string{"direction"})
 )

--- a/internal/metrics/histograms.go
+++ b/internal/metrics/histograms.go
@@ -36,6 +36,16 @@ var (
 		Help:    "Time to build an aggregated signature proof",
 		Buckets: []float64{0.1, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 4},
 	})
+	metricPqSigAggVerificationTime = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "lean_pq_sig_aggregated_signatures_verification_time_seconds",
+		Help:    "Time to verify an aggregated attestation signature",
+		Buckets: []float64{0.1, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 4},
+	})
+	metricCommitteeSignaturesAggregationTime = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "lean_committee_signatures_aggregation_time_seconds",
+		Help:    "Time taken to aggregate committee signatures",
+		Buckets: []float64{0.05, 0.1, 0.25, 0.5, 0.75, 1, 2, 3, 4},
+	})
 	metricAggregationPrepTime = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "lean_aggregation_prep_time_seconds",
 		Help:    "Per-aggregate prep time",
@@ -61,10 +71,30 @@ var (
 		Help:    "Time to process full state transition",
 		Buckets: []float64{0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 4},
 	})
+	metricSTFSlotsTime = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "lean_state_transition_slots_processing_time_seconds",
+		Help:    "Time taken to process slots",
+		Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 1},
+	})
+	metricSTFBlockTime = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "lean_state_transition_block_processing_time_seconds",
+		Help:    "Time taken to process block",
+		Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 1},
+	})
+	metricSTFAttestationsTime = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "lean_state_transition_attestations_processing_time_seconds",
+		Help:    "Time taken to process attestations",
+		Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 1},
+	})
 	metricBlockBuildingTime = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "lean_block_building_time_seconds",
 		Help:    "Time to build a block",
 		Buckets: []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1},
+	})
+	metricBlockBuildingPayloadAggregationTime = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "lean_block_building_payload_aggregation_time_seconds",
+		Help:    "Time taken to build aggregated_payloads during block building",
+		Buckets: []float64{0.1, 0.25, 0.5, 0.75, 1, 2, 3, 4},
 	})
 	metricBlockAggregatedPayloads = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "lean_block_aggregated_payloads",

--- a/internal/metrics/inc.go
+++ b/internal/metrics/inc.go
@@ -7,7 +7,11 @@ func IncForkChoiceReorgs()                   { metricForkChoiceReorgs.Inc() }
 func IncBlocksSkippedLag()                   { metricBlocksSkippedLag.Inc() }
 func IncAttestationsSkippedLag()             { metricAttestationsSkippedLag.Inc() }
 func IncPqSigAggregatedTotal()               { metricPqSigAggregatedSignaturesTotal.Inc() }
+func IncPqSigAggregatedValid()               { metricPqSigAggregatedValid.Inc() }
+func IncPqSigAggregatedInvalid()             { metricPqSigAggregatedInvalid.Inc() }
 func IncPqSigAttestationsInAggregated(n int) { addCount(metricPqSigAttestationsInAggregated, n) }
+func IncSTFSlotsProcessed(n uint64)          { addUint(metricSTFSlotsProcessed, n) }
+func IncSTFAttestationsProcessed(n int)      { addCount(metricSTFAttestationsProcessed, n) }
 func IncPqSigAttestationSigsTotal()          { metricPqSigAttestationSigsTotal.Inc() }
 func IncPqSigAttestationSigsValid()          { metricPqSigAttestationSigsValid.Inc() }
 func IncPqSigAttestationSigsInvalid()        { metricPqSigAttestationSigsInvalid.Inc() }

--- a/internal/metrics/labels.go
+++ b/internal/metrics/labels.go
@@ -23,6 +23,25 @@ var aggregatorSkipReasons = []string{
 	AggregatorSkipOther,
 }
 
+// Attestation-aggregate coverage label values, matching the leanSpec reference
+// node's section/subnet/direction taxonomy.
+const (
+	CoverageSectionTimely            = "timely"
+	CoverageSectionLate              = "late"
+	CoverageSectionBlock             = "block"
+	CoverageSectionCombined          = "combined"
+	CoverageSectionAggregateStartNew = "aggregate_start_new"
+	CoverageSectionProposalPayloads  = "proposal_payloads"
+	CoverageSectionProposalGossip    = "proposal_gossip"
+	CoverageSectionProposalCombined  = "proposal_combined"
+
+	// CoverageSubnetCombined is the all-subnet validator total for a section.
+	CoverageSubnetCombined = "combined"
+
+	CoverageDiffBlockOnly  = "block_only"
+	CoverageDiffTimelyOnly = "timely_only"
+)
+
 func syncStatusLabel(status string) string {
 	status = labelOrUnknown(status)
 	for _, label := range syncStatusLabels {

--- a/internal/metrics/observe.go
+++ b/internal/metrics/observe.go
@@ -10,6 +10,12 @@ func ObservePqSigVerificationTime(seconds float64) {
 func ObservePqSigAggBuildingTime(seconds float64) {
 	observeNonNegative(metricPqSigAggBuildingTime, seconds)
 }
+func ObservePqSigAggVerificationTime(seconds float64) {
+	observeNonNegative(metricPqSigAggVerificationTime, seconds)
+}
+func ObserveCommitteeSignaturesAggregationTime(seconds float64) {
+	observeNonNegative(metricCommitteeSignaturesAggregationTime, seconds)
+}
 func ObserveAggregationPrepTime(seconds float64) {
 	observeNonNegative(metricAggregationPrepTime, seconds)
 }
@@ -19,8 +25,16 @@ func ObserveForkChoiceReorgDepth(depth float64) {
 func ObserveTickIntervalDuration(seconds float64) {
 	observeNonNegative(metricTickIntervalDuration, seconds)
 }
-func ObserveSTFTime(seconds float64)           { observeNonNegative(metricSTFTime, seconds) }
+func ObserveSTFTime(seconds float64)      { observeNonNegative(metricSTFTime, seconds) }
+func ObserveSTFSlotsTime(seconds float64) { observeNonNegative(metricSTFSlotsTime, seconds) }
+func ObserveSTFBlockTime(seconds float64) { observeNonNegative(metricSTFBlockTime, seconds) }
+func ObserveSTFAttestationsTime(seconds float64) {
+	observeNonNegative(metricSTFAttestationsTime, seconds)
+}
 func ObserveBlockBuildingTime(seconds float64) { observeNonNegative(metricBlockBuildingTime, seconds) }
+func ObserveBlockBuildingPayloadAggregationTime(seconds float64) {
+	observeNonNegative(metricBlockBuildingPayloadAggregationTime, seconds)
+}
 func ObserveBlockAggregatedPayloads(n int) {
 	observeNonNegative(metricBlockAggregatedPayloads, countValue(n))
 }

--- a/internal/metrics/set.go
+++ b/internal/metrics/set.go
@@ -9,6 +9,8 @@ func SetCurrentSlot(s uint64)         { metricCurrentSlot.Set(float64(s)) }
 func SetSafeTargetSlot(s uint64)      { metricSafeTargetSlot.Set(float64(s)) }
 func SetLatestJustifiedSlot(s uint64) { metricLatestJustifiedSlot.Set(float64(s)) }
 func SetLatestFinalizedSlot(s uint64) { metricLatestFinalizedSlot.Set(float64(s)) }
+func SetJustifiedSlot(s uint64)       { metricJustifiedSlot.Set(float64(s)) }
+func SetFinalizedSlot(s uint64)       { metricFinalizedSlot.Set(float64(s)) }
 func SetValidatorsCount(n int)        { metricValidatorsCount.Set(countValue(n)) }
 
 func SetIsAggregator(b bool) {
@@ -32,4 +34,18 @@ func SetSyncStatus(status string) {
 	for _, s := range syncStatusLabels {
 		metricNodeSyncStatus.WithLabelValues(s).Set(boolValue(s == active))
 	}
+}
+
+func SetAttestationAggregateCoverageValidators(section, subnet string, n int) {
+	metricAttestationAggregateCoverageValidators.
+		WithLabelValues(labelOrUnknown(section), labelOrUnknown(subnet)).Set(countValue(n))
+}
+
+func SetAttestationAggregateCoverageSubnets(section string, n int) {
+	metricAttestationAggregateCoverageSubnets.WithLabelValues(labelOrUnknown(section)).Set(countValue(n))
+}
+
+func SetAttestationAggregateCoverageDiffValidators(direction string, n int) {
+	metricAttestationAggregateCoverageDiffValidators.
+		WithLabelValues(labelOrUnknown(direction)).Set(countValue(n))
 }

--- a/internal/node/gossip.go
+++ b/internal/node/gossip.go
@@ -77,10 +77,15 @@ func (e *Engine) onGossipAggregatedAttestation(agg *types.SignedAggregatedAttest
 	if agg.Proof == nil || len(agg.Proof.ProofData) == 0 {
 		return
 	}
-	if err := attestation.VerifyAggregatedGossipAttestation(e.Store, agg.Data, agg.Proof.Participants, agg.Proof.ProofData); err != nil {
+	verifyStart := time.Now()
+	err := attestation.VerifyAggregatedGossipAttestation(e.Store, agg.Data, agg.Proof.Participants, agg.Proof.ProofData)
+	metrics.ObservePqSigAggVerificationTime(time.Since(verifyStart).Seconds())
+	if err != nil {
+		metrics.IncPqSigAggregatedInvalid()
 		logger.Error(logger.Signature, "aggregated attestation verification failed: %v", err)
 		return
 	}
+	metrics.IncPqSigAggregatedValid()
 
 	dataRoot, err := agg.Data.HashTreeRoot()
 	if err != nil {

--- a/internal/node/head.go
+++ b/internal/node/head.go
@@ -32,6 +32,8 @@ func (e *Engine) updateHead() {
 			metrics.SetHeadSlot(newHeader.Slot)
 			metrics.SetLatestJustifiedSlot(justified.Slot)
 			metrics.SetLatestFinalizedSlot(finalized.Slot)
+			metrics.SetJustifiedSlot(justified.Slot)
+			metrics.SetFinalizedSlot(finalized.Slot)
 			metrics.SetGossipSignatures(e.Store.AttestationSignatures.Len())
 			metrics.SetNewAggregatedPayloads(e.Store.NewPayloads.Len())
 			metrics.SetKnownAggregatedPayloads(e.Store.KnownPayloads.Len())

--- a/internal/statetransition/transition.go
+++ b/internal/statetransition/transition.go
@@ -14,6 +14,12 @@ func StateTransition(state *types.State, block *types.Block) error {
 		return err
 	}
 
+	return VerifyStateRoot(state, block)
+}
+
+// VerifyStateRoot checks that the post-transition state root matches the
+// block's committed state root.
+func VerifyStateRoot(state *types.State, block *types.Block) error {
 	computedRoot, err := state.HashTreeRoot()
 	if err != nil {
 		return err
@@ -24,6 +30,5 @@ func StateTransition(state *types.State, block *types.Block) error {
 			Computed: computedRoot,
 		}
 	}
-
 	return nil
 }


### PR DESCRIPTION
## Summary

The `node/metrics.go` → `internal/metrics/` move (commit `42000ad`) dropped **9 metrics** as an R085 rename (2 added / 50 removed). This restores them, closes the remaining leanMetrics.md catalog gaps, and defines the leanSpec attestation-aggregate coverage gauges — bringing this branch from 44/56 to full leanMetrics coverage.

## Defined and wired to real emission sites (12)

| Metric | Emission site |
|---|---|
| `lean_state_transition_slots_processed_total` | `blockprocessor/state.go` |
| `lean_state_transition_slots_processing_time_seconds` | `blockprocessor/state.go` |
| `lean_state_transition_block_processing_time_seconds` | `blockprocessor/state.go` |
| `lean_state_transition_attestations_processed_total` | `blockprocessor/state.go` |
| `lean_state_transition_attestations_processing_time_seconds` | `blockprocessor/state.go` |
| `lean_pq_sig_aggregated_signatures_valid_total` | `node/gossip.go` |
| `lean_pq_sig_aggregated_signatures_invalid_total` | `node/gossip.go` |
| `lean_pq_sig_aggregated_signatures_verification_time_seconds` | `node/gossip.go` |
| `lean_block_building_payload_aggregation_time_seconds` | `blockbuilder/build.go` |
| `lean_committee_signatures_aggregation_time_seconds` | `aggregation/aggregate.go` |
| `lean_justified_slot` | `node/head.go` |
| `lean_finalized_slot` | `node/head.go` |

> Note: on `devnet-4`, 8 of the 9 restored metrics were registered-but-never-emitted. This PR actually wires them.

## Design notes

- **`statetransition` stays pure.** `VerifyStateRoot` is extracted from `StateTransition`; the per-phase timing/counts are taken in the caller (`blockprocessor/state.go`), not inside the spec package.
- Definitions follow the package's existing type-based file layout (counters/histograms/gauges + set/inc/observe/labels) — no new feature file.
- Remaining metrics are one line each at existing instrumentation points — no duplicated logic.

## Defined with setters but not yet emitting (3)

`lean_attestation_aggregate_coverage_{validators,subnets,diff_validators}` (leanSpec-specific). gean has no per-slot aggregate-coverage report to source these from, so they are registered with a ready `Set*` API rather than wired to fabricated values. Populating them is a separate, larger feature (porting the coverage-report computation).

## Testing

- `go build ./...` ✅
- `go vet` on all touched packages ✅
- `go test` on `metrics`, `statetransition`, `blockbuilder`, `blockprocessor`, `node`, `aggregation` ✅
- `gofmt -l internal/` clean ✅