### PR TITLE
chore(devnet5): bump leanVM to e2592df + Rust 1.92

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   GO_VERSION: "1.25.11"
-  RUST_VERSION: "1.90"
+  RUST_VERSION: "1.92"
 
 jobs:
   build-and-test:

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   GO_VERSION: "1.25.11"
-  RUST_VERSION: "1.90"
+  RUST_VERSION: "1.92"
 
 jobs:
   go-lint:
@@ -68,11 +68,11 @@ jobs:
       - name: Check Rust formatting
         working-directory: xmss/rust
         run: |
-          rustup component add --toolchain 1.90.0-x86_64-unknown-linux-gnu rustfmt
+          rustup component add --toolchain 1.92.0-x86_64-unknown-linux-gnu rustfmt
           cargo fmt --check
 
       - name: Run Clippy
         working-directory: xmss/rust
         run: |
-          rustup component add --toolchain 1.90.0-x86_64-unknown-linux-gnu clippy
+          rustup component add --toolchain 1.92.0-x86_64-unknown-linux-gnu clippy
           cargo clippy -- -D warnings -A clippy::missing_safety_doc

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   GO_VERSION: "1.25.11"
-  RUST_VERSION: "1.90"
+  RUST_VERSION: "1.92"
 
 jobs:
   go-audit:

--- a/.github/workflows/spec-tests.yml
+++ b/.github/workflows/spec-tests.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   GO_VERSION: "1.25.11"
-  RUST_VERSION: "1.90"
+  RUST_VERSION: "1.92"
 
 jobs:
   spec-tests:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Build & test
 
