### PR TITLE
fix(consensus): attestation target lower bound + STF slot-monotonicity spectest

### DIFF
--- a/internal/aggregation/mutation.go
+++ b/internal/aggregation/mutation.go
@@ -2,7 +2,9 @@ package aggregation
 
 import "github.com/geanlabs/gean/internal/store"
 
+// Locally-built aggregates land in the new pool; the accept-attestations tick
+// promotes them to known, matching leanSpec aggregate (latest_new_aggregated_payloads).
 func applyAggregationMutations(s *store.ConsensusStore, payloads []store.PayloadKV, deletes []store.AttestationDeleteKey) {
-	s.KnownPayloads.PushBatch(payloads)
+	s.NewPayloads.PushBatch(payloads)
 	s.AttestationSignatures.Delete(deletes)
 }

--- a/internal/aggregation/mutation_test.go
+++ b/internal/aggregation/mutation_test.go
@@ -1,0 +1,29 @@
+package aggregation
+
+import (
+	"testing"
+
+	"github.com/geanlabs/gean/internal/storage"
+	"github.com/geanlabs/gean/internal/store"
+	"github.com/geanlabs/gean/internal/types"
+)
+
+func TestApplyAggregationMutationsTargetsNewPool(t *testing.T) {
+	s := store.NewConsensusStore(storage.NewInMemoryBackend())
+	participants := types.NewBitlistSSZ(1)
+	types.BitlistSet(participants, 0)
+	payloads := []store.PayloadKV{{
+		DataRoot: [32]byte{0x01},
+		Data:     &types.AttestationData{Head: &types.Checkpoint{}, Source: &types.Checkpoint{}, Target: &types.Checkpoint{}},
+		Proof:    &types.SingleMessageAggregate{Participants: participants, Proof: []byte{1}},
+	}}
+
+	applyAggregationMutations(s, payloads, nil)
+
+	if s.NewPayloads.Len() != 1 {
+		t.Fatalf("NewPayloads.Len() = %d, want 1 (aggregates must enter the new pool)", s.NewPayloads.Len())
+	}
+	if s.KnownPayloads.Len() != 0 {
+		t.Fatalf("KnownPayloads.Len() = %d, want 0 (must wait for accept-attestations promotion)", s.KnownPayloads.Len())
+	}
+}

--- a/internal/attestation/target.go
+++ b/internal/attestation/target.go
@@ -13,14 +13,21 @@ func GetAttestationTarget(s *store.ConsensusStore) *types.Checkpoint {
 		return &types.Checkpoint{}
 	}
 
-	safeTargetHeader := s.GetBlockHeader(s.SafeTarget())
 	safeTargetSlot := uint64(0)
