### PR TITLE
fix(consensus): attestation ancestry, aggregation pool, verify_proofs + poseidon spectests

### DIFF
--- a/internal/aggregation/mutation.go
+++ b/internal/aggregation/mutation.go
@@ -2,7 +2,9 @@ package aggregation
 
 import "github.com/geanlabs/gean/internal/store"
 
+// Locally-built aggregates land in the new pool; the accept-attestations tick
+// promotes them to known, matching leanSpec aggregate (latest_new_aggregated_payloads).
 func applyAggregationMutations(s *store.ConsensusStore, payloads []store.PayloadKV, deletes []store.AttestationDeleteKey) {
-	s.KnownPayloads.PushBatch(payloads)
+	s.NewPayloads.PushBatch(payloads)
 	s.AttestationSignatures.Delete(deletes)
 }

--- a/internal/aggregation/mutation_test.go
+++ b/internal/aggregation/mutation_test.go
@@ -1,0 +1,29 @@
+package aggregation
+
+import (
+	"testing"
+
+	"github.com/geanlabs/gean/internal/storage"
+	"github.com/geanlabs/gean/internal/store"
+	"github.com/geanlabs/gean/internal/types"
+)
+
+func TestApplyAggregationMutationsTargetsNewPool(t *testing.T) {
+	s := store.NewConsensusStore(storage.NewInMemoryBackend())
+	participants := types.NewBitlistSSZ(1)
+	types.BitlistSet(participants, 0)
+	payloads := []store.PayloadKV{{
+		DataRoot: [32]byte{0x01},
+		Data:     &types.AttestationData{Head: &types.Checkpoint{}, Source: &types.Checkpoint{}, Target: &types.Checkpoint{}},
+		Proof:    &types.SingleMessageAggregate{Participants: participants, Proof: []byte{1}},
+	}}
+
+	applyAggregationMutations(s, payloads, nil)
+
+	if s.NewPayloads.Len() != 1 {
+		t.Fatalf("NewPayloads.Len() = %d, want 1 (aggregates must enter the new pool)", s.NewPayloads.Len())
+	}
+	if s.KnownPayloads.Len() != 0 {
+		t.Fatalf("KnownPayloads.Len() = %d, want 0 (must wait for accept-attestations promotion)", s.KnownPayloads.Len())
+	}
+}

--- a/internal/attestation/validate.go
+++ b/internal/attestation/validate.go
@@ -48,6 +48,14 @@ func errAttestationTooFarInFuture(attSlot, storeTime uint64) error {
 	return &store.StoreError{Kind: store.ErrAttestationTooFarInFuture, Message: fmt.Sprintf("attestation slot %d too far in future (store time %d intervals)", attSlot, storeTime)}
 }
 