-The build has a hard ordering: **Rust FFI must be built before any Go code that touches `xmss`**. `make build` does this for you (`ffi` is a prerequisite). The toolchain is pinned — Rust 1.90.0, Go 1.25.
+The build has a hard ordering: **Rust FFI must be built before any Go code that touches `xmss`**. `make build` does this for you (`ffi` is a prerequisite). The toolchain is pinned — Rust 1.92.0, Go 1.25.
 
 ```
 make build        # builds Rust FFI glue, then bin/gean and bin/keygen

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Build stage: Rust FFI + Go binary
 FROM golang:1.25-bookworm AS builder
 
-# Install Rust 1.90.0 (pinned for leansig/leanMultisig compatibility)
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.90.0
+# Install Rust 1.92.0 (pinned for leansig/leanMultisig compatibility)
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.92.0
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Install build dependencies

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Gean is:
 ### Prerequisites
 
 - [Go](https://go.dev/doc/install) 1.25+
-- [Rust](https://www.rust-lang.org/tools/install) 1.90.0
+- [Rust](https://www.rust-lang.org/tools/install) 1.92.0
 - [uv](https://docs.astral.sh/uv/)
 - [Docker](https://www.docker.com/get-started/)
 

--- a/xmss/rust/Cargo.lock
+++ b/xmss/rust/Cargo.lock
@@ -59,6 +59,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,7 +338,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 [[package]]
 name = "backend"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
@@ -299,8 +349,9 @@ dependencies = [
  "mt-symetric",
  "mt-utils",
  "mt-whir",
- "rayon",
+ "parallel",
  "tracing",
+ "zk-alloc",
 ]
 
 [[package]]
@@ -448,6 +499,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,6 +546,12 @@ checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "const-hex"
@@ -1111,6 +1208,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,9 +1310,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lean-multisig"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
+dependencies = [
+ "backend",
+ "clap",
+ "lean_vm",
+ "leansig_wrapper",
+ "libc",
+ "rand 0.10.1",
+ "rec_aggregation",
+ "serde_json",
+ "sub_protocols",
+ "system-info",
+ "utils",
+ "zk-alloc",
+]
+
+[[package]]
 name = "lean_compiler"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "backend",
  "include_dir",
@@ -1225,7 +1347,7 @@ dependencies = [
 [[package]]
 name = "lean_prover"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -1243,7 +1365,7 @@ dependencies = [
 [[package]]
 name = "lean_vm"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -1299,7 +1421,7 @@ dependencies = [
 [[package]]
 name = "leansig_wrapper"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "backend",
  "ethereum_ssz",
@@ -1375,7 +1497,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 [[package]]
 name = "mt-air"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "mt-field",
  "mt-poly",
@@ -1384,13 +1506,13 @@ dependencies = [
 [[package]]
 name = "mt-fiat-shamir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
  "mt-symetric",
  "mt-utils",
- "rayon",
+ "parallel",
  "serde",
  "tracing",
 ]
@@ -1398,14 +1520,14 @@ dependencies = [
 [[package]]
 name = "mt-field"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "itertools 0.14.0",
  "mt-utils",
  "num-bigint",
+ "parallel",
  "paste",
  "rand 0.10.1",
- "rayon",
  "serde",
  "tracing",
 ]
@@ -1413,7 +1535,7 @@ dependencies = [
 [[package]]
 name = "mt-koala-bear"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
@@ -1421,7 +1543,6 @@ dependencies = [
  "num-bigint",
  "paste",
  "rand 0.10.1",
- "rayon",
  "serde",
  "tracing",
 ]
@@ -1429,44 +1550,47 @@ dependencies = [
 [[package]]
 name = "mt-poly"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
  "mt-utils",
+ "parallel",
  "rand 0.10.1",
- "rayon",
  "serde",
  "system-info",
+ "zk-alloc",
 ]
 
 [[package]]
 name = "mt-sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
  "mt-field",
  "mt-poly",
- "rayon",
+ "parallel",
  "tracing",
+ "zk-alloc",
 ]
 
 [[package]]
 name = "mt-symetric"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
- "rayon",
+ "parallel",
+ "zk-alloc",
 ]
 
 [[package]]
 name = "mt-utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "serde",
 ]
@@ -1474,7 +1598,7 @@ dependencies = [
 [[package]]
 name = "mt-whir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "itertools 0.14.0",
  "mt-fiat-shamir",
@@ -1484,18 +1608,18 @@ dependencies = [
  "mt-sumcheck",
  "mt-symetric",
  "mt-utils",
+ "parallel",
  "rand 0.10.1",
- "rayon",
  "system-info",
  "tracing",
+ "zk-alloc",
 ]
 
 [[package]]
 name = "multisig-glue"
 version = "0.1.0"
 dependencies = [
- "backend",
- "leansig_wrapper",
+ "lean-multisig",
  "rec_aggregation",
 ]
 
@@ -1569,6 +1693,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1577,7 +1707,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "p3-baby-bear"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#5739e64a36ed4743823b10f50c7e3a49d3c39a82"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 dependencies = [
  "p3-challenger",
  "p3-field",
@@ -1592,7 +1722,7 @@ dependencies = [
 [[package]]
 name = "p3-challenger"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#5739e64a36ed4743823b10f50c7e3a49d3c39a82"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -1605,21 +1735,21 @@ dependencies = [
 [[package]]
 name = "p3-dft"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#5739e64a36ed4743823b10f50c7e3a49d3c39a82"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
  "p3-matrix",
  "p3-maybe-rayon",
  "p3-util",
- "spin 0.11.0",
+ "spin 0.10.0",
  "tracing",
 ]
 
 [[package]]
 name = "p3-field"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#5739e64a36ed4743823b10f50c7e3a49d3c39a82"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
@@ -1634,7 +1764,7 @@ dependencies = [
 [[package]]
 name = "p3-koala-bear"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#5739e64a36ed4743823b10f50c7e3a49d3c39a82"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 dependencies = [
  "p3-challenger",
  "p3-field",
@@ -1649,7 +1779,7 @@ dependencies = [
 [[package]]
 name = "p3-matrix"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#5739e64a36ed4743823b10f50c7e3a49d3c39a82"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -1663,12 +1793,12 @@ dependencies = [
 [[package]]
 name = "p3-maybe-rayon"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#5739e64a36ed4743823b10f50c7e3a49d3c39a82"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 
 [[package]]
 name = "p3-mds"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#5739e64a36ed4743823b10f50c7e3a49d3c39a82"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 dependencies = [
  "p3-dft",
  "p3-field",
@@ -1680,7 +1810,7 @@ dependencies = [
 [[package]]
 name = "p3-monty-31"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#5739e64a36ed4743823b10f50c7e3a49d3c39a82"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
@@ -1696,17 +1826,16 @@ dependencies = [
  "paste",
  "rand 0.10.1",
  "serde",
- "spin 0.11.0",
+ "spin 0.10.0",
  "tracing",
 ]
 
 [[package]]
 name = "p3-poseidon1"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#5739e64a36ed4743823b10f50c7e3a49d3c39a82"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 dependencies = [
  "p3-field",
- "p3-mds",
  "p3-symmetric",
  "rand 0.10.1",
 ]
@@ -1714,7 +1843,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#5739e64a36ed4743823b10f50c7e3a49d3c39a82"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -1726,7 +1855,7 @@ dependencies = [
 [[package]]
 name = "p3-symmetric"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#5739e64a36ed4743823b10f50c7e3a49d3c39a82"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -1737,10 +1866,18 @@ dependencies = [
 [[package]]
 name = "p3-util"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#5739e64a36ed4743823b10f50c7e3a49d3c39a82"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 dependencies = [
  "serde",
  "transpose",
+]
+
+[[package]]
+name = "parallel"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
+dependencies = [
+ "system-info",
 ]
 
 [[package]]
@@ -2081,7 +2218,7 @@ dependencies = [
 [[package]]
 name = "rec_aggregation"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "backend",
  "include_dir",
@@ -2446,9 +2583,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.11.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783f3f6f6b01e295a669edfc402133a5f2553d1f0e81284b3ba4594e80bdd4a2"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 dependencies = [
  "lock_api",
 ]
@@ -2482,9 +2619,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "sub_protocols"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "backend",
  "lean_vm",
@@ -2523,10 +2666,9 @@ dependencies = [
 [[package]]
 name = "system-info"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "libc",
- "rayon",
 ]
 
 [[package]]
@@ -2746,9 +2888,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "backend",
  "tracing",
@@ -3027,9 +3175,10 @@ dependencies = [
 [[package]]
 name = "zk-alloc"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "libc",
+ "parallel",
  "system-info",
 ]
 

--- a/xmss/rust/multisig-glue/Cargo.toml
+++ b/xmss/rust/multisig-glue/Cargo.toml
@@ -4,10 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-# Matches leanSpec fd7dfd0 through lean-multisig-py v0.0.6.
-rec_aggregation = { git = "https://github.com/leanEthereum/leanVM.git", rev = "8fcbd77958a58666e828315de2d6ce7c93297117" }
-leansig_wrapper = { git = "https://github.com/leanEthereum/leanVM.git", rev = "8fcbd77958a58666e828315de2d6ce7c93297117" }
-backend = { git = "https://github.com/leanEthereum/leanVM.git", rev = "8fcbd77958a58666e828315de2d6ce7c93297117" }
+# leanVM devnet5 HEAD. The root crate re-exports the aggregation API,
+# Xmss key/signature types, and setup_prover/setup_verifier (which now own
+# the internal arena allocator; no global_allocator override). Proofs stay
+# verify-compatible with the leanSpec fixture rev (8fcbd779), so this is a
+# non-snark-breaking bump.
+lean-multisig = { git = "https://github.com/leanEthereum/leanVM.git", rev = "e2592df4e30fdddbbf8ae26a333116c68cec7026" }
+# split-by-message is not re-exported by the root crate; pull it from the
+# aggregation crate directly (same git rev, identical re-exported types).
+rec_aggregation = { git = "https://github.com/leanEthereum/leanVM.git", rev = "e2592df4e30fdddbbf8ae26a333116c68cec7026" }
 
 [lib]
 # Built as an rlib so its `#[no_mangle] pub extern "C"` symbols can be

