### PR TITLE
fix(node): skip stale proposal duties instead of erroring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ NUM_NODES ?= 3
 # Pinned leanSpec revision for spec fixtures. Must be defined before the test-spec/test-all
 # rules that reference it: Make expands a rule's prerequisites when it reads the rule, so a
 # definition placed after those rules would expand to empty in their prerequisites.
-LEAN_SPEC_COMMIT_HASH := fd7dfd0e85bd83d43e0a6b1bc2bfafb1ea3049d5
+LEAN_SPEC_COMMIT_HASH := cd6981a25c3e11e2a50556590025f097c266a27d
 
 help: ## Show help for each Makefile recipe
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/internal/node/proposal.go
+++ b/internal/node/proposal.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/geanlabs/gean/internal/blockbuilder"
 	"github.com/geanlabs/gean/internal/logger"
 	"github.com/geanlabs/gean/internal/metrics"
+	"github.com/geanlabs/gean/internal/statetransition"
 	"github.com/geanlabs/gean/internal/store"
 	"github.com/geanlabs/gean/internal/types"
 	"github.com/geanlabs/gean/xmss"
@@ -50,6 +52,12 @@ func (e *Engine) runProposalWorker(ctx context.Context) {
 			return
 		case duty := <-e.ProposalCh:
 			metrics.SetProvingQueueDepth("proposal", len(e.ProposalCh))
+			// Duty may have gone stale while the worker proved an earlier slot.
+			if head := e.Store.HeadSlot(); head >= duty.slot {
+				logger.Warn(logger.Validator, "skipping stale proposal slot=%d head=%d", duty.slot, head)
+				metrics.IncProofOperation("proposal", "skipped_stale")
+				continue
+			}
 			deadline, cancel := context.WithTimeout(ctx, 3*types.MillisecondsPerInterval*time.Millisecond)
 			if e.ProvingGate != nil && !e.ProvingGate.Acquire(deadline, true) {
 				cancel()
@@ -79,6 +87,13 @@ func (e *Engine) buildProposal(slot, validatorID uint64) *proposalResult {
 
 	block, attSigProofs, err := e.produceBlockWithSignatures(slot, validatorID)
 	if err != nil {
+		// Head advanced past the target slot; skip as a slot-boundary miss (matches spec).
+		var stale *statetransition.StateSlotIsNewerError
+		if errors.As(err, &stale) {
+			logger.Warn(logger.Validator, "skipping stale proposal slot=%d head=%d", slot, e.Store.HeadSlot())
+			metrics.IncProofOperation("proposal", "skipped_stale")
+			return nil
+		}
 		logger.Error(logger.Validator, "produce block failed: %v", err)
 		return nil
 	}

--- a/internal/node/proposal_test.go
+++ b/internal/node/proposal_test.go
@@ -1,8 +1,10 @@
 package node
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/geanlabs/gean/internal/statetransition"
 	"github.com/geanlabs/gean/internal/store"
 	"github.com/geanlabs/gean/internal/types"
 )
@@ -95,6 +97,36 @@ func TestPayloadsFromEntriesCopiesMapAndProofSlice(t *testing.T) {
 
 	if copied[0].DataRoot != root || copied[0].Data == nil {
 		t.Fatal("copied payload lost entry after original map mutation")
+	}
+}
+
+func TestProduceBlockWithSignaturesStaleHeadReturnsSlotError(t *testing.T) {
+	s := makeTestStore()
+	headState, parentRoot := proposalHeadState(t)
+	headState.Slot = 1
+	s.SetHead(parentRoot)
+	s.InsertState(parentRoot, headState)
+	s.InsertBlockHeader(parentRoot, headState.LatestBlockHeader)
+
+	e := &Engine{Store: s}
+	_, _, err := e.produceBlockWithSignatures(1, 0)
+	var stale *statetransition.StateSlotIsNewerError
+	if !errors.As(err, &stale) {
+		t.Fatalf("err=%v, want StateSlotIsNewerError", err)
+	}
+}
+
+func TestBuildProposalSkipsStaleSlot(t *testing.T) {
+	s := makeTestStore()
+	headState, parentRoot := proposalHeadState(t)
+	headState.Slot = 1
+	s.SetHead(parentRoot)
+	s.InsertState(parentRoot, headState)
+	s.InsertBlockHeader(parentRoot, headState.LatestBlockHeader)
+
+	e := &Engine{Store: s}
+	if result := e.buildProposal(1, 0); result != nil {
+		t.Fatalf("buildProposal result=%v, want nil (skipped)", result)
 	}
 }
 


### PR DESCRIPTION
Closes #341.

## Problem

Under proving load, gean's async proposal worker could execute a **stale** duty: a duty queued on the capacity-1 `ProposalCh` while the worker proves an earlier slot, then dequeued after a newer block advanced the head past the duty's slot. `blockbuilder.Build` → `ProcessSlots` then rejected it and the worker surfaced a spurious ERROR:

```
ERROR [validator] produce block failed: process slots: state slot 30 >= target slot 29
```

Observed twice (slots 29, 69) during devnet5 gean↔ethlambda interop.

## Fix

Skip the stale slot instead of erroring — a missed/empty slot is normal. This matches the spec proposer duty, which catches the rejection and skips (`node/validator/service.py`: `except → "Block production skipped"`), and ethlambda (logs and returns). gean is the only client that hits it because it proves asynchronously rather than synchronously for the current slot.

Two layers, both in `internal/node/proposal.go`:
- **`runProposalWorker`** — skip before acquiring the proving gate when the head already reached the duty's slot (avoids wasting the gate).
- **`buildProposal`** — catch `*statetransition.StateSlotIsNewerError` (via `errors.As`, unwrapping blockbuilder's `process slots: %w`) and skip; other errors still surface as ERROR.

Both log at WARN (matching the sibling `proposal worker busy` warning) and increment `proof_operation{result="skipped_stale"}`. The state-transition guard (`statetransition/slots.go`) is unchanged — block-import validity is untouched.

## Tests

- `TestProduceBlockWithSignaturesStaleHeadReturnsSlotError` — the rejection survives blockbuilder's wrap so the catch works.
- `TestBuildProposalSkipsStaleSlot` — stale duty returns nil (skipped, no error).
- Existing happy-path / non-proposer / accept-stale tests unchanged.

`make build`, `go test ./internal/node/`, and `make lint` pass.

## Notes

- Out of scope (deferred): the `proposal worker busy` cap-1 drop (latest-wins) and prover throughput (aarch64/AVX2).
- The second commit (`chore(devnet5): bump leanSpec pin to cd6981a`) is an unrelated spec-pin bump bundled on this branch; can be split out if preferred.