### PR TITLE
chore(devnet5): bump leanSpec pin to 8e28a19 + fix gean-side fork_choice spectest failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ NUM_NODES ?= 3
 # Pinned leanSpec revision for spec fixtures. Must be defined before the test-spec/test-all
 # rules that reference it: Make expands a rule's prerequisites when it reads the rule, so a
 # definition placed after those rules would expand to empty in their prerequisites.
-LEAN_SPEC_COMMIT_HASH := cd6981a25c3e11e2a50556590025f097c266a27d
+LEAN_SPEC_COMMIT_HASH := 8e28a1992c1c27a2b5774cf4e7d65d921a67ac3d
 
 help: ## Show help for each Makefile recipe
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/internal/spectests/forkchoice_test.go
+++ b/internal/spectests/forkchoice_test.go
@@ -94,6 +94,10 @@ type fcStep struct {
 	Checks      *fcChecks            `json:"checks,omitempty"`
 	Time        *uint64              `json:"time,omitempty"`
 	Interval    *uint64              `json:"interval,omitempty"`
+	// TickToSlot reports whether the store clock advances to the block's slot
+	// before import. Absent means the default (advance); false delivers the
+	// block ahead of the store clock.
+	TickToSlot *bool `json:"tickToSlot,omitempty"`
 }
 
 // fcGossipAttestation represents an individual gossip attestation step.
@@ -417,11 +421,15 @@ func runForkChoiceTest(t *testing.T, tt *fcTest) {
 				Proof: &types.MultiMessageAggregate{},
 			}
 
-			// Advance store time to at least this block's slot so that
-			// subsequent attestation validation doesn't reject as "too far in future".
-			minTime := block.Slot * types.IntervalsPerSlot
-			if s.Time() < minTime {
-				s.SetTime(minTime)
+			// Advance the store clock to this block's slot unless the fixture
+			// delivers the block ahead of the clock (tickToSlot=false). The clock
+			// gates attestation future-validation, so it must reach the slot
+			// before subsequent attestations validate.
+			if step.TickToSlot == nil || *step.TickToSlot {
+				minTime := block.Slot * types.IntervalsPerSlot
+				if s.Time() < minTime {
+					s.SetTime(minTime)
+				}
 			}
 
 			// Process block through store (no signature verification).
@@ -440,6 +448,27 @@ func runForkChoiceTest(t *testing.T, tt *fcTest) {
 
 			// Register block in fork choice.
 			fc.OnBlock(block.Slot, blockRoot, block.ParentRoot)
+
+			// Seed the block's on-chain aggregated attestations into the known
+			// pool with their participant sets so the votes carry fork-choice
+			// weight. The spec test framework merges a block's aggregated proofs
+			// into latest_known_aggregated_payloads when building it; block
+			// import alone (data, empty proof set) leaves them weightless, which
+			// would mis-resolve weight-driven reorgs. Only participants are read
+			// during head computation, so a non-empty placeholder proof suffices.
+			for _, att := range block.Body.Attestations {
+				if att == nil || att.Data == nil || types.BitlistCount(att.AggregationBits) == 0 {
+					continue
+				}
+				dataRoot, err := att.Data.HashTreeRoot()
+				if err != nil {
+					continue
+				}
+				s.KnownPayloads.Push(dataRoot, att.Data, &types.SingleMessageAggregate{
+					Participants: att.AggregationBits,
+					Proof:        []byte{0x01},
+				})
+			}
 
 			// Update head: extract known attestations, feed to fork choice, compute head.
 			attestations := s.ExtractLatestKnownAttestations()


### PR DESCRIPTION
Bumps the leanSpec pin to `8e28a19` and fixes the gean-side fork_choice spec-test failures it surfaced. Closes #349.

## Commits

1. **`chore(devnet5): bump leanSpec pin to 8e28a19`** — picks up leanSpec #892 (`fix(fork-choice): merge aggregate pools in deterministic order`), which fixes the fixture generator: at `cd6981a` `pytest fill` crashed in the equivocation/head-determinism path. At `8e28a19` all 525 fixtures generate cleanly and 11/12 spectest categories pass. The other 5 commits in `cd6981a..8e28a19` are test/refactor only; the `lean-multisig-py` pin is unchanged (fixture prover/verifier stays leanVM `8fcbd779`).
2. **`test(spectests): give block on-chain votes weight + honor tickToSlot`** — fixes 13 fork_choice harness failures (test-only).

## fork_choice results

Before: 67/86 passing. After: **80/86 passing, zero regressions.**

The 13 fixed failures were **harness-fidelity gaps**, not production fork-choice bugs:

- **Block on-chain votes carried zero weight.** The harness imported block attestations as data-only (empty proof set). The spec's test framework merges a block's aggregated proofs into `latest_known_aggregated_payloads` when building it, so those votes carry weight. Weight-driven reorg/head fixtures (`test_simple_one_block_reorg`, `test_head_switches_to_heavier_fork`, the `test_fork_choice_reorgs/*` set) therefore resolved to the wrong head. Verified concretely against the fixture `storeSnapshot` (`blockWeights`, `participantSets`). The harness now seeds each block attestation's participant set into the known pool (only participants are read during head computation, so a placeholder proof byte suffices).
- **`tickToSlot` was ignored.** The block step always advanced the store clock to the block's slot; `test_block_ahead_of_store_clock_is_imported` delivers a block ahead of the clock (`tickToSlot=false`) and checks the clock stayed put. The harness now honors the flag.

## Remaining 6 fork_choice failures — upstream, tracked in #345

`test_equivocation/test_equivocating_proposer_with_split_attestations`, `test_gossip_attestation_validation/*` (4), and `test_store_pruning/test_finalization_prunes_stale_attestation_signatures` fail with `signature verification failed`. gean's verifier is byte-identical crypto to the fixture prover (both leanVM `8fcbd779`), yet rejects these → the fixture signatures are genuinely invalid (XMSS one-time-leaf reuse in the test key-manager), labeled `valid`. gean is correct to reject; the fixtures are wrong. Not in scope here.

## Scope / verification

- Production fork choice (`internal/forkchoice/`, `internal/node/head.go`) is **unchanged**; the second commit touches only `internal/spectests/forkchoice_test.go` (build-tagged test code).
- `go vet -tags=spectests ./internal/spectests/` and `gofmt` clean.
- Per the leanSpec pin bump, fixtures were regenerated (`make test-spec`); only the fork_choice category was re-run for the harness fix (the other 11 categories were already green after the pin bump).

Closes #349. Relates to #345.