-	if safeTargetHeader != nil {
+	if safeTargetHeader := s.GetBlockHeader(s.SafeTarget()); safeTargetHeader != nil {
 		safeTargetSlot = safeTargetHeader.Slot
 	}
 
+	// The walk never crosses the finalized boundary: a safe target lagging
+	// behind finalization falls back to the finalized slot as the lower bound.
+	finalizedSlot := s.LatestFinalized().Slot
+	lowerBoundSlot := safeTargetSlot
+	if finalizedSlot > lowerBoundSlot {
+		lowerBoundSlot = finalizedSlot
+	}
+
 	for range uint64(types.JustificationLookbackSlots) {
-		if targetHeader.Slot <= safeTargetSlot {
+		if targetHeader.Slot <= lowerBoundSlot {
 			break
 		}
 		targetRoot = targetHeader.ParentRoot
@@ -31,7 +38,6 @@ func GetAttestationTarget(s *store.ConsensusStore) *types.Checkpoint {
 		targetHeader = parent
 	}
 
-	finalizedSlot := s.LatestFinalized().Slot
 	for targetHeader.Slot > finalizedSlot &&
 		!statetransition.SlotIsJustifiableAfter(targetHeader.Slot, finalizedSlot) {
 		targetRoot = targetHeader.ParentRoot
@@ -40,11 +46,6 @@ func GetAttestationTarget(s *store.ConsensusStore) *types.Checkpoint {
 			break
 		}
 		targetHeader = parent
-	}
-
-	latestJustified := s.LatestJustified()
-	if targetHeader.Slot < latestJustified.Slot {
-		return latestJustified
 	}
 
 	return &types.Checkpoint{

--- a/internal/attestation/target_test.go
+++ b/internal/attestation/target_test.go
@@ -39,3 +39,26 @@ func TestGetAttestationTargetWalksBackToSafeTarget(t *testing.T) {
 		t.Fatalf("target = %+v, want slot 8 root %x", cp, h8)
 	}
 }
+
+// When the safe target lags behind finalization, the lower bound is the
+// finalized slot: the walk must stop at finalized, not rewind to the stale
+// safe target. Chain head(6)->5->4, safe target slot 4, finalized slot 5.
+func TestGetAttestationTargetLowerBoundIsFinalizedWhenSafeTargetStale(t *testing.T) {
+	s := makeValidationStore()
+	h6 := [32]byte{6}
+	h5 := [32]byte{5}
+	h4 := [32]byte{4}
+	s.InsertBlockHeader(h6, &types.BlockHeader{Slot: 6, ParentRoot: h5})
+	s.InsertBlockHeader(h5, &types.BlockHeader{Slot: 5, ParentRoot: h4})
+	s.InsertBlockHeader(h4, &types.BlockHeader{Slot: 4})
+
+	s.SetHead(h6)
+	s.SetSafeTarget(h4)
+	s.SetLatestFinalized(&types.Checkpoint{Slot: 5, Root: h5})
+	s.SetLatestJustified(&types.Checkpoint{Slot: 0})
+
+	cp := attestation.GetAttestationTarget(s)
+	if cp.Slot != 5 || cp.Root != h5 {
+		t.Fatalf("target = %+v, want slot 5 root %x (finalized lower bound)", cp, h5)
+	}
+}

--- a/internal/attestation/validate.go
+++ b/internal/attestation/validate.go
@@ -48,6 +48,14 @@ func errAttestationTooFarInFuture(attSlot, storeTime uint64) error {
 	return &store.StoreError{Kind: store.ErrAttestationTooFarInFuture, Message: fmt.Sprintf("attestation slot %d too far in future (store time %d intervals)", attSlot, storeTime)}
 }
 
+func errSourceNotAncestorOfTarget() error {
+	return &store.StoreError{Kind: store.ErrSourceNotAncestorOfTarget, Message: "source checkpoint is not an ancestor of target"}
+}
+
+func errTargetNotAncestorOfHead() error {
+	return &store.StoreError{Kind: store.ErrTargetNotAncestorOfHead, Message: "target checkpoint is not an ancestor of head"}
+}
+
 func ValidateAttestationData(s *store.ConsensusStore, data *types.AttestationData) error {
 	if err := validateDataShape(data); err != nil {
 		return err
@@ -81,12 +89,42 @@ func ValidateAttestationData(s *store.ConsensusStore, data *types.AttestationDat
 	if headHeader.Slot != data.Head.Slot {
 		return errHeadSlotMismatch(data.Head.Slot, headHeader.Slot)
 	}
+	if !checkpointIsAncestor(s, data.Source, data.Target) {
+		return errSourceNotAncestorOfTarget()
+	}
+	if !checkpointIsAncestor(s, data.Target, data.Head) {
+		return errTargetNotAncestorOfHead()
+	}
 	if data.Slot > math.MaxUint64/types.IntervalsPerSlot ||
 		data.Slot*types.IntervalsPerSlot > s.Time()+types.GossipDisparityIntervals {
 		return errAttestationTooFarInFuture(data.Slot, s.Time())
 	}
 
 	return nil
+}
+
+// checkpointIsAncestor reports whether ancestor lies on descendant's parent
+// chain. Mirrors leanSpec _checkpoint_is_ancestor: climb parent links from the
+// descendant; the ancestor's slot must carry its exact root, otherwise the two
+// checkpoints sit on forked branches.
+func checkpointIsAncestor(s *store.ConsensusStore, ancestor, descendant *types.Checkpoint) bool {
+	if ancestor.Slot > descendant.Slot {
+		return false
+	}
+	current := descendant.Root
+	for {
+		header := s.GetBlockHeader(current)
+		if header == nil {
+			return false
+		}
+		if header.Slot == ancestor.Slot {
+			return current == ancestor.Root
+		}
+		if header.Slot < ancestor.Slot {
+			return false
+		}
+		current = header.ParentRoot
+	}
 }
 
 func validateDataShape(data *types.AttestationData) error {

--- a/internal/attestation/validate_test.go
+++ b/internal/attestation/validate_test.go
@@ -27,8 +27,8 @@ func makeValidAttestationData() *types.AttestationData {
 
 func insertValidationHeaders(s *store.ConsensusStore) {
 	s.InsertBlockHeader([32]byte{1}, &types.BlockHeader{Slot: 3})
-	s.InsertBlockHeader([32]byte{2}, &types.BlockHeader{Slot: 4})
-	s.InsertBlockHeader([32]byte{3}, &types.BlockHeader{Slot: 5})
+	s.InsertBlockHeader([32]byte{2}, &types.BlockHeader{Slot: 4, ParentRoot: [32]byte{1}})
+	s.InsertBlockHeader([32]byte{3}, &types.BlockHeader{Slot: 5, ParentRoot: [32]byte{2}})
 }
 
 func TestValidateAttestationDataAvailability(t *testing.T) {
@@ -130,5 +130,49 @@ func TestValidateAttestationDataFutureSlot(t *testing.T) {
 	se, ok := err.(*store.StoreError)
 	if !ok || se.Kind != store.ErrAttestationTooFarInFuture {
 		t.Fatalf("error=%v, want ErrAttestationTooFarInFuture", err)
+	}
+}
+
+func TestValidateAttestationDataAncestry(t *testing.T) {
+	// Chain root1(3) <- root2(4) <- root3(5), plus a fork root4(4) off root1.
+	newStore := func() *store.ConsensusStore {
+		s := makeValidationStore()
+		s.SetTime(30)
+		insertValidationHeaders(s)
+		s.InsertBlockHeader([32]byte{4}, &types.BlockHeader{Slot: 4, ParentRoot: [32]byte{1}})
+		return s
+	}
+	cp := func(root byte, slot uint64) *types.Checkpoint {
+		return &types.Checkpoint{Root: [32]byte{root}, Slot: slot}
+	}
+
+	tests := []struct {
+		name           string
+		source, target *types.Checkpoint
+		head           *types.Checkpoint
+		want           store.StoreErrorKind
+	}{
+		{
+			name:   "source_not_ancestor_of_target",
+			source: cp(4, 4), target: cp(3, 5), head: cp(3, 5),
+			want: store.ErrSourceNotAncestorOfTarget,
+		},
+		{
+			name:   "target_not_ancestor_of_head",
+			source: cp(1, 3), target: cp(4, 4), head: cp(3, 5),
+			want: store.ErrTargetNotAncestorOfHead,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newStore()
+			data := &types.AttestationData{Slot: 5, Source: tc.source, Target: tc.target, Head: tc.head}
+			err := attestation.ValidateAttestationData(s, data)
+			se, ok := err.(*store.StoreError)
+			if !ok || se.Kind != tc.want {
+				t.Fatalf("error=%v, want kind %d", err, tc.want)
+			}
+		})
 	}
 }

--- a/internal/blockbuilder/errors.go
+++ b/internal/blockbuilder/errors.go
@@ -12,6 +12,7 @@ var ErrJustifiedDivergenceNotClosed = errors.New("justified divergence not close
 var ErrMalformedInput = errors.New("malformed blockbuilder input")
 var ErrMalformedPayload = errors.New("malformed payload")
 var ErrPayloadHeadUnknown = errors.New("payload head root unknown")
+var ErrPayloadHeadOffChain = errors.New("payload head off canonical chain")
 var ErrPayloadRootMismatch = errors.New("payload root mismatch")
 var ErrPayloadVoteInvalid = errors.New("payload vote invalid")
 
@@ -69,6 +70,10 @@ func errPayloadRootMismatch(dataRoot, computed [32]byte) error {
 
 func errPayloadHeadUnknown(root [32]byte) error {
 	return fmt.Errorf("%w: head root=0x%x [%w]", ErrPayloadHeadUnknown, root, errExpectedSkip)
+}
+
+func errPayloadHeadOffChain(root [32]byte) error {
+	return fmt.Errorf("%w: head root=0x%x [%w]", ErrPayloadHeadOffChain, root, errExpectedSkip)
 }
 
 func errPayloadVoteInvalid(data *types.AttestationData, reason string) error {

--- a/internal/blockbuilder/payloads.go
+++ b/internal/blockbuilder/payloads.go
@@ -81,6 +81,12 @@ func payloadBuildIssue(state *types.State, knownRoots KnownRoots, payload Attest
 	if !knownRoots.Contains(data.Head.Root) {
 		return errPayloadHeadUnknown(data.Head.Root)
 	}
+	// Mirror the spec proposer: head must sit on the canonical chain, not just be
+	// a known block, so the builder drops the same off-fork votes the state
+	// transition would skip. Source/target chain membership is covered below.
+	if !statetransition.HeadMatchesChain(state, data.Head) {
+		return errPayloadHeadOffChain(data.Head.Root)
+	}
 	if reason := statetransition.VoteInvalidReason(state, data.Source, data.Target); reason != "" {
 		if data.Source.Slot == 0 && data.Target.Slot == 0 &&
 			reason == statetransition.VoteReasonTargetAlreadyJustified {

--- a/internal/blockbuilder/payloads_test.go
+++ b/internal/blockbuilder/payloads_test.go
@@ -199,6 +199,18 @@ func TestPayloadBuildIssueUsesTransitionVoteRules(t *testing.T) {
 		t.Fatalf("head unknown skip was not marked expected: %v", err)
 	}
 
+	// Head known but off the canonical chain (a forked block) must be dropped,
+	// matching the spec proposer; expected skip, not a hard error.
+	offHead := *data
+	forkHead := [32]byte{0xfe}
+	offHead.Head = &types.Checkpoint{Slot: data.Head.Slot, Root: forkHead}
+	if err := payloadBuildIssue(workingState, map[[32]byte]bool{parentRoot: true, forkHead: true},
+		AttestationPayload{DataRoot: dataRoot, Data: &offHead, Proofs: payload.Proofs}); !errors.Is(err, ErrPayloadHeadOffChain) {
+		t.Fatalf("payload build issue=%v, want ErrPayloadHeadOffChain", err)
+	} else if !IsExpectedSkip(err) {
+		t.Fatalf("off-chain head skip was not marked expected: %v", err)
+	}
+
 	sameSlot := *data
 	sameSlot.Target = &types.Checkpoint{Slot: data.Source.Slot, Root: data.Source.Root}
 	payload.Data = &sameSlot

--- a/internal/spectests/fixture.go
+++ b/internal/spectests/fixture.go
@@ -69,8 +69,8 @@ type TestDataList struct {
 }
 
 type TestValidator struct {
-	AttestationPubkey string `json:"attestationPubkey"`
-	ProposalPubkey    string `json:"proposalPubkey"`
+	AttestationPubkey string `json:"attestationPublicKey"`
+	ProposalPubkey    string `json:"proposalPublicKey"`
 	Index             uint64 `json:"index"`
 }
 

--- a/internal/spectests/forkchoice_test.go
+++ b/internal/spectests/forkchoice_test.go
@@ -63,8 +63,8 @@ type fcDataList struct {
 }
 
 type fcValidator struct {
-	AttestationPubkey string `json:"attestationPubkey"`
-	ProposalPubkey    string `json:"proposalPubkey"`
+	AttestationPubkey string `json:"attestationPublicKey"`
+	ProposalPubkey    string `json:"proposalPublicKey"`
 	Pubkey            string `json:"pubkey"` // legacy fallback
 	Index             uint64 `json:"index"`
 }

--- a/internal/spectests/poseidon_test.go
+++ b/internal/spectests/poseidon_test.go
@@ -1,0 +1,57 @@
+//go:build spectests
+
+package spectests
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/geanlabs/gean/xmss"
+)
+
+type poseidonCase struct {
+	Width       int      `json:"width"`
+	InputState  []string `json:"inputState"`
+	OutputState []string `json:"outputState"`
+}
+
+func TestSpecPoseidonPermutation(t *testing.T) {
+	walkFixtures(t, "../../leanSpec/fixtures/consensus/poseidon_permutation", func(t *testing.T, raw []byte) {
+		var fixture map[string]poseidonCase
+		if err := json.Unmarshal(raw, &fixture); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		for name, tc := range fixture {
+			tc := tc
+			t.Run(name, func(t *testing.T) {
+				state := parseFieldElements(t, tc.InputState)
+				if err := xmss.Poseidon2Permute(state); err != nil {
+					t.Fatalf("permute width %d: %v", tc.Width, err)
+				}
+				want := parseFieldElements(t, tc.OutputState)
+				if len(state) != len(want) {
+					t.Fatalf("length mismatch: got %d want %d", len(state), len(want))
+				}
+				for i := range want {
+					if state[i] != want[i] {
+						t.Fatalf("element %d: got %d want %d", i, state[i], want[i])
+					}
+				}
+			})
+		}
+	})
+}
+
+func parseFieldElements(t *testing.T, vals []string) []uint32 {
+	t.Helper()
+	out := make([]uint32, len(vals))
+	for i, v := range vals {
+		n, err := strconv.ParseUint(v, 10, 32)
+		if err != nil {
+			t.Fatalf("parse field element %q: %v", v, err)
+		}
+		out[i] = uint32(n)
+	}
+	return out
+}

--- a/internal/spectests/signatures_test.go
+++ b/internal/spectests/signatures_test.go
@@ -49,11 +49,7 @@ type sigSBA struct {
 // MultiMessageAggregate serializes as {"proof": {"data": "0x..."}} — its proof
 // field is a ByteList nested one level deeper than a bare ByteList.
 type sigProof struct {
-	Proof sigByteList `json:"proof"`
-}
-
-type sigByteList struct {
-	Data string `json:"data"`
+	Proof fcProofData `json:"proof"`
 }
 
 // toState converts fixture anchor state to types.State.

--- a/internal/spectests/signatures_test.go
+++ b/internal/spectests/signatures_test.go
@@ -46,7 +46,13 @@ type sigSBA struct {
 	Proof sigProof `json:"proof"`
 }
 
+// MultiMessageAggregate serializes as {"proof": {"data": "0x..."}} — its proof
+// field is a ByteList nested one level deeper than a bare ByteList.
 type sigProof struct {
+	Proof sigByteList `json:"proof"`
+}
+
+type sigByteList struct {
 	Data string `json:"data"`
 }
 
@@ -124,7 +130,7 @@ func (fs *sigState) toState() *types.State {
 func (sba *sigSBA) toSignedBlock() *types.SignedBlock {
 	return &types.SignedBlock{
 		Block: sba.Block.toBlock(),
-		Proof: &types.MultiMessageAggregate{Proof: parseHexBytes(sba.Proof.Data)},
+		Proof: &types.MultiMessageAggregate{Proof: parseHexBytes(sba.Proof.Proof.Data)},
 	}
 }
 

--- a/internal/spectests/slot_clock_test.go
+++ b/internal/spectests/slot_clock_test.go
@@ -23,24 +23,26 @@ type slotClockFixtureOuter map[string]slotClockFixture
 type slotClockFixture struct {
 	Network   string                 `json:"network"`
 	LeanEnv   string                 `json:"leanEnv"`
-	Operation string                 `json:"operation"`
-	Input     slotClockInput         `json:"input"`
+	Operation slotClockOperation     `json:"operation"`
+	Config    slotClockConfig        `json:"config"`
 	Output    slotClockOutput        `json:"output"`
 	Info      map[string]interface{} `json:"_info"`
 }
 
-type slotClockInput struct {
-	GenesisTime   uint64 `json:"genesisTime"`
-	CurrentTimeMs uint64 `json:"currentTimeMs"`
-	UnixSeconds   uint64 `json:"unixSeconds"`
-	Slot          uint64 `json:"slot"`
+// operation carries the derivation kind and its inputs inline. The spec emits
+// the numeric inputs as JSON floats, so they are parsed as floats and truncated.
+type slotClockOperation struct {
+	Kind                    string  `json:"kind"`
+	GenesisTime             float64 `json:"genesisTime"`
+	CurrentTimeMilliseconds float64 `json:"currentTimeMilliseconds"`
+	UnixSeconds             float64 `json:"unixSeconds"`
+	Slot                    float64 `json:"slot"`
 }
 
 type slotClockOutput struct {
-	Config         slotClockConfig `json:"config"`
-	Slot           uint64          `json:"slot"`
-	Interval       uint64          `json:"interval"`
-	TotalIntervals uint64          `json:"totalIntervals"`
+	Slot           uint64 `json:"slot"`
+	Interval       uint64 `json:"interval"`
+	TotalIntervals uint64 `json:"totalIntervals"`
 }
 
 type slotClockConfig struct {
@@ -82,41 +84,41 @@ func TestSpecSlotClock(t *testing.T) {
 		for _, fx := range outer {
 			fx := fx
 			t.Run(base, func(t *testing.T) {
-				assertConstantsMatch(t, fx.Output.Config)
+				assertConstantsMatch(t, fx.Config)
 
-				switch fx.Operation {
+				op := fx.Operation
+				gt := uint64(op.GenesisTime)
+				nowMs := uint64(op.CurrentTimeMilliseconds)
+				unix := uint64(op.UnixSeconds)
+				slot := uint64(op.Slot)
+				switch op.Kind {
 				case "current_slot":
-					got := types.CurrentSlot(fx.Input.GenesisTime, fx.Input.CurrentTimeMs)
+					got := types.CurrentSlot(gt, nowMs)
 					if got != fx.Output.Slot {
-						t.Errorf("CurrentSlot(gt=%d, now=%d) = %d, want %d",
-							fx.Input.GenesisTime, fx.Input.CurrentTimeMs, got, fx.Output.Slot)
+						t.Errorf("CurrentSlot(gt=%d, now=%d) = %d, want %d", gt, nowMs, got, fx.Output.Slot)
 					}
 				case "current_interval":
-					got := types.CurrentInterval(fx.Input.GenesisTime, fx.Input.CurrentTimeMs)
+					got := types.CurrentInterval(gt, nowMs)
 					if got != fx.Output.Interval {
-						t.Errorf("CurrentInterval(gt=%d, now=%d) = %d, want %d",
-							fx.Input.GenesisTime, fx.Input.CurrentTimeMs, got, fx.Output.Interval)
+						t.Errorf("CurrentInterval(gt=%d, now=%d) = %d, want %d", gt, nowMs, got, fx.Output.Interval)
 					}
 				case "total_intervals":
-					got := types.TotalIntervals(fx.Input.GenesisTime, fx.Input.CurrentTimeMs)
+					got := types.TotalIntervals(gt, nowMs)
 					if got != fx.Output.TotalIntervals {
-						t.Errorf("TotalIntervals(gt=%d, now=%d) = %d, want %d",
-							fx.Input.GenesisTime, fx.Input.CurrentTimeMs, got, fx.Output.TotalIntervals)
+						t.Errorf("TotalIntervals(gt=%d, now=%d) = %d, want %d", gt, nowMs, got, fx.Output.TotalIntervals)
 					}
 				case "from_slot":
-					got := types.IntervalsFromSlot(fx.Input.Slot)
+					got := types.IntervalsFromSlot(slot)
 					if got != fx.Output.Interval {
-						t.Errorf("IntervalsFromSlot(%d) = %d, want %d",
-							fx.Input.Slot, got, fx.Output.Interval)
+						t.Errorf("IntervalsFromSlot(%d) = %d, want %d", slot, got, fx.Output.Interval)
 					}
 				case "from_unix_time":
-					got := types.IntervalsFromUnixTime(fx.Input.UnixSeconds, fx.Input.GenesisTime)
+					got := types.IntervalsFromUnixTime(unix, gt)
 					if got != fx.Output.Interval {
-						t.Errorf("IntervalsFromUnixTime(unix=%d, gt=%d) = %d, want %d",
-							fx.Input.UnixSeconds, fx.Input.GenesisTime, got, fx.Output.Interval)
+						t.Errorf("IntervalsFromUnixTime(unix=%d, gt=%d) = %d, want %d", unix, gt, got, fx.Output.Interval)
 					}
 				default:
-					t.Skipf("unsupported slot_clock operation %q", fx.Operation)
+					t.Skipf("unsupported slot_clock operation %q", op.Kind)
 				}
 			})
 		}

--- a/internal/spectests/ssz_test.go
+++ b/internal/spectests/ssz_test.go
@@ -20,13 +20,6 @@ var sszFixtureRoots = []string{
 	"../../leanSpec/fixtures/consensus/ssz/lstar/ssz/test_consensus_containers",
 	"../../leanSpec/fixtures/consensus/ssz/lstar/ssz/test_networking_containers",
 	"../../leanSpec/fixtures/consensus/ssz/lstar/ssz/test_xmss_containers",
-	// Basic/parameterized-type suites: gean exposes these only inline (not as
-	// standalone SSZ codecs), so the runner consumes them and skips per
-	// unregistered typeName rather than silently leaving the dirs unwalked.
-	"../../leanSpec/fixtures/consensus/ssz/lstar/ssz/test_basic_types",
-	"../../leanSpec/fixtures/consensus/ssz/lstar/ssz/test_decode_rejections",
-	"../../leanSpec/fixtures/consensus/ssz/lstar/ssz/test_merkleization_boundaries",
-	"../../leanSpec/fixtures/consensus/ssz/lstar/ssz/test_decode_failure_smoke",
 }
 
 type sszFixtureOuter map[string]sszFixture

--- a/internal/spectests/ssz_test.go
+++ b/internal/spectests/ssz_test.go
@@ -20,6 +20,13 @@ var sszFixtureRoots = []string{
 	"../../leanSpec/fixtures/consensus/ssz/lstar/ssz/test_consensus_containers",
 	"../../leanSpec/fixtures/consensus/ssz/lstar/ssz/test_networking_containers",
 	"../../leanSpec/fixtures/consensus/ssz/lstar/ssz/test_xmss_containers",
+	// Basic/parameterized-type suites: gean exposes these only inline (not as
+	// standalone SSZ codecs), so the runner consumes them and skips per
+	// unregistered typeName rather than silently leaving the dirs unwalked.
+	"../../leanSpec/fixtures/consensus/ssz/lstar/ssz/test_basic_types",
+	"../../leanSpec/fixtures/consensus/ssz/lstar/ssz/test_decode_rejections",
+	"../../leanSpec/fixtures/consensus/ssz/lstar/ssz/test_merkleization_boundaries",
+	"../../leanSpec/fixtures/consensus/ssz/lstar/ssz/test_decode_failure_smoke",
 }
 
 type sszFixtureOuter map[string]sszFixture

--- a/internal/spectests/stf_test.go
+++ b/internal/spectests/stf_test.go
@@ -69,11 +69,12 @@ func runStateTransitionTest(t *testing.T, tt *StateTransitionTest) {
 
 	expectError := tt.ExpectException != "" || tt.Post == nil
 
-	// Empty blocks list with an expected exception means the spec filler
-	// raised the assertion internally (e.g., process_slots target == state.slot
-	// rejected before any block was constructed). The spec framework's verdict
-	// stands; nothing for us to replay.
-	if len(tt.Blocks) == 0 && tt.ExpectException != "" {
+	// Empty blocks list with an expected rejection means the spec filler raised
+	// the assertion internally (e.g., process_slots target == state.slot rejected
+	// before any block was constructed). The rejection may be signalled via
+	// expectException or via rejectionReason with no post state. The spec
+	// framework's verdict stands; nothing for us to replay.
+	if len(tt.Blocks) == 0 && expectError {
 		return
 	}
 

--- a/internal/spectests/sync_test.go
+++ b/internal/spectests/sync_test.go
@@ -23,13 +23,14 @@ type syncFixtureOuter map[string]syncFixture
 type syncFixture struct {
 	Network   string                 `json:"network"`
 	LeanEnv   string                 `json:"leanEnv"`
-	Operation string                 `json:"operation"`
-	Input     syncInput              `json:"input"`
+	Operation syncOperation          `json:"operation"`
 	Output    syncOutput             `json:"output"`
 	Info      map[string]interface{} `json:"_info"`
 }
 
-type syncInput struct {
+// operation carries the kind and its inputs inline (lstar fixture shape).
+type syncOperation struct {
+	Kind          string `json:"kind"`
 	NumValidators uint64 `json:"numValidators"`
 	AnchorSlot    uint64 `json:"anchorSlot"`
 }
@@ -94,8 +95,8 @@ func TestSpecSync(t *testing.T) {
 		for _, fx := range outer {
 			fx := fx
 			t.Run(base, func(t *testing.T) {
-				if fx.Operation != "verify_checkpoint" {
-					t.Skipf("unsupported sync operation %q", fx.Operation)
+				if fx.Operation.Kind != "verify_checkpoint" {
+					t.Skipf("unsupported sync operation %q", fx.Operation.Kind)
 				}
 
 				stateBytes, err := hex.DecodeString(strings.TrimPrefix(fx.Output.StateBytes, "0x"))

--- a/internal/spectests/verify_proofs_test.go
+++ b/internal/spectests/verify_proofs_test.go
@@ -1,0 +1,154 @@
+//go:build spectests
+
+package spectests
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geanlabs/gean/xmss"
+)
+
+type vpByteList struct {
+	Data string `json:"data"`
+}
+
+// Single-message (Type-1) proof fixtures.
+type verifyProofsSingleCase struct {
+	PublicKeys      []string   `json:"publicKeys"`
+	Message         string     `json:"message"`
+	Slot            uint32     `json:"slot"`
+	Proof           vpByteList `json:"proof"`
+	RejectionReason *string    `json:"rejectionReason"`
+}
+
+// Multi-message (Type-2) proof fixtures.
+type verifyProofsMultiCase struct {
+	PublicKeysPerMessage [][]string `json:"publicKeysPerMessage"`
+	Messages             []string   `json:"messages"`
+	Slots                []uint32   `json:"slots"`
+	Proof                vpByteList `json:"proof"`
+	RejectionReason      *string    `json:"rejectionReason"`
+}
+
+func parsePubkeyHandles(t *testing.T, hexKeys []string) []xmss.CPubKey {
+	t.Helper()
+	keys := make([]xmss.CPubKey, 0, len(hexKeys))
+	for _, h := range hexKeys {
+		pk, err := xmss.ParsePublicKey(parseHexPubkey(h))
+		if err != nil {
+			t.Fatalf("parse pubkey: %v", err)
+		}
+		keys = append(keys, pk)
+	}
+	return keys
+}
+
+func walkFixtures(t *testing.T, root string, run func(t *testing.T, raw []byte)) {
+	t.Helper()
+	if _, err := os.Stat(root); os.IsNotExist(err) {
+		t.Skipf("fixtures not present at %s; skipping", root)
+	}
+	var files []string
+	if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && filepath.Ext(path) == ".json" {
+			files = append(files, path)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+	if len(files) == 0 {
+		t.Skipf("no fixtures in %s; skipping", root)
+	}
+	for _, file := range files {
+		file := file
+		rel, _ := filepath.Rel(root, file)
+		t.Run(rel, func(t *testing.T) {
+			raw, err := os.ReadFile(file)
+			if err != nil {
+				t.Fatalf("reading %s: %v", file, err)
+			}
+			run(t, raw)
+		})
+	}
+}
+
+func TestSpecVerifySingleMessageProofs(t *testing.T) {
+	walkFixtures(t, "../../leanSpec/fixtures/consensus/verify_single_message_proofs", func(t *testing.T, raw []byte) {
+		var fixture map[string]verifyProofsSingleCase
+		if err := json.Unmarshal(raw, &fixture); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		for name, tc := range fixture {
+			tc := tc
+			t.Run(name, func(t *testing.T) {
+				keys := parsePubkeyHandles(t, tc.PublicKeys)
+				defer func() {
+					for _, k := range keys {
+						xmss.FreePublicKey(k)
+					}
+				}()
+				err := xmss.VerifyAggregatedSignature(parseHexBytes(tc.Proof.Data), keys, parseHexRoot(tc.Message), tc.Slot)
+				assertProofOutcome(t, err, tc.RejectionReason)
+			})
+		}
+	})
+}
+
+func TestSpecVerifyMultiMessageProofs(t *testing.T) {
+	walkFixtures(t, "../../leanSpec/fixtures/consensus/verify_multi_message_proofs", func(t *testing.T, raw []byte) {
+		var fixture map[string]verifyProofsMultiCase
+		if err := json.Unmarshal(raw, &fixture); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		for name, tc := range fixture {
+			tc := tc
+			t.Run(name, func(t *testing.T) {
+				// Component counts may intentionally disagree in rejection fixtures
+				// (e.g. a missing binding); let the verifier reject rather than guarding here.
+				groups := make([][]xmss.CPubKey, len(tc.PublicKeysPerMessage))
+				defer func() {
+					for _, g := range groups {
+						for _, k := range g {
+							xmss.FreePublicKey(k)
+						}
+					}
+				}()
+				for i := range tc.PublicKeysPerMessage {
+					groups[i] = parsePubkeyHandles(t, tc.PublicKeysPerMessage[i])
+				}
+				bindings := make([]xmss.MessageBinding, len(tc.Messages))
+				for i := range tc.Messages {
+					var msg [xmss.MessageLength]byte
+					copy(msg[:], parseHexBytes(tc.Messages[i]))
+					var slot uint32
+					if i < len(tc.Slots) {
+						slot = tc.Slots[i]
+					}
+					bindings[i] = xmss.MessageBinding{Message: msg, Slot: slot}
+				}
+				err := xmss.VerifyType2Proof(parseHexBytes(tc.Proof.Data), groups, bindings)
+				assertProofOutcome(t, err, tc.RejectionReason)
+			})
+		}
+	})
+}
+
+func assertProofOutcome(t *testing.T, err error, rejection *string) {
+	t.Helper()
+	if rejection != nil {
+		if err == nil {
+			t.Fatalf("expected rejection %q, got valid", *rejection)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("expected valid proof, got error: %v", err)
+	}
+}

--- a/internal/spectests/verify_proofs_test.go
+++ b/internal/spectests/verify_proofs_test.go
@@ -11,26 +11,22 @@ import (
 	"github.com/geanlabs/gean/xmss"
 )
 
-type vpByteList struct {
-	Data string `json:"data"`
-}
-
 // Single-message (Type-1) proof fixtures.
 type verifyProofsSingleCase struct {
-	PublicKeys      []string   `json:"publicKeys"`
-	Message         string     `json:"message"`
-	Slot            uint32     `json:"slot"`
-	Proof           vpByteList `json:"proof"`
-	RejectionReason *string    `json:"rejectionReason"`
+	PublicKeys      []string    `json:"publicKeys"`
+	Message         string      `json:"message"`
+	Slot            uint32      `json:"slot"`
+	Proof           fcProofData `json:"proof"`
+	RejectionReason *string     `json:"rejectionReason"`
 }
 
 // Multi-message (Type-2) proof fixtures.
 type verifyProofsMultiCase struct {
-	PublicKeysPerMessage [][]string `json:"publicKeysPerMessage"`
-	Messages             []string   `json:"messages"`
-	Slots                []uint32   `json:"slots"`
-	Proof                vpByteList `json:"proof"`
-	RejectionReason      *string    `json:"rejectionReason"`
+	PublicKeysPerMessage [][]string  `json:"publicKeysPerMessage"`
+	Messages             []string    `json:"messages"`
+	Slots                []uint32    `json:"slots"`
+	Proof                fcProofData `json:"proof"`
+	RejectionReason      *string     `json:"rejectionReason"`
 }
 
 func parsePubkeyHandles(t *testing.T, hexKeys []string) []xmss.CPubKey {

--- a/internal/statetransition/attestations.go
+++ b/internal/statetransition/attestations.go
@@ -41,6 +41,9 @@ func ProcessAttestations(state *types.State, attestations []*types.AggregatedAtt
 		if !IsValidVote(state, source, target) {
 			continue
 		}
+		if !headMatchesChain(state, agg.Data.Head) {
+			continue
+		}
 
 		votes, exists := justifications[target.Root]
 		if !exists {

--- a/internal/statetransition/attestations.go
+++ b/internal/statetransition/attestations.go
@@ -41,7 +41,7 @@ func ProcessAttestations(state *types.State, attestations []*types.AggregatedAtt
 		if !IsValidVote(state, source, target) {
 			continue
 		}
-		if !headMatchesChain(state, agg.Data.Head) {
+		if !HeadMatchesChain(state, agg.Data.Head) {
 			continue
 		}
 

--- a/internal/statetransition/attestations_test.go
+++ b/internal/statetransition/attestations_test.go
@@ -211,3 +211,58 @@ func TestSerializeJustificationsSortsAndCopiesRoots(t *testing.T) {
 		t.Fatal("serialized root alias mutated source root")
 	}
 }
+
+func TestProcessAttestationsRequiresHeadOnChain(t *testing.T) {
+	const numValidators = 4
+	var r0, r2 [types.RootSize]byte
+	r0[0] = 0xa0
+	r2[0] = 0xa2
+
+	mkState := func() *types.State {
+		hashes := make([][]byte, 3)
+		for i := range hashes {
+			hashes[i] = make([]byte, types.RootSize)
+		}
+		copy(hashes[0], r0[:])
+		copy(hashes[2], r2[:])
+		s := makeGenesisState(numValidators)
+		s.LatestJustified = &types.Checkpoint{Slot: 0, Root: r0}
+		s.LatestFinalized = &types.Checkpoint{Slot: 0, Root: r0}
+		s.HistoricalBlockHashes = hashes
+		s.JustifiedSlots = types.NewBitlistSSZ(0)
+		return s
+	}
+	mkAtt := func(head *types.Checkpoint) *types.AggregatedAttestation {
+		return &types.AggregatedAttestation{
+			AggregationBits: types.BitlistFromIndices([]uint64{0, 1, 2}),
+			Data: &types.AttestationData{
+				Slot:   2,
+				Head:   head,
+				Source: &types.Checkpoint{Slot: 0, Root: r0},
+				Target: &types.Checkpoint{Slot: 2, Root: r2},
+			},
+		}
+	}
+
+	t.Run("on_chain_head_justifies", func(t *testing.T) {
+		s := mkState()
+		if err := ProcessAttestations(s, []*types.AggregatedAttestation{mkAtt(&types.Checkpoint{Slot: 2, Root: r2})}); err != nil {
+			t.Fatalf("ProcessAttestations: %v", err)
+		}
+		if s.LatestJustified.Slot != 2 {
+			t.Fatalf("LatestJustified.Slot = %d, want 2", s.LatestJustified.Slot)
+		}
+	})
+
+	t.Run("off_chain_head_skipped", func(t *testing.T) {
+		var bogus [types.RootSize]byte
+		bogus[0] = 0xee
+		s := mkState()
+		if err := ProcessAttestations(s, []*types.AggregatedAttestation{mkAtt(&types.Checkpoint{Slot: 2, Root: bogus})}); err != nil {
+			t.Fatalf("ProcessAttestations: %v", err)
+		}
+		if s.LatestJustified.Slot != 0 {
+			t.Fatalf("LatestJustified.Slot = %d, want 0 (off-chain head must be skipped)", s.LatestJustified.Slot)
+		}
+	})
+}

--- a/internal/statetransition/votes.go
+++ b/internal/statetransition/votes.go
@@ -47,9 +47,10 @@ func IsValidVote(state *types.State, source, target *types.Checkpoint) bool {
 	return VoteInvalidReason(state, source, target) == ""
 }
 
-// headMatchesChain reports whether the attestation head sits on the canonical
-// chain at its slot. Mirrors the head clause of leanSpec attestation_data_matches_chain.
-func headMatchesChain(state *types.State, head *types.Checkpoint) bool {
+// HeadMatchesChain reports whether the attestation head sits on the canonical
+// chain at its slot. Mirrors the head clause of leanSpec attestation_data_matches_chain;
+// applied both in process_attestations and in block production.
+func HeadMatchesChain(state *types.State, head *types.Checkpoint) bool {
 	return head != nil && !types.IsZeroRoot(head.Root) && checkpointExists(state, head)
 }
 

--- a/internal/statetransition/votes.go
+++ b/internal/statetransition/votes.go
@@ -47,6 +47,12 @@ func IsValidVote(state *types.State, source, target *types.Checkpoint) bool {
 	return VoteInvalidReason(state, source, target) == ""
 }
 
+// headMatchesChain reports whether the attestation head sits on the canonical
+// chain at its slot. Mirrors the head clause of leanSpec attestation_data_matches_chain.
+func headMatchesChain(state *types.State, head *types.Checkpoint) bool {
+	return head != nil && !types.IsZeroRoot(head.Root) && checkpointExists(state, head)
+}
+
 func IsSlotJustified(state *types.State, finalizedSlot, slot uint64) bool {
 	if slot <= finalizedSlot {
 		return true

--- a/internal/statetransition/votes_test.go
+++ b/internal/statetransition/votes_test.go
@@ -152,8 +152,8 @@ func TestHeadMatchesChain(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := headMatchesChain(state, tc.head); got != tc.want {
-				t.Fatalf("headMatchesChain(%s) = %v, want %v", tc.name, got, tc.want)
+			if got := HeadMatchesChain(state, tc.head); got != tc.want {
+				t.Fatalf("HeadMatchesChain(%s) = %v, want %v", tc.name, got, tc.want)
 			}
 		})
 	}

--- a/internal/statetransition/votes_test.go
+++ b/internal/statetransition/votes_test.go
@@ -119,3 +119,42 @@ func TestVoteInvalidReason(t *testing.T) {
 		}
 	})
 }
+
+func TestHeadMatchesChain(t *testing.T) {
+	var onChain, offChain [types.RootSize]byte
+	onChain[0] = 0x11
+	offChain[0] = 0x22
+
+	hashes := make([][]byte, 3)
+	for i := range hashes {
+		hashes[i] = make([]byte, types.RootSize)
+	}
+	copy(hashes[2], onChain[:])
+
+	state := makeGenesisState(1)
+	state.HistoricalBlockHashes = hashes
+
+	cp := func(slot uint64, root [types.RootSize]byte) *types.Checkpoint {
+		return &types.Checkpoint{Slot: slot, Root: root}
+	}
+
+	cases := []struct {
+		name string
+		head *types.Checkpoint
+		want bool
+	}{
+		{"on_chain", cp(2, onChain), true},
+		{"zero_root", cp(2, [types.RootSize]byte{}), false},
+		{"off_chain", cp(2, offChain), false},
+		{"beyond_chain", cp(5, onChain), false},
+		{"nil", nil, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := headMatchesChain(state, tc.head); got != tc.want {
+				t.Fatalf("headMatchesChain(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -36,4 +36,6 @@ const (
 	ErrDuplicateAttestationData
 	ErrTooManyAttestationData
 	ErrJustifiedDivergenceNotClosed
+	ErrSourceNotAncestorOfTarget
+	ErrTargetNotAncestorOfHead
 )

--- a/xmss/ffi.go
+++ b/xmss/ffi.go
@@ -80,6 +80,9 @@ package xmss
 //     const uint8_t* proof, size_t proof_len,
 //     const PublicKey* const* pubkeys, const size_t* pubkey_counts,
 //     size_t count, const uint8_t* message_hashes, const uint32_t* message_slots);
+//
+// int32_t poseidon_permute_kb16(uint32_t* state, size_t len);
+// int32_t poseidon_permute_kb24(uint32_t* state, size_t len);
 import "C"
 
 import (
@@ -116,7 +119,29 @@ var (
 	ErrMalformedChildProof = errors.New("malformed child proof")
 	ErrMalformedRawInput   = errors.New("malformed raw signature input")
 	ErrSetupFailed         = errors.New("XMSS setup failed")
+	ErrPoseidonWidth       = errors.New("poseidon permutation width must be 16 or 24")
+	ErrPoseidonPermute     = errors.New("poseidon permutation failed")
 )
+
+// Poseidon2Permute applies the KoalaBear Poseidon permutation in place. The
+// state holds canonical field-element values; width must be 16 or 24.
+func Poseidon2Permute(state []uint32) error {
+	if len(state) != 16 && len(state) != 24 {
+		return ErrPoseidonWidth
+	}
+	ptr := (*C.uint32_t)(unsafe.Pointer(&state[0]))
+	n := C.size_t(len(state))
+	var status C.int32_t
+	if len(state) == 16 {
+		status = C.poseidon_permute_kb16(ptr, n)
+	} else {
+		status = C.poseidon_permute_kb24(ptr, n)
+	}
+	if status != 0 {
+		return ErrPoseidonPermute
+	}
+	return nil
+}
 
 var (
 	proverOnce   sync.Once

--- a/xmss/rust/multisig-glue/src/lib.rs
+++ b/xmss/rust/multisig-glue/src/lib.rs
@@ -1,3 +1,7 @@
+use backend::symmetric::Permutation;
+use backend::{
+    default_koalabear_poseidon1_16, default_koalabear_poseidon1_24, KoalaBear, PrimeField32,
+};
 use leansig_wrapper::{XmssPublicKey, XmssSignature};
 use rec_aggregation::{
     aggregate_type_1, init_aggregation_bytecode, merge_many_type_1, split_type_2_by_msg,
@@ -362,5 +366,45 @@ pub unsafe extern "C" fn xmss_verify_type_2(
             }
         }
         verify_type_2(&proof).is_ok()
+    })
+}
+
+// Poseidon permutation over KoalaBear, exposed for spec test vectors. The state
+// is the canonical u32 field representation, permuted in place. This is the same
+// instance the XMSS stack hashes with, so it matches the spec. Returns -1 on a
+// null pointer or wrong width.
+#[no_mangle]
+pub unsafe extern "C" fn poseidon_permute_kb16(state: *mut u32, len: usize) -> i32 {
+    ffi_guard!(-1, {
+        if state.is_null() || len != 16 {
+            return -1;
+        }
+        let raw = slice::from_raw_parts_mut(state, 16);
+        let mut input = [0u32; 16];
+        input.copy_from_slice(raw);
+        let mut fe = KoalaBear::new_array(input);
+        default_koalabear_poseidon1_16().permute_mut(&mut fe);
+        for (dst, x) in raw.iter_mut().zip(fe.iter()) {
+            *dst = x.as_canonical_u32();
+        }
+        0
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn poseidon_permute_kb24(state: *mut u32, len: usize) -> i32 {
+    ffi_guard!(-1, {
+        if state.is_null() || len != 24 {
+            return -1;
+        }
+        let raw = slice::from_raw_parts_mut(state, 24);
+        let mut input = [0u32; 24];
+        input.copy_from_slice(raw);
+        let mut fe = KoalaBear::new_array(input);
+        default_koalabear_poseidon1_24().permute_mut(&mut fe);
+        for (dst, x) in raw.iter_mut().zip(fe.iter()) {
+            *dst = x.as_canonical_u32();
+        }
+        0
     })
 }


### PR DESCRIPTION
Lands the cleanly-scoped, validated items from the cd6981a spec-compliance pass. The large remaining gap (fc spectest suite, 20 fixtures) is tracked in #345.

## fix(attestation): get_attestation_target lower bound
`get_attestation_target` walked back only to the safe-target slot and carried a non-spec `latest_justified` fallback. leanSpec uses `max(safe_target_slot, finalized_slot)` as the lower bound (the walk never crosses the finalized boundary) and returns the selected block directly. `internal/attestation/target.go` + test for the stale-safe-target case.

## test(spectests): STF slot-monotonicity
`test_process_slots_target_equal_to_state_slot_rejected` rejects during fixture generation, emitting empty blocks with the rejection signalled via `rejectionReason` (post=null), not `expectException`. Broadened the runner's empty-blocks skip to any expected rejection. gean's `ProcessSlots` already rejects same-slot targets (unit-tested); nothing to replay. `internal/spectests/stf_test.go`. TestSpecStateTransition now fully passes.

## Validation
go vet ./...
cd xmss/rust && cargo fmt --check
cd xmss/rust && cargo clippy -- -D warnings -A clippy::missing_safety_doc, attestation + node unit tests, and TestSpecStateTransition all pass.

## Deferred to #345 (dedicated)
- fc spectest suite (20 fixtures) gated on the raw gossip-attestation signature-verify root cause + cascade.
- ssz (basic/parameterized type codecs) and api (post_genesis/metrics runners) spectest coverage — low value / need new runners.
- External: XMSS #887 (upstream crate), leanSpec cd6981a fixture-gen failure.

## Stacking
Off `fix/attestation-ancestry-aggpool-spectests` (#344) → #343 (#337) → #342 (#341 + bump). Against devnet-5 this PR lists those commits until they merge.

Closes #337
Closes #338
Closes #339
Closes #340
