### PR TITLE
fix(statetransition): reject empty and out-of-range aggregation bits in ProcessAttestations

### DIFF
--- a/internal/blockbuilder/build_test.go
+++ b/internal/blockbuilder/build_test.go
@@ -546,7 +546,7 @@ func TestPlanAttestationsDoesNotReportSkippedPayloadsWhenFull(t *testing.T) {
 		payloads = append(payloads, AttestationPayload{
 			DataRoot: hashAttestationData(t, data),
 			Data:     data,
-			Proofs:   []*types.SingleMessageAggregate{mockProof([]uint64{1})},
+			Proofs:   []*types.SingleMessageAggregate{mockProof([]uint64{0})},
 		})
 	}
 	unknownHead := &types.AttestationData{
@@ -558,7 +558,7 @@ func TestPlanAttestationsDoesNotReportSkippedPayloadsWhenFull(t *testing.T) {
 	payloads = append(payloads, AttestationPayload{
 		DataRoot: hashAttestationData(t, unknownHead),
 		Data:     unknownHead,
-		Proofs:   []*types.SingleMessageAggregate{mockProof([]uint64{1})},
+		Proofs:   []*types.SingleMessageAggregate{mockProof([]uint64{0})},
 	})
 
 	plan, err := planAttestations(Input{

--- a/internal/statetransition/attestations.go
+++ b/internal/statetransition/attestations.go
@@ -45,21 +45,29 @@ func ProcessAttestations(state *types.State, attestations []*types.AggregatedAtt
 			continue
 		}
 
+		// An attestation that reaches the tally must name at least one
+		// in-range voter; empty bits or a set bit outside the registry
+		// reject the whole block. Unset padding past the registry is
+		// harmless. This guards the unsigned path, which has no signature
+		// stage to reject such bits first.
+		voterIndices := types.BitlistIndices(agg.AggregationBits)
+		if len(voterIndices) == 0 {
+			return ErrEmptyAggregationBits
+		}
+		for _, voter := range voterIndices {
+			if voter >= uint64(validatorCount) {
+				return &AttesterIndexOutOfRangeError{Index: voter, Validators: uint64(validatorCount)}
+			}
+		}
+
 		votes, exists := justifications[target.Root]
 		if !exists {
 			votes = make([]bool, validatorCount)
 			justifications[target.Root] = votes
 		}
 
-		bitsLen := types.BitlistLen(agg.AggregationBits)
-		if bitsLen > uint64(validatorCount) {
-			continue
-		}
-
-		for i := range bitsLen {
-			if types.BitlistGet(agg.AggregationBits, i) {
-				votes[i] = true
-			}
+		for _, voter := range voterIndices {
+			votes[voter] = true
 		}
 
 		voteCount := countTrue(votes)

--- a/internal/statetransition/attestations_test.go
+++ b/internal/statetransition/attestations_test.go
@@ -266,3 +266,74 @@ func TestProcessAttestationsRequiresHeadOnChain(t *testing.T) {
 		}
 	})
 }
+
+func bitsBoundsHarness() (*types.State, func(bits []byte) *types.AggregatedAttestation) {
+	var r3, r4 [types.RootSize]byte
+	r3[0] = 3
+	r4[0] = 4
+	hashes := make([][]byte, 10)
+	for i := range hashes {
+		hashes[i] = make([]byte, types.RootSize)
+	}
+	copy(hashes[3], r3[:])
+	copy(hashes[4], r4[:])
+
+	state := makeGenesisState(4)
+	state.LatestJustified = &types.Checkpoint{Slot: 3, Root: r3}
+	state.LatestFinalized = &types.Checkpoint{}
+	state.HistoricalBlockHashes = hashes
+	setSlotJustified(state, 0, 3)
+
+	mkAtt := func(bits []byte) *types.AggregatedAttestation {
+		return &types.AggregatedAttestation{
+			AggregationBits: bits,
+			Data: &types.AttestationData{
+				Slot:   4,
+				Head:   &types.Checkpoint{Slot: 4, Root: r4},
+				Target: &types.Checkpoint{Slot: 4, Root: r4},
+				Source: &types.Checkpoint{Slot: 3, Root: r3},
+			},
+		}
+	}
+	return state, mkAtt
+}
+
+func TestProcessAttestationsRejectsEmptyAggregationBits(t *testing.T) {
+	state, mkAtt := bitsBoundsHarness()
+
+	err := ProcessAttestations(state, []*types.AggregatedAttestation{mkAtt(types.NewBitlistSSZ(4))})
+	if !errors.Is(err, ErrEmptyAggregationBits) {
+		t.Fatalf("err = %v, want ErrEmptyAggregationBits", err)
+	}
+}
+
+func TestProcessAttestationsRejectsOutOfRangeSetBit(t *testing.T) {
+	state, mkAtt := bitsBoundsHarness()
+
+	err := ProcessAttestations(state, []*types.AggregatedAttestation{mkAtt(types.BitlistFromIndices([]uint64{0, 7}))})
+	var oor *AttesterIndexOutOfRangeError
+	if !errors.As(err, &oor) {
+		t.Fatalf("err = %v, want AttesterIndexOutOfRangeError", err)
+	}
+	if oor.Index != 7 || oor.Validators != 4 {
+		t.Fatalf("index=%d validators=%d, want 7 and 4", oor.Index, oor.Validators)
+	}
+}
+
+func TestProcessAttestationsToleratesUnsetPaddingBits(t *testing.T) {
+	state, mkAtt := bitsBoundsHarness()
+
+	// Bitlist longer than the registry, set bits all in range: a valid
+	// supermajority whose votes must count despite the padding.
+	bits := types.NewBitlistSSZ(8)
+	for _, i := range []uint64{0, 1, 2} {
+		types.BitlistSet(bits, i)
+	}
+
+	if err := ProcessAttestations(state, []*types.AggregatedAttestation{mkAtt(bits)}); err != nil {
+		t.Fatalf("ProcessAttestations: %v", err)
+	}
+	if state.LatestJustified.Slot != 4 {
+		t.Fatalf("LatestJustified.Slot = %d, want 4 (padded votes must be tallied)", state.LatestJustified.Slot)
+	}
+}

--- a/internal/statetransition/errors.go
+++ b/internal/statetransition/errors.go
@@ -66,6 +66,17 @@ func (e *SlotGapTooLargeError) Error() string {
 	return fmt.Sprintf("slot gap %d at slot %d exceeds max %d", e.Gap, e.Current, e.Max)
 }
 
+type AttesterIndexOutOfRangeError struct {
+	Index      uint64
+	Validators uint64
+}
+
+func (e *AttesterIndexOutOfRangeError) Error() string {
+	return fmt.Sprintf("attestation aggregation bit %d outside validator registry of %d", e.Index, e.Validators)
+}
+
+var ErrEmptyAggregationBits = fmt.Errorf("attestation aggregation bits have no set bits")
+
 var ErrNoValidators = fmt.Errorf("state has no validators")
 var ErrZeroHashInJustificationRoots = fmt.Errorf("zero hash found in justifications_roots")
 var ErrMalformedState = fmt.Errorf("malformed state")


### PR DESCRIPTION
## Summary

Aligns gean's unsigned attestation-processing path with leanSpec `e7519866` (#899), which made aggregation-bits handling explicit in `process_attestations`:

- **Empty aggregation bits** (an attestation passing the vote filters with zero set bits) now **rejects the whole block** (`EMPTY_AGGREGATION_BITS`).
- **A set bit outside the validator registry** now **rejects the whole block** (`VALIDATOR_INDEX_OUT_OF_RANGE`); trailing **unset padding** past the registry is explicitly tolerated.

Closes #357.

## What gean did before (three divergences)

1. No empty-bits check — gean accepted blocks the updated spec rejects.
2. `bitsLen > validatorCount → continue` skipped the attestation instead of failing the block.
3. The predicate keyed off bitlist **length**, not **set bits** — a validly padded bitlist had its votes silently dropped, a justification-count divergence even on honest input.

The fix resolves set-bit indices once after the existing vote filters (mirroring the spec's ordering), errors with typed `statetransition` errors, and tallies the resolved indices. The blockbuilder full-plan test was updated where its mock payloads named a validator outside the test registry — exactly the input the spec now forbids.

Adoption needs no peer coordination: the stricter rules only change behavior on malformed blocks, which honest clients never produce.

## Verification

- New table tests: empty bits → `ErrEmptyAggregationBits`; set bit out of range → `AttesterIndexOutOfRangeError` (with index/registry payload); padded-but-valid bitlist → votes tallied and target justified (the case the old length-skip silently broke).
- `make test` all packages green; `make lint` clean.
- Spectests at the **current pin (`8e28a19`)**: exactly the 6 pre-existing #345-family failures — zero regressions from the stricter STF.

## Why the pin bump is NOT in this PR (honest note)

Bumping `LEAN_SPEC_COMMIT_HASH` to `e7519866` requires regenerating fixtures, and the spec's new prover bindings (`lean-multisig-py v0.0.9`, leanSpec #896) **do not build on stable Rust** — they pin a leanVM/Plonky3 combo needing the unstable `maybe_uninit_slice` feature. Generation succeeds with a nightly toolchain (`RUSTUP_TOOLCHAIN=nightly make test-spec`); a full regen + #899-vector validation run is in progress and the pin bump will follow as its own change once it's proven green — including checking proof verify-compat, since v0.0.9 wraps a leanVM ahead of gean's pinned `e2592df`. Until then this PR keeps the pin at `8e28a19`, where the new strictness is regression-free. The stable-Rust build issue is upstream leanSpec/leanMultisig-py territory and affects every client that regenerates vectors.