+func errSourceNotAncestorOfTarget() error {
+	return &store.StoreError{Kind: store.ErrSourceNotAncestorOfTarget, Message: "source checkpoint is not an ancestor of target"}
+}
+
+func errTargetNotAncestorOfHead() error {
+	return &store.StoreError{Kind: store.ErrTargetNotAncestorOfHead, Message: "target checkpoint is not an ancestor of head"}
+}
+
 func ValidateAttestationData(s *store.ConsensusStore, data *types.AttestationData) error {
 	if err := validateDataShape(data); err != nil {
 		return err
@@ -81,12 +89,42 @@ func ValidateAttestationData(s *store.ConsensusStore, data *types.AttestationDat
 	if headHeader.Slot != data.Head.Slot {
 		return errHeadSlotMismatch(data.Head.Slot, headHeader.Slot)
 	}
+	if !checkpointIsAncestor(s, data.Source, data.Target) {
+		return errSourceNotAncestorOfTarget()
+	}
+	if !checkpointIsAncestor(s, data.Target, data.Head) {
+		return errTargetNotAncestorOfHead()
+	}
 	if data.Slot > math.MaxUint64/types.IntervalsPerSlot ||
 		data.Slot*types.IntervalsPerSlot > s.Time()+types.GossipDisparityIntervals {
 		return errAttestationTooFarInFuture(data.Slot, s.Time())
 	}
 
 	return nil
+}
+
+// checkpointIsAncestor reports whether ancestor lies on descendant's parent
+// chain. Mirrors leanSpec _checkpoint_is_ancestor: climb parent links from the
+// descendant; the ancestor's slot must carry its exact root, otherwise the two
+// checkpoints sit on forked branches.
+func checkpointIsAncestor(s *store.ConsensusStore, ancestor, descendant *types.Checkpoint) bool {
+	if ancestor.Slot > descendant.Slot {
+		return false
+	}
+	current := descendant.Root
+	for {
+		header := s.GetBlockHeader(current)
+		if header == nil {
+			return false
+		}
+		if header.Slot == ancestor.Slot {
+			return current == ancestor.Root
+		}
+		if header.Slot < ancestor.Slot {
+			return false
+		}
+		current = header.ParentRoot
+	}
 }
 
 func validateDataShape(data *types.AttestationData) error {

--- a/internal/attestation/validate_test.go
+++ b/internal/attestation/validate_test.go
@@ -27,8 +27,8 @@ func makeValidAttestationData() *types.AttestationData {
 
 func insertValidationHeaders(s *store.ConsensusStore) {
 	s.InsertBlockHeader([32]byte{1}, &types.BlockHeader{Slot: 3})
-	s.InsertBlockHeader([32]byte{2}, &types.BlockHeader{Slot: 4})
-	s.InsertBlockHeader([32]byte{3}, &types.BlockHeader{Slot: 5})
+	s.InsertBlockHeader([32]byte{2}, &types.BlockHeader{Slot: 4, ParentRoot: [32]byte{1}})
+	s.InsertBlockHeader([32]byte{3}, &types.BlockHeader{Slot: 5, ParentRoot: [32]byte{2}})
 }
 
 func TestValidateAttestationDataAvailability(t *testing.T) {
@@ -130,5 +130,49 @@ func TestValidateAttestationDataFutureSlot(t *testing.T) {
 	se, ok := err.(*store.StoreError)
 	if !ok || se.Kind != store.ErrAttestationTooFarInFuture {
 		t.Fatalf("error=%v, want ErrAttestationTooFarInFuture", err)
+	}
+}
+
+func TestValidateAttestationDataAncestry(t *testing.T) {
+	// Chain root1(3) <- root2(4) <- root3(5), plus a fork root4(4) off root1.
+	newStore := func() *store.ConsensusStore {
+		s := makeValidationStore()
+		s.SetTime(30)
+		insertValidationHeaders(s)
+		s.InsertBlockHeader([32]byte{4}, &types.BlockHeader{Slot: 4, ParentRoot: [32]byte{1}})
+		return s
+	}
+	cp := func(root byte, slot uint64) *types.Checkpoint {
+		return &types.Checkpoint{Root: [32]byte{root}, Slot: slot}
+	}
+
+	tests := []struct {
+		name           string
+		source, target *types.Checkpoint
+		head           *types.Checkpoint
+		want           store.StoreErrorKind
+	}{
+		{
+			name:   "source_not_ancestor_of_target",
+			source: cp(4, 4), target: cp(3, 5), head: cp(3, 5),
+			want: store.ErrSourceNotAncestorOfTarget,
+		},
+		{
+			name:   "target_not_ancestor_of_head",
+			source: cp(1, 3), target: cp(4, 4), head: cp(3, 5),
+			want: store.ErrTargetNotAncestorOfHead,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newStore()
+			data := &types.AttestationData{Slot: 5, Source: tc.source, Target: tc.target, Head: tc.head}
+			err := attestation.ValidateAttestationData(s, data)
+			se, ok := err.(*store.StoreError)
+			if !ok || se.Kind != tc.want {
+				t.Fatalf("error=%v, want kind %d", err, tc.want)
+			}
+		})
 	}
 }

--- a/internal/spectests/fixture.go
+++ b/internal/spectests/fixture.go
@@ -69,8 +69,8 @@ type TestDataList struct {
 }
 
 type TestValidator struct {
-	AttestationPubkey string `json:"attestationPubkey"`
-	ProposalPubkey    string `json:"proposalPubkey"`
+	AttestationPubkey string `json:"attestationPublicKey"`
+	ProposalPubkey    string `json:"proposalPublicKey"`
 	Index             uint64 `json:"index"`
 }
 

--- a/internal/spectests/forkchoice_test.go
+++ b/internal/spectests/forkchoice_test.go
@@ -63,8 +63,8 @@ type fcDataList struct {
 }
 
 type fcValidator struct {
-	AttestationPubkey string `json:"attestationPubkey"`
-	ProposalPubkey    string `json:"proposalPubkey"`
+	AttestationPubkey string `json:"attestationPublicKey"`
+	ProposalPubkey    string `json:"proposalPublicKey"`
 	Pubkey            string `json:"pubkey"` // legacy fallback
 	Index             uint64 `json:"index"`
 }

--- a/internal/spectests/poseidon_test.go
+++ b/internal/spectests/poseidon_test.go
@@ -1,0 +1,57 @@
+//go:build spectests
+
+package spectests
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/geanlabs/gean/xmss"
+)
+
+type poseidonCase struct {
+	Width       int      `json:"width"`
+	InputState  []string `json:"inputState"`
+	OutputState []string `json:"outputState"`
+}
+
+func TestSpecPoseidonPermutation(t *testing.T) {
+	walkFixtures(t, "../../leanSpec/fixtures/consensus/poseidon_permutation", func(t *testing.T, raw []byte) {
+		var fixture map[string]poseidonCase
+		if err := json.Unmarshal(raw, &fixture); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		for name, tc := range fixture {
+			tc := tc
+			t.Run(name, func(t *testing.T) {
+				state := parseFieldElements(t, tc.InputState)
+				if err := xmss.Poseidon2Permute(state); err != nil {
+					t.Fatalf("permute width %d: %v", tc.Width, err)
+				}
+				want := parseFieldElements(t, tc.OutputState)
+				if len(state) != len(want) {
+					t.Fatalf("length mismatch: got %d want %d", len(state), len(want))
+				}
+				for i := range want {
+					if state[i] != want[i] {
+						t.Fatalf("element %d: got %d want %d", i, state[i], want[i])
+					}
+				}
+			})
+		}
+	})
+}
+
+func parseFieldElements(t *testing.T, vals []string) []uint32 {
+	t.Helper()
+	out := make([]uint32, len(vals))
+	for i, v := range vals {
+		n, err := strconv.ParseUint(v, 10, 32)
+		if err != nil {
+			t.Fatalf("parse field element %q: %v", v, err)
+		}
+		out[i] = uint32(n)
+	}
+	return out
+}

--- a/internal/spectests/verify_proofs_test.go
+++ b/internal/spectests/verify_proofs_test.go
@@ -1,0 +1,154 @@
+//go:build spectests
+
+package spectests
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geanlabs/gean/xmss"
+)
+
+type vpByteList struct {
+	Data string `json:"data"`
+}
+
+// Single-message (Type-1) proof fixtures.
+type verifyProofsSingleCase struct {
+	PublicKeys      []string   `json:"publicKeys"`
+	Message         string     `json:"message"`
+	Slot            uint32     `json:"slot"`
+	Proof           vpByteList `json:"proof"`
+	RejectionReason *string    `json:"rejectionReason"`
+}
+
+// Multi-message (Type-2) proof fixtures.
+type verifyProofsMultiCase struct {
+	PublicKeysPerMessage [][]string `json:"publicKeysPerMessage"`
+	Messages             []string   `json:"messages"`
+	Slots                []uint32   `json:"slots"`
+	Proof                vpByteList `json:"proof"`
+	RejectionReason      *string    `json:"rejectionReason"`
+}
+
+func parsePubkeyHandles(t *testing.T, hexKeys []string) []xmss.CPubKey {
+	t.Helper()
+	keys := make([]xmss.CPubKey, 0, len(hexKeys))
+	for _, h := range hexKeys {
+		pk, err := xmss.ParsePublicKey(parseHexPubkey(h))
+		if err != nil {
+			t.Fatalf("parse pubkey: %v", err)
+		}
+		keys = append(keys, pk)
+	}
+	return keys
+}
+
+func walkFixtures(t *testing.T, root string, run func(t *testing.T, raw []byte)) {
+	t.Helper()
+	if _, err := os.Stat(root); os.IsNotExist(err) {
+		t.Skipf("fixtures not present at %s; skipping", root)
+	}
+	var files []string
+	if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && filepath.Ext(path) == ".json" {
+			files = append(files, path)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+	if len(files) == 0 {
+		t.Skipf("no fixtures in %s; skipping", root)
+	}
+	for _, file := range files {
+		file := file
+		rel, _ := filepath.Rel(root, file)
+		t.Run(rel, func(t *testing.T) {
+			raw, err := os.ReadFile(file)
+			if err != nil {
+				t.Fatalf("reading %s: %v", file, err)
+			}
+			run(t, raw)
+		})
+	}
+}
+
+func TestSpecVerifySingleMessageProofs(t *testing.T) {
+	walkFixtures(t, "../../leanSpec/fixtures/consensus/verify_single_message_proofs", func(t *testing.T, raw []byte) {
+		var fixture map[string]verifyProofsSingleCase
+		if err := json.Unmarshal(raw, &fixture); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		for name, tc := range fixture {
+			tc := tc
+			t.Run(name, func(t *testing.T) {
+				keys := parsePubkeyHandles(t, tc.PublicKeys)
+				defer func() {
+					for _, k := range keys {
+						xmss.FreePublicKey(k)
+					}
+				}()
+				err := xmss.VerifyAggregatedSignature(parseHexBytes(tc.Proof.Data), keys, parseHexRoot(tc.Message), tc.Slot)
+				assertProofOutcome(t, err, tc.RejectionReason)
+			})
+		}
+	})
+}
+
+func TestSpecVerifyMultiMessageProofs(t *testing.T) {
+	walkFixtures(t, "../../leanSpec/fixtures/consensus/verify_multi_message_proofs", func(t *testing.T, raw []byte) {
+		var fixture map[string]verifyProofsMultiCase
+		if err := json.Unmarshal(raw, &fixture); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		for name, tc := range fixture {
+			tc := tc
+			t.Run(name, func(t *testing.T) {
+				// Component counts may intentionally disagree in rejection fixtures
+				// (e.g. a missing binding); let the verifier reject rather than guarding here.
+				groups := make([][]xmss.CPubKey, len(tc.PublicKeysPerMessage))
+				defer func() {
+					for _, g := range groups {
+						for _, k := range g {
+							xmss.FreePublicKey(k)
+						}
+					}
+				}()
+				for i := range tc.PublicKeysPerMessage {
+					groups[i] = parsePubkeyHandles(t, tc.PublicKeysPerMessage[i])
+				}
+				bindings := make([]xmss.MessageBinding, len(tc.Messages))
+				for i := range tc.Messages {
+					var msg [xmss.MessageLength]byte
+					copy(msg[:], parseHexBytes(tc.Messages[i]))
+					var slot uint32
+					if i < len(tc.Slots) {
+						slot = tc.Slots[i]
+					}
+					bindings[i] = xmss.MessageBinding{Message: msg, Slot: slot}
+				}
+				err := xmss.VerifyType2Proof(parseHexBytes(tc.Proof.Data), groups, bindings)
+				assertProofOutcome(t, err, tc.RejectionReason)
+			})
+		}
+	})
+}
+
+func assertProofOutcome(t *testing.T, err error, rejection *string) {
+	t.Helper()
+	if rejection != nil {
+		if err == nil {
+			t.Fatalf("expected rejection %q, got valid", *rejection)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("expected valid proof, got error: %v", err)
+	}
+}

--- a/internal/statetransition/attestations.go
+++ b/internal/statetransition/attestations.go
@@ -41,6 +41,9 @@ func ProcessAttestations(state *types.State, attestations []*types.AggregatedAtt
 		if !IsValidVote(state, source, target) {
 			continue
 		}
+		if !headMatchesChain(state, agg.Data.Head) {
+			continue
+		}
 
 		votes, exists := justifications[target.Root]
 		if !exists {

--- a/internal/statetransition/attestations_test.go
+++ b/internal/statetransition/attestations_test.go
@@ -211,3 +211,58 @@ func TestSerializeJustificationsSortsAndCopiesRoots(t *testing.T) {
 		t.Fatal("serialized root alias mutated source root")
 	}
 }
+
+func TestProcessAttestationsRequiresHeadOnChain(t *testing.T) {
+	const numValidators = 4
+	var r0, r2 [types.RootSize]byte
+	r0[0] = 0xa0
+	r2[0] = 0xa2
+
+	mkState := func() *types.State {
+		hashes := make([][]byte, 3)
+		for i := range hashes {
+			hashes[i] = make([]byte, types.RootSize)
+		}
+		copy(hashes[0], r0[:])
+		copy(hashes[2], r2[:])
+		s := makeGenesisState(numValidators)
+		s.LatestJustified = &types.Checkpoint{Slot: 0, Root: r0}
+		s.LatestFinalized = &types.Checkpoint{Slot: 0, Root: r0}
+		s.HistoricalBlockHashes = hashes
+		s.JustifiedSlots = types.NewBitlistSSZ(0)
+		return s
+	}
+	mkAtt := func(head *types.Checkpoint) *types.AggregatedAttestation {
+		return &types.AggregatedAttestation{
+			AggregationBits: types.BitlistFromIndices([]uint64{0, 1, 2}),
+			Data: &types.AttestationData{
+				Slot:   2,
+				Head:   head,
+				Source: &types.Checkpoint{Slot: 0, Root: r0},
+				Target: &types.Checkpoint{Slot: 2, Root: r2},
+			},
+		}
+	}
+
+	t.Run("on_chain_head_justifies", func(t *testing.T) {
+		s := mkState()
+		if err := ProcessAttestations(s, []*types.AggregatedAttestation{mkAtt(&types.Checkpoint{Slot: 2, Root: r2})}); err != nil {
+			t.Fatalf("ProcessAttestations: %v", err)
+		}
+		if s.LatestJustified.Slot != 2 {
+			t.Fatalf("LatestJustified.Slot = %d, want 2", s.LatestJustified.Slot)
+		}
+	})
+
+	t.Run("off_chain_head_skipped", func(t *testing.T) {
+		var bogus [types.RootSize]byte
+		bogus[0] = 0xee
+		s := mkState()
+		if err := ProcessAttestations(s, []*types.AggregatedAttestation{mkAtt(&types.Checkpoint{Slot: 2, Root: bogus})}); err != nil {
+			t.Fatalf("ProcessAttestations: %v", err)
+		}
+		if s.LatestJustified.Slot != 0 {
+			t.Fatalf("LatestJustified.Slot = %d, want 0 (off-chain head must be skipped)", s.LatestJustified.Slot)
+		}
+	})
+}

--- a/internal/statetransition/votes.go
+++ b/internal/statetransition/votes.go
@@ -47,6 +47,12 @@ func IsValidVote(state *types.State, source, target *types.Checkpoint) bool {
 	return VoteInvalidReason(state, source, target) == ""
 }
 
+// headMatchesChain reports whether the attestation head sits on the canonical
+// chain at its slot. Mirrors the head clause of leanSpec attestation_data_matches_chain.
+func headMatchesChain(state *types.State, head *types.Checkpoint) bool {
+	return head != nil && !types.IsZeroRoot(head.Root) && checkpointExists(state, head)
+}
+
 func IsSlotJustified(state *types.State, finalizedSlot, slot uint64) bool {
 	if slot <= finalizedSlot {
 		return true

--- a/internal/statetransition/votes_test.go
+++ b/internal/statetransition/votes_test.go
@@ -119,3 +119,42 @@ func TestVoteInvalidReason(t *testing.T) {
 		}
 	})
 }
+
+func TestHeadMatchesChain(t *testing.T) {
+	var onChain, offChain [types.RootSize]byte
+	onChain[0] = 0x11
+	offChain[0] = 0x22
+
+	hashes := make([][]byte, 3)
+	for i := range hashes {
+		hashes[i] = make([]byte, types.RootSize)
+	}
+	copy(hashes[2], onChain[:])
+
+	state := makeGenesisState(1)
+	state.HistoricalBlockHashes = hashes
+
+	cp := func(slot uint64, root [types.RootSize]byte) *types.Checkpoint {
+		return &types.Checkpoint{Slot: slot, Root: root}
+	}
+
+	cases := []struct {
+		name string
+		head *types.Checkpoint
+		want bool
+	}{
+		{"on_chain", cp(2, onChain), true},
+		{"zero_root", cp(2, [types.RootSize]byte{}), false},
+		{"off_chain", cp(2, offChain), false},
+		{"beyond_chain", cp(5, onChain), false},
+		{"nil", nil, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := headMatchesChain(state, tc.head); got != tc.want {
+				t.Fatalf("headMatchesChain(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -36,4 +36,6 @@ const (
 	ErrDuplicateAttestationData
 	ErrTooManyAttestationData
 	ErrJustifiedDivergenceNotClosed
+	ErrSourceNotAncestorOfTarget
+	ErrTargetNotAncestorOfHead
 )

--- a/xmss/ffi.go
+++ b/xmss/ffi.go
@@ -80,6 +80,9 @@ package xmss
 //     const uint8_t* proof, size_t proof_len,
 //     const PublicKey* const* pubkeys, const size_t* pubkey_counts,
 //     size_t count, const uint8_t* message_hashes, const uint32_t* message_slots);
+//
+// int32_t poseidon_permute_kb16(uint32_t* state, size_t len);
+// int32_t poseidon_permute_kb24(uint32_t* state, size_t len);
 import "C"
 
 import (
@@ -116,7 +119,29 @@ var (
 	ErrMalformedChildProof = errors.New("malformed child proof")
 	ErrMalformedRawInput   = errors.New("malformed raw signature input")
 	ErrSetupFailed         = errors.New("XMSS setup failed")
+	ErrPoseidonWidth       = errors.New("poseidon permutation width must be 16 or 24")
+	ErrPoseidonPermute     = errors.New("poseidon permutation failed")
 )
+
+// Poseidon2Permute applies the KoalaBear Poseidon permutation in place. The
+// state holds canonical field-element values; width must be 16 or 24.
+func Poseidon2Permute(state []uint32) error {
+	if len(state) != 16 && len(state) != 24 {
+		return ErrPoseidonWidth
+	}
+	ptr := (*C.uint32_t)(unsafe.Pointer(&state[0]))
+	n := C.size_t(len(state))
+	var status C.int32_t
+	if len(state) == 16 {
+		status = C.poseidon_permute_kb16(ptr, n)
+	} else {
+		status = C.poseidon_permute_kb24(ptr, n)
+	}
+	if status != 0 {
+		return ErrPoseidonPermute
+	}
+	return nil
+}
 
 var (
 	proverOnce   sync.Once

--- a/xmss/rust/multisig-glue/src/lib.rs
+++ b/xmss/rust/multisig-glue/src/lib.rs
@@ -1,3 +1,7 @@
+use backend::symmetric::Permutation;
+use backend::{
+    default_koalabear_poseidon1_16, default_koalabear_poseidon1_24, KoalaBear, PrimeField32,
+};
 use leansig_wrapper::{XmssPublicKey, XmssSignature};
 use rec_aggregation::{
     aggregate_type_1, init_aggregation_bytecode, merge_many_type_1, split_type_2_by_msg,
@@ -362,5 +366,45 @@ pub unsafe extern "C" fn xmss_verify_type_2(
             }
         }
         verify_type_2(&proof).is_ok()
+    })
+}
+
+// Poseidon permutation over KoalaBear, exposed for spec test vectors. The state
+// is the canonical u32 field representation, permuted in place. This is the same
+// instance the XMSS stack hashes with, so it matches the spec. Returns -1 on a
+// null pointer or wrong width.
+#[no_mangle]
+pub unsafe extern "C" fn poseidon_permute_kb16(state: *mut u32, len: usize) -> i32 {
+    ffi_guard!(-1, {
+        if state.is_null() || len != 16 {
+            return -1;
+        }
+        let raw = slice::from_raw_parts_mut(state, 16);
+        let mut input = [0u32; 16];
+        input.copy_from_slice(raw);
+        let mut fe = KoalaBear::new_array(input);
+        default_koalabear_poseidon1_16().permute_mut(&mut fe);
+        for (dst, x) in raw.iter_mut().zip(fe.iter()) {
+            *dst = x.as_canonical_u32();
+        }
+        0
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn poseidon_permute_kb24(state: *mut u32, len: usize) -> i32 {
+    ffi_guard!(-1, {
+        if state.is_null() || len != 24 {
+            return -1;
+        }
+        let raw = slice::from_raw_parts_mut(state, 24);
+        let mut input = [0u32; 24];
+        input.copy_from_slice(raw);
+        let mut fe = KoalaBear::new_array(input);
+        default_koalabear_poseidon1_24().permute_mut(&mut fe);
+        for (dst, x) in raw.iter_mut().zip(fe.iter()) {
+            *dst = x.as_canonical_u32();
+        }
+        0
     })
 }


### PR DESCRIPTION
Closes #338, #339, #340.

Bundled per request as one multi-part change; each issue is its own commit.

## #338 — attestation ancestry validation
`ValidateAttestationData` checked block existence + slot ordering but not ancestry. Added a parent-chain walk so **source ⊑ target** and **target ⊑ head**, mirroring leanSpec `_checkpoint_is_ancestor` / `validate_attestation`, with new `StoreError` kinds (`ErrSourceNotAncestorOfTarget`, `ErrTargetNotAncestorOfHead`). `internal/attestation/validate.go`, `internal/store/errors.go`.

## #339 — locally-built aggregates → new pool
leanSpec `aggregate` writes to `latest_new_aggregated_payloads`; the accept tick promotes new→known. gean pushed locally-built aggregates straight to the **known** pool (counting a tick early). Now routed to `NewPayloads`, matching gossip/recovery. `internal/aggregation/mutation.go`.

## #340 — verify_proofs + poseidon spectest runners
- **verify_proofs** — Type-1 (single-message) and Type-2 (multi-message) runners; pass all fixtures incl. rejection cases.
- **poseidon** — exposes the KoalaBear Poseidon permutation (width 16/24) over the existing FFI, using the **same instance the XMSS stack hashes with** (no new dependency — the leanVM `poseidon1` is structurally the spec's 8-full/20-partial permutation). All width-16/24 fixtures pass.
- `internal/spectests/{verify_proofs_test,poseidon_test}.go`, `xmss/ffi.go`, `xmss/rust/multisig-glue/src/lib.rs`.

## Enabling fix — spectest pubkey tags
A prerequisite commit aligns the spectest validator fixture tags (`attestationPubkey`→`attestationPublicKey`, `proposalPubkey`→`proposalPublicKey`); the cd6981a fixtures use the `PublicKey` spelling and every consensus spectest previously panicked on an empty pubkey. This also unblocks #337's STF validation.

## Validation
`make ffi`, `make lint` (go vet + cargo fmt + clippy), unit tests for attestation/aggregation/store, and the verify_proofs / poseidon / state_transition spectests against the generated `cd6981a` fixtures all pass.

## Known pre-existing gaps (surfaced by running spectests at cd6981a — NOT addressed here)
- STF `test_process_slots_target_equal_to_state_slot_rejected` (slot-monotonicity)
- fc `test_valid_gossip_attestation`, `test_finalization_prunes_stale_attestation_signatures` (signature verification), `test_safe_target_ignores_known_pool_at_interval_3` (vote tracker)
- leanSpec's own fixture generation fails one case at cd6981a (`test_same_slot_equivocating_attesters_count_once`), so `make test-spec` doesn't complete its marker — spectests must be run directly. Affects CI on the bump (#342).

## Stacking
Branches off `fix/attestation-head-chain-validation` (#343 / #337), which is off `fix/stale-proposal-skip` (#342 / #341 + leanSpec bump). Against `devnet-5` this PR therefore also lists those commits until #342 and #343 merge.