### PR TITLE
fix(statetransition): validate attestation head against canonical chain

### DIFF
--- a/internal/statetransition/attestations.go
+++ b/internal/statetransition/attestations.go
@@ -41,6 +41,9 @@ func ProcessAttestations(state *types.State, attestations []*types.AggregatedAtt
 		if !IsValidVote(state, source, target) {
 			continue
 		}
+		if !headMatchesChain(state, agg.Data.Head) {
+			continue
+		}
 
 		votes, exists := justifications[target.Root]
 		if !exists {

--- a/internal/statetransition/attestations_test.go
+++ b/internal/statetransition/attestations_test.go
@@ -211,3 +211,58 @@ func TestSerializeJustificationsSortsAndCopiesRoots(t *testing.T) {
 		t.Fatal("serialized root alias mutated source root")
 	}
 }
+
+func TestProcessAttestationsRequiresHeadOnChain(t *testing.T) {
+	const numValidators = 4
+	var r0, r2 [types.RootSize]byte
+	r0[0] = 0xa0
+	r2[0] = 0xa2
+
+	mkState := func() *types.State {
+		hashes := make([][]byte, 3)
+		for i := range hashes {
+			hashes[i] = make([]byte, types.RootSize)
+		}
+		copy(hashes[0], r0[:])
+		copy(hashes[2], r2[:])
+		s := makeGenesisState(numValidators)
+		s.LatestJustified = &types.Checkpoint{Slot: 0, Root: r0}
+		s.LatestFinalized = &types.Checkpoint{Slot: 0, Root: r0}
+		s.HistoricalBlockHashes = hashes
+		s.JustifiedSlots = types.NewBitlistSSZ(0)
+		return s
+	}
+	mkAtt := func(head *types.Checkpoint) *types.AggregatedAttestation {
+		return &types.AggregatedAttestation{
+			AggregationBits: types.BitlistFromIndices([]uint64{0, 1, 2}),
+			Data: &types.AttestationData{
+				Slot:   2,
+				Head:   head,
+				Source: &types.Checkpoint{Slot: 0, Root: r0},
+				Target: &types.Checkpoint{Slot: 2, Root: r2},
+			},
+		}
+	}
+
+	t.Run("on_chain_head_justifies", func(t *testing.T) {
+		s := mkState()
+		if err := ProcessAttestations(s, []*types.AggregatedAttestation{mkAtt(&types.Checkpoint{Slot: 2, Root: r2})}); err != nil {
+			t.Fatalf("ProcessAttestations: %v", err)
+		}
+		if s.LatestJustified.Slot != 2 {
+			t.Fatalf("LatestJustified.Slot = %d, want 2", s.LatestJustified.Slot)
+		}
+	})
+
+	t.Run("off_chain_head_skipped", func(t *testing.T) {
+		var bogus [types.RootSize]byte
+		bogus[0] = 0xee
+		s := mkState()
+		if err := ProcessAttestations(s, []*types.AggregatedAttestation{mkAtt(&types.Checkpoint{Slot: 2, Root: bogus})}); err != nil {
+			t.Fatalf("ProcessAttestations: %v", err)
+		}
+		if s.LatestJustified.Slot != 0 {
+			t.Fatalf("LatestJustified.Slot = %d, want 0 (off-chain head must be skipped)", s.LatestJustified.Slot)
+		}
+	})
+}

--- a/internal/statetransition/votes.go
+++ b/internal/statetransition/votes.go
@@ -47,6 +47,12 @@ func IsValidVote(state *types.State, source, target *types.Checkpoint) bool {
 	return VoteInvalidReason(state, source, target) == ""
 }
 
+// headMatchesChain reports whether the attestation head sits on the canonical
+// chain at its slot. Mirrors the head clause of leanSpec attestation_data_matches_chain.
+func headMatchesChain(state *types.State, head *types.Checkpoint) bool {
+	return head != nil && !types.IsZeroRoot(head.Root) && checkpointExists(state, head)
+}
+
 func IsSlotJustified(state *types.State, finalizedSlot, slot uint64) bool {
 	if slot <= finalizedSlot {
 		return true

--- a/internal/statetransition/votes_test.go
+++ b/internal/statetransition/votes_test.go
@@ -119,3 +119,42 @@ func TestVoteInvalidReason(t *testing.T) {
 		}
 	})
 }
+
+func TestHeadMatchesChain(t *testing.T) {
+	var onChain, offChain [types.RootSize]byte
+	onChain[0] = 0x11
+	offChain[0] = 0x22
+
+	hashes := make([][]byte, 3)
+	for i := range hashes {
+		hashes[i] = make([]byte, types.RootSize)
+	}
+	copy(hashes[2], onChain[:])
+
+	state := makeGenesisState(1)
+	state.HistoricalBlockHashes = hashes
+
+	cp := func(slot uint64, root [types.RootSize]byte) *types.Checkpoint {
+		return &types.Checkpoint{Slot: slot, Root: root}
+	}
+
+	cases := []struct {
+		name string
+		head *types.Checkpoint
+		want bool
+	}{
+		{"on_chain", cp(2, onChain), true},
+		{"zero_root", cp(2, [types.RootSize]byte{}), false},
+		{"off_chain", cp(2, offChain), false},
+		{"beyond_chain", cp(5, onChain), false},
+		{"nil", nil, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := headMatchesChain(state, tc.head); got != tc.want {
+				t.Fatalf("headMatchesChain(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #337.

## Problem

`ProcessAttestations` validated the attestation **source** and **target** checkpoints against `historical_block_hashes`, but not **head**. leanSpec `attestation_data_matches_chain` (`spec/forks/lstar/state_transition.py`, called from `process_attestations`) requires all three checkpoints to pass the same chain test: non-zero root, slot within chain length, and root matching the canonical block at that slot. An attestation with a valid source/target but a bogus or zero head root was accepted by gean and rejected by the spec, which can diverge justification.

## Fix

Add the missing head check in the state-transition path only:
- `votes.go` — `headMatchesChain` helper (non-zero + `checkpointExists`), mirroring the head clause of `attestation_data_matches_chain`; reuses the existing `checkpointExists` (chain-length bound + root match).
- `attestations.go` — apply it in `ProcessAttestations` right after the existing source/target vote validity check; an off-chain or zero head is skipped.

Scope is deliberately confined to the state transition. The shared `VoteInvalidReason` signature and the block-builder payload filter are **unchanged** — the block-builder's separate head-on-canonical-chain alignment (it currently only requires head to be a *known* block) is a distinct concern and out of scope for #337.

## Tests

- `TestHeadMatchesChain` — on-chain / zero-root / off-chain / beyond-chain-length / nil.
- `TestProcessAttestationsRequiresHeadOnChain` — on-chain head justifies; off-chain head is skipped (no justification).
- Existing STF tests unchanged (they already use on-chain heads).

`make build`, `go test ./internal/statetransition/ ./internal/blockbuilder/ ./internal/node/`, and `make lint` pass. The full prod `make test-spec` fixture run is still generating locally (prod XMSS proving is slow); CI runs it authoritatively on this PR. A /lean-review pass found no subtraction opportunities.

## Note on stacking

This branch is stacked on `fix/stale-proposal-skip` (PR #342), so until that merges this PR's commit list also shows #342's commits + the leanSpec pin bump. The #337-specific change is commit `366a9f6`. Can retarget the base to `fix/stale-proposal-skip` for a clean diff if preferred; otherwise the extra commits drop off automatically once #342 merges.