--- a/xmss/rust/multisig-glue/src/lib.rs
+++ b/xmss/rust/multisig-glue/src/lib.rs
@@ -1,8 +1,9 @@
-use leansig_wrapper::{XmssPublicKey, XmssSignature};
-use rec_aggregation::{
-    aggregate_type_1, init_aggregation_bytecode, merge_many_type_1, split_type_2_by_msg,
-    verify_type_1, verify_type_2, TypeOneMultiSignature, TypeTwoMultiSignature,
+use lean_multisig::{
+    aggregate_single_message_signatures, merge_single_message_aggregates, setup_prover,
+    setup_verifier, verify_multi_message_aggregate, verify_single_message_aggregate,
+    MultiMessageAggregateSignature, SingleMessageAggregateSignature, XmssPublicKey, XmssSignature,
 };
+use rec_aggregation::split_multi_message_aggregate_by_message;
 use std::panic::AssertUnwindSafe;
 use std::slice;
 use std::sync::OnceLock;
@@ -28,15 +29,14 @@ macro_rules! ffi_guard {
     };
 }
 
+// setup_prover enables a process-wide arena allocator and warms the prover.
+// Its single shared region means two proofs must never be generated
+// concurrently; the Go-side proving.Gate serializes all aggregate/merge/split
+// work to one at a time, so that invariant holds. Verification does not use the
+// arena and stays safe to run concurrently.
 #[no_mangle]
 pub extern "C" fn xmss_setup_prover() -> i32 {
-    let ready = PROVER_READY.get_or_init(|| {
-        std::panic::catch_unwind(|| {
-            init_aggregation_bytecode();
-            backend::precompute_dft_twiddles::<backend::KoalaBear>(1 << 24);
-        })
-        .is_ok()
-    });
+    let ready = PROVER_READY.get_or_init(|| std::panic::catch_unwind(setup_prover).is_ok());
     if *ready {
         0
     } else {
@@ -46,8 +46,7 @@ pub extern "C" fn xmss_setup_prover() -> i32 {
 
 #[no_mangle]
 pub extern "C" fn xmss_setup_verifier() -> i32 {
-    let ready =
-        VERIFIER_READY.get_or_init(|| std::panic::catch_unwind(init_aggregation_bytecode).is_ok());
+    let ready = VERIFIER_READY.get_or_init(|| std::panic::catch_unwind(setup_verifier).is_ok());
     if *ready {
         0
     } else {
@@ -173,7 +172,7 @@ pub unsafe extern "C" fn xmss_aggregate_type_1(
                     return -1;
                 }
                 let proof = slice::from_raw_parts(proofs[i], lengths[i]);
-                match TypeOneMultiSignature::decompress_without_pubkeys(proof, keys) {
+                match SingleMessageAggregateSignature::decompress_without_pubkeys(proof, keys) {
                     Some(proof) => children.push(proof),
                     None => return -1,
                 }
@@ -181,7 +180,7 @@ pub unsafe extern "C" fn xmss_aggregate_type_1(
         }
 
         let proof = match std::panic::catch_unwind(AssertUnwindSafe(|| {
-            aggregate_type_1(&children, raw, message, slot, log_inv_rate)
+            aggregate_single_message_signatures(&children, raw, message, slot, log_inv_rate)
         })) {
             Ok(Ok(proof)) => proof,
             _ => return -1,
@@ -212,7 +211,7 @@ pub unsafe extern "C" fn xmss_verify_type_1(
             Some(keys) => keys,
             None => return false,
         };
-        let proof = match TypeOneMultiSignature::decompress_without_pubkeys(
+        let proof = match SingleMessageAggregateSignature::decompress_without_pubkeys(
             slice::from_raw_parts(proof, proof_len),
             keys,
         ) {
@@ -223,7 +222,7 @@ pub unsafe extern "C" fn xmss_verify_type_1(
         {
             return false;
         }
-        verify_type_1(&proof).is_ok()
+        verify_single_message_aggregate(&proof).is_ok()
     })
 }
 
@@ -260,7 +259,7 @@ pub unsafe extern "C" fn xmss_merge_type_1_to_type_2(
             if proof_ptrs[i].is_null() || proof_lens[i] == 0 {
                 return -1;
             }
-            match TypeOneMultiSignature::decompress_without_pubkeys(
+            match SingleMessageAggregateSignature::decompress_without_pubkeys(
                 slice::from_raw_parts(proof_ptrs[i], proof_lens[i]),
                 groups[i].clone(),
             ) {
@@ -269,7 +268,7 @@ pub unsafe extern "C" fn xmss_merge_type_1_to_type_2(
             }
         }
         let proof = match std::panic::catch_unwind(AssertUnwindSafe(|| {
-            merge_many_type_1(proofs, log_inv_rate)
+            merge_single_message_aggregates(proofs, log_inv_rate)
         })) {
             Ok(Ok(proof)) => proof,
             _ => return -1,
@@ -299,7 +298,7 @@ pub unsafe extern "C" fn xmss_split_type_2_by_message(
             Some(groups) => groups,
             None => return -1,
         };
-        let proof = match TypeTwoMultiSignature::decompress_without_pubkeys(
+        let proof = match MultiMessageAggregateSignature::decompress_without_pubkeys(
             slice::from_raw_parts(proof, proof_len),
             groups,
         ) {
@@ -312,7 +311,7 @@ pub unsafe extern "C" fn xmss_split_type_2_by_message(
                 Err(_) => return -1,
             };
         let proof = match std::panic::catch_unwind(AssertUnwindSafe(|| {
-            split_type_2_by_msg(proof, target, log_inv_rate)
+            split_multi_message_aggregate_by_message(proof, target, log_inv_rate)
         })) {
             Ok(Ok(proof)) => proof,
             _ => return -1,
@@ -340,7 +339,7 @@ pub unsafe extern "C" fn xmss_verify_type_2(
             Some(groups) => groups,
             None => return false,
         };
-        let proof = match TypeTwoMultiSignature::decompress_without_pubkeys(
+        let proof = match MultiMessageAggregateSignature::decompress_without_pubkeys(
             slice::from_raw_parts(proof, proof_len),
             groups,
         ) {
@@ -361,6 +360,6 @@ pub unsafe extern "C" fn xmss_verify_type_2(
                 return false;
             }
         }
-        verify_type_2(&proof).is_ok()
+        verify_multi_message_aggregate(&proof).is_ok()
     })
 }

--- a/xmss/rust/rust-toolchain.toml
+++ b/xmss/rust/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.92.0"


### PR DESCRIPTION
## Summary

Bumps the leanVM dependency to the devnet5 branch HEAD **`e2592df`** (was `8fcbd779`) and the Rust toolchain to **1.92.0** (was 1.90.0). Closes #347.

`e2592df` supersedes the `3f2116d` named in #347 by two non-breaking commits — it is the current devnet5 branch HEAD and the rev the interop peer ethlambda tracks. Per Emile's note this is **not a snark breaking-change**: proofs stay verify-compatible with the leanSpec fixture rev (`8fcbd779`), so the prover/verifier still interops across clients.

## What changed

**Renamed aggregation API** (`xmss/rust/multisig-glue/src/lib.rs`) — the C ABI symbol names (`xmss_aggregate_type_1`, etc.) are unchanged, so the Go side is untouched; only the inner Rust calls move:

| old | new |
|---|---|
| `TypeOneMultiSignature` | `SingleMessageAggregateSignature` |
| `TypeTwoMultiSignature` | `MultiMessageAggregateSignature` |
| `aggregate_type_1` | `aggregate_single_message_signatures` |
| `merge_many_type_1` | `merge_single_message_aggregates` |
| `split_type_2_by_msg` | `split_multi_message_aggregate_by_message` |
| `verify_type_1` / `verify_type_2` | `verify_single_message_aggregate` / `verify_multi_message_aggregate` |

**Prover setup / arena allocator** — `setup_prover`/`setup_verifier` replace the hand-rolled `init_aggregation_bytecode` + `backend::precompute_dft_twiddles`. `setup_prover` now enables a process-wide arena allocator (no more `global_allocator` override — the "easier to integrate" change). Its single shared region means **two proofs must never be generated concurrently**; gean's existing process-global `proving.Gate` already guarantees this by serializing all aggregate/merge/split work. Verification does not use the arena and stays safe to run concurrently.

**Dependencies: 3 → 2** — `lean-multisig` re-exports everything except split-by-message, which comes from `rec_aggregation` at the same rev. `leansig_wrapper` and `backend` are no longer direct deps.

**Build requirements**
- Rust `1.90.0 → 1.92.0`: `rust-toolchain.toml`, the 4 CI workflows, `Dockerfile`, `README.md`, `CLAUDE.md`.
- Plonky3 pinned to `3f67d136` (the rev leanVM `e2592df` locks against). Floating Plonky3 HEAD uses the unstable `maybe_uninit_slice` feature and will not build on stable.

## Verification

- ✅ `make ffi` — compiles (Rust 1.92 + leanVM `e2592df` + Plonky3 `3f67d136`)
- ✅ `make test-ffi` — aggregate / merge / split-by-message / verify round-trips + sequential-arena proving pass
- ✅ `make lint` — `go vet`, `cargo fmt --check`, `cargo clippy -D warnings` clean
- ⏳ `make test-spec` — not yet run to completion in this session; should be confirmed green before merge to validate that `8fcbd779`-generated fixtures still verify under the `e2592df` verifier (fork_choice remains red upstream, see #345)

## Reviewer notes

- The `.github/workflows/*` edits require the `workflow` token scope; this branch was pushed over SSH.
- `proving.Gate` (`internal/proving/gate.go`) is the load-bearing safety invariant for the new arena allocator — it must keep serializing all three proving workers.