### PR TITLE
chore(spec): bump leanSpec to 46f9532 + attestation-data cap and justified-slot-range fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ NUM_NODES ?= 3
 # Pinned leanSpec revision for spec fixtures. Must be defined before the test-spec/test-all
 # rules that reference it: Make expands a rule's prerequisites when it reads the rule, so a
 # definition placed after those rules would expand to empty in their prerequisites.
-LEAN_SPEC_COMMIT_HASH := e913ec9f34bcdb759c7aa59ce9b3dd6a43dced3d
+LEAN_SPEC_COMMIT_HASH := 46f9532d0e0adcaa9aa372c42c2b0d54bfe20ea5
 
 help: ## Show help for each Makefile recipe
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/internal/blockbuilder/payloads.go
+++ b/internal/blockbuilder/payloads.go
@@ -87,7 +87,13 @@ func payloadBuildIssue(state *types.State, knownRoots KnownRoots, payload Attest
 	if !statetransition.HeadMatchesChain(state, data.Head) {
 		return errPayloadHeadOffChain(data.Head.Root)
 	}
-	if reason := statetransition.VoteInvalidReason(state, data.Source, data.Target); reason != "" {
+	// An out-of-range justified-slot query would reject the block the proposer is
+	// building, so drop the vote rather than include it.
+	reason, err := statetransition.VoteInvalidReason(state, data.Source, data.Target)
+	if err != nil {
+		return errPayloadVoteInvalid(data, err.Error())
+	}
+	if reason != "" {
 		if data.Source.Slot == 0 && data.Target.Slot == 0 &&
 			reason == statetransition.VoteReasonTargetAlreadyJustified {
 			return nil

--- a/internal/blockbuilder/payloads_test.go
+++ b/internal/blockbuilder/payloads_test.go
@@ -218,6 +218,18 @@ func TestPayloadBuildIssueUsesTransitionVoteRules(t *testing.T) {
 		t.Fatalf("payload build issue=%v, want ErrPayloadVoteInvalid", err)
 	}
 
+	// Chain mismatch must be tested before any slot is justified below, since
+	// leanSpec checks target justification ahead of chain membership: an
+	// already-justified target would otherwise mask the mismatch as an expected skip.
+	wrongRoot := *data
+	wrongRoot.Target = &types.Checkpoint{Slot: data.Target.Slot, Root: [32]byte{0x99}}
+	payload.Data = &wrongRoot
+	if err := payloadBuildIssue(workingState, knownRoots, payload); !errors.Is(err, ErrPayloadVoteInvalid) {
+		t.Fatalf("payload build issue=%v, want ErrPayloadVoteInvalid", err)
+	} else if IsExpectedSkip(err) {
+		t.Fatalf("chain mismatch was marked expected: %v", err)
+	}
+
 	alreadyJustified := *data
 	workingState.JustifiedSlots = types.BitlistExtend(workingState.JustifiedSlots, 2)
 	types.BitlistSet(workingState.JustifiedSlots, 1)
@@ -226,15 +238,6 @@ func TestPayloadBuildIssueUsesTransitionVoteRules(t *testing.T) {
 		t.Fatalf("payload build issue=%v, want ErrPayloadVoteInvalid", err)
 	} else if !IsExpectedSkip(err) {
 		t.Fatalf("already-justified vote was not marked expected: %v", err)
-	}
-
-	wrongRoot := *data
-	wrongRoot.Target = &types.Checkpoint{Slot: data.Target.Slot, Root: [32]byte{0x99}}
-	payload.Data = &wrongRoot
-	if err := payloadBuildIssue(workingState, knownRoots, payload); !errors.Is(err, ErrPayloadVoteInvalid) {
-		t.Fatalf("payload build issue=%v, want ErrPayloadVoteInvalid", err)
-	} else if IsExpectedSkip(err) {
-		t.Fatalf("chain mismatch was marked expected: %v", err)
 	}
 
 	farState, err := workingState.Clone()
@@ -246,6 +249,9 @@ func TestPayloadBuildIssueUsesTransitionVoteRules(t *testing.T) {
 		farState.HistoricalBlockHashes = append(farState.HistoricalBlockHashes, make([]byte, types.RootSize))
 	}
 	farState.HistoricalBlockHashes[7] = copyRoot(farRoot)
+	// Grow the justification window alongside the chain so slot 7 is in range and
+	// the vote is rejected as not-justifiable rather than out-of-range.
+	farState.JustifiedSlots = types.BitlistExtend(farState.JustifiedSlots, 7)
 
 	farTarget := *data
 	farTarget.Target = &types.Checkpoint{Slot: 7, Root: farRoot}

--- a/internal/blockprocessor/validate.go
+++ b/internal/blockprocessor/validate.go
@@ -39,6 +39,10 @@ func validateSignedBlock(signedBlock *types.SignedBlock, verify bool) (*types.Bl
 	return signedBlock.Block, nil
 }
 
+// validateBlockAttestations enforces the wire-level prohibition on exact-duplicate
+// AttestationData. The per-block cap on the distinct-data count lives in the state
+// transition, where it binds every caller; split aggregates sharing one data entry
+// are a legitimate, idempotently merged input and so are not rejected here.
 func validateBlockAttestations(block *types.Block) error {
 	seen := make(map[[32]byte]bool)
 	for _, att := range block.Body.Attestations {
@@ -57,13 +61,6 @@ func validateBlockAttestations(block *types.Block) error {
 			}
 		}
 		seen[dataRoot] = true
-	}
-
-	if len(seen) > int(types.MaxAttestationsData) {
-		return &store.StoreError{
-			Kind:    store.ErrTooManyAttestationData,
-			Message: fmt.Sprintf("block has %d distinct AttestationData (max %d)", len(seen), types.MaxAttestationsData),
-		}
 	}
 	return nil
 }

--- a/internal/statetransition/attestations.go
+++ b/internal/statetransition/attestations.go
@@ -1,6 +1,8 @@
 package statetransition
 
 import (
+	"fmt"
+
 	"github.com/geanlabs/gean/internal/types"
 )
 
@@ -13,6 +15,28 @@ func ProcessAttestations(state *types.State, attestations []*types.AggregatedAtt
 	}
 	if state.LatestFinalized == nil {
 		return malformedState("latest finalized")
+	}
+
+	// Bound the distinct votes the block may carry. The cap belongs to the
+	// transition itself, not to any one caller, so the raw transition and
+	// block-production trial blocks inherit the bound. Each distinct data builds a
+	// tally sized to the validator set, so an unbounded count amplifies import
+	// work; the SSZ list limit sits far above the consensus cap and cannot
+	// substitute. Only the distinct count is bounded: split aggregates that share
+	// one data entry count once.
+	distinct := make(map[[32]byte]struct{})
+	for _, agg := range attestations {
+		if agg == nil || agg.Data == nil {
+			continue
+		}
+		dataRoot, err := agg.Data.HashTreeRoot()
+		if err != nil {
+			return fmt.Errorf("hash attestation data: %w", err)
+		}
+		distinct[dataRoot] = struct{}{}
+	}
+	if len(distinct) > int(types.MaxAttestationsData) {
+		return &TooManyAttestationDataError{Count: uint64(len(distinct)), Max: uint64(types.MaxAttestationsData)}
 	}
 
 	validatorCount := int(state.NumValidators())
@@ -38,7 +62,13 @@ func ProcessAttestations(state *types.State, attestations []*types.AggregatedAtt
 		source := agg.Data.Source
 		target := agg.Data.Target
 
-		if !IsValidVote(state, source, target) {
+		// An out-of-range justified-slot query rejects the whole block; any other
+		// invalid reason just filters the vote out, matching leanSpec.
+		reason, err := VoteInvalidReason(state, source, target)
+		if err != nil {
+			return err
+		}
+		if reason != "" {
 			continue
 		}
 		if !HeadMatchesChain(state, agg.Data.Head) {

--- a/internal/statetransition/attestations_test.go
+++ b/internal/statetransition/attestations_test.go
@@ -29,6 +29,9 @@ func TestLatestJustifiedDoesNotRegressWithinBlock(t *testing.T) {
 	state.LatestJustified = &types.Checkpoint{Slot: 3, Root: r3}
 	state.LatestFinalized = &types.Checkpoint{}
 	state.HistoricalBlockHashes = hashes
+	// Header processing would size the window to cover every voted slot; do the
+	// same here so the slot-9 vote is in range rather than a spurious rejection.
+	state.JustifiedSlots = types.NewBitlistSSZ(9)
 	setSlotJustified(state, 0, 3)
 
 	bits := []byte{0x17}
@@ -84,7 +87,9 @@ func TestProcessAttestationsStaleSourceJustifiesWithoutReFinalizing(t *testing.T
 	state.LatestJustified = &types.Checkpoint{Slot: 4, Root: r4}
 	state.LatestFinalized = &types.Checkpoint{Slot: 4, Root: r4}
 	state.HistoricalBlockHashes = hashes
-	state.JustifiedSlots = types.NewBitlistSSZ(0)
+	// Window covers slots 5..6 above the finalized boundary; the slot-1 source is
+	// below it and justified by definition, so only the slot-6 target is tracked.
+	state.JustifiedSlots = types.NewBitlistSSZ(2)
 
 	att := &types.AggregatedAttestation{
 		AggregationBits: types.BitlistFromIndices([]uint64{0, 1, 2}),
@@ -159,6 +164,7 @@ func TestProcessAttestationsCopiesCheckpointInputs(t *testing.T) {
 		make([]byte, types.RootSize),
 		append([]byte(nil), targetRoot[:]...),
 	}
+	state.JustifiedSlots = types.NewBitlistSSZ(2)
 
 	source := &types.Checkpoint{Slot: 0, Root: sourceRoot}
 	target := &types.Checkpoint{Slot: 2, Root: targetRoot}
@@ -229,7 +235,7 @@ func TestProcessAttestationsRequiresHeadOnChain(t *testing.T) {
 		s.LatestJustified = &types.Checkpoint{Slot: 0, Root: r0}
 		s.LatestFinalized = &types.Checkpoint{Slot: 0, Root: r0}
 		s.HistoricalBlockHashes = hashes
-		s.JustifiedSlots = types.NewBitlistSSZ(0)
+		s.JustifiedSlots = types.NewBitlistSSZ(2)
 		return s
 	}
 	mkAtt := func(head *types.Checkpoint) *types.AggregatedAttestation {
@@ -282,6 +288,9 @@ func bitsBoundsHarness() (*types.State, func(bits []byte) *types.AggregatedAttes
 	state.LatestJustified = &types.Checkpoint{Slot: 3, Root: r3}
 	state.LatestFinalized = &types.Checkpoint{}
 	state.HistoricalBlockHashes = hashes
+	// Window covers slots 1..4 so the slot-4 target is in range; slot-3 source is
+	// justified within it.
+	state.JustifiedSlots = types.NewBitlistSSZ(4)
 	setSlotJustified(state, 0, 3)
 
 	mkAtt := func(bits []byte) *types.AggregatedAttestation {

--- a/internal/statetransition/errors.go
+++ b/internal/statetransition/errors.go
@@ -75,6 +75,35 @@ func (e *AttesterIndexOutOfRangeError) Error() string {
 	return fmt.Sprintf("attestation aggregation bit %d outside validator registry of %d", e.Index, e.Validators)
 }
 
+// TooManyAttestationDataError rejects a block whose distinct AttestationData count
+// exceeds the per-block cap. The bound is a property of the transition itself so it
+// holds for raw state transitions and block-production trial blocks alike, not only
+// the import caller. Split aggregates that share one data entry count once.
+type TooManyAttestationDataError struct {
+	Count uint64
+	Max   uint64
+}
+
+func (e *TooManyAttestationDataError) Error() string {
+	return fmt.Sprintf("block contains %d distinct AttestationData entries; maximum is %d", e.Count, e.Max)
+}
+
+// JustifiedSlotOutOfRangeError rejects a block whose attestation queries the
+// justification status of an active slot that lies beyond the tracked bitfield.
+// Slots at or below the finalized boundary are justified by definition and never
+// reach this path; only an in-future-but-untracked slot is a domain rejection
+// rather than a silently dropped vote.
+type JustifiedSlotOutOfRangeError struct {
+	Slot              uint64
+	FinalizedBoundary uint64
+	TrackedLength     uint64
+}
+
+func (e *JustifiedSlotOutOfRangeError) Error() string {
+	return fmt.Sprintf("Slot %d is outside the tracked range (finalized_boundary=%d, tracked_length=%d)",
+		e.Slot, e.FinalizedBoundary, e.TrackedLength)
+}
+
 var ErrEmptyAggregationBits = fmt.Errorf("attestation aggregation bits have no set bits")
 
 var ErrNoValidators = fmt.Errorf("state has no validators")

--- a/internal/statetransition/justifiable_test.go
+++ b/internal/statetransition/justifiable_test.go
@@ -49,12 +49,14 @@ func TestIsSlotJustifiedIgnoresBitlistTerminator(t *testing.T) {
 	state := makeGenesisState(1)
 	state.LatestFinalized.Slot = 0
 
-	if IsSlotJustified(state, 0, 1) {
-		t.Fatal("empty justified bitlist must not justify slot 1")
+	// An empty justified bitlist tracks no slots: slot 1 is out of range rather
+	// than spuriously justified by the SSZ terminator bit.
+	if justified, err := IsSlotJustified(state, 0, 1); justified || err == nil {
+		t.Fatalf("empty justified bitlist: got justified=%v err=%v, want false + out-of-range error", justified, err)
 	}
 
 	setSlotJustified(state, 0, 1)
-	if !IsSlotJustified(state, 0, 1) {
-		t.Fatal("explicitly justified slot 1 should be recognized")
+	if justified, err := IsSlotJustified(state, 0, 1); !justified || err != nil {
+		t.Fatalf("explicitly justified slot 1: got justified=%v err=%v, want true + nil", justified, err)
 	}
 }

--- a/internal/statetransition/votes.go
+++ b/internal/statetransition/votes.go
@@ -16,35 +16,52 @@ const (
 	VoteReasonTargetNotJustifiable   = "target_not_justifiable"
 )
 
-func VoteInvalidReason(state *types.State, source, target *types.Checkpoint) string {
+// VoteInvalidReason classifies a vote for filtering. A non-empty reason means the
+// vote is skipped; a non-nil error is a hard block rejection. The justification
+// queries are ordered ahead of the chain checks to mirror leanSpec
+// process_attestations, where an out-of-range source or target slot rejects the
+// block before the chain-membership filter runs.
+func VoteInvalidReason(state *types.State, source, target *types.Checkpoint) (string, error) {
 	if state == nil || state.LatestFinalized == nil || source == nil || target == nil {
-		return VoteReasonNilInput
+		return VoteReasonNilInput, nil
 	}
 
 	finalizedSlot := state.LatestFinalized.Slot
-	if !IsSlotJustified(state, finalizedSlot, source.Slot) {
-		return VoteReasonSourceNotJustified
+
+	sourceJustified, err := IsSlotJustified(state, finalizedSlot, source.Slot)
+	if err != nil {
+		return "", err
 	}
+	if !sourceJustified {
+		return VoteReasonSourceNotJustified, nil
+	}
+
+	targetJustified, err := IsSlotJustified(state, finalizedSlot, target.Slot)
+	if err != nil {
+		return "", err
+	}
+	if targetJustified {
+		return VoteReasonTargetAlreadyJustified, nil
+	}
+
 	if types.IsZeroRoot(source.Root) || types.IsZeroRoot(target.Root) {
-		return VoteReasonZeroRoot
+		return VoteReasonZeroRoot, nil
 	}
 	if !checkpointExists(state, source) || !checkpointExists(state, target) {
-		return VoteReasonChainMismatch
-	}
-	if IsSlotJustified(state, finalizedSlot, target.Slot) {
-		return VoteReasonTargetAlreadyJustified
+		return VoteReasonChainMismatch, nil
 	}
 	if target.Slot <= source.Slot {
-		return VoteReasonTargetNotAfterSource
+		return VoteReasonTargetNotAfterSource, nil
 	}
 	if !SlotIsJustifiableAfter(target.Slot, finalizedSlot) {
-		return VoteReasonTargetNotJustifiable
+		return VoteReasonTargetNotJustifiable, nil
 	}
-	return ""
+	return "", nil
 }
 
 func IsValidVote(state *types.State, source, target *types.Checkpoint) bool {
-	return VoteInvalidReason(state, source, target) == ""
+	reason, err := VoteInvalidReason(state, source, target)
+	return err == nil && reason == ""
 }
 
 // HeadMatchesChain reports whether the attestation head sits on the canonical
@@ -54,16 +71,27 @@ func HeadMatchesChain(state *types.State, head *types.Checkpoint) bool {
 	return head != nil && !types.IsZeroRoot(head.Root) && checkpointExists(state, head)
 }
 
-func IsSlotJustified(state *types.State, finalizedSlot, slot uint64) bool {
+// IsSlotJustified reports whether a slot is justified. Slots at or below the
+// finalized boundary are justified by definition. An active slot beyond the tracked
+// bitfield is not a "false" answer but a domain rejection: leanSpec surfaces it as
+// JUSTIFIED_SLOT_OUT_OF_RANGE rather than letting it pass as an unjustified vote.
+func IsSlotJustified(state *types.State, finalizedSlot, slot uint64) (bool, error) {
 	if slot <= finalizedSlot {
-		return true
+		return true, nil
 	}
 	if state == nil {
-		return false
+		return false, nil
 	}
 	relIndex := slot - finalizedSlot - 1
-	return relIndex < types.BitlistLen(state.JustifiedSlots) &&
-		types.BitlistGet(state.JustifiedSlots, relIndex)
+	trackedLen := types.BitlistLen(state.JustifiedSlots)
+	if relIndex >= trackedLen {
+		return false, &JustifiedSlotOutOfRangeError{
+			Slot:              slot,
+			FinalizedBoundary: finalizedSlot,
+			TrackedLength:     trackedLen,
+		}
+	}
+	return types.BitlistGet(state.JustifiedSlots, relIndex), nil
 }
 
 func setSlotJustified(state *types.State, finalizedSlot, slot uint64) {

--- a/internal/statetransition/votes_test.go
+++ b/internal/statetransition/votes_test.go
@@ -1,6 +1,7 @@
 package statetransition
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/geanlabs/gean/internal/types"
@@ -21,7 +22,11 @@ func TestVoteInvalidReason(t *testing.T) {
 		s := makeGenesisState(numValidators)
 		s.LatestFinalized = &types.Checkpoint{Slot: 0, Root: roots[0]}
 		s.HistoricalBlockHashes = hashes
-		s.JustifiedSlots = types.NewBitlistSSZ(0)
+		// Track slots 1..8 (all unjustified). Header processing sizes the window
+		// to (finalized, block.slot-1], so a vote referencing a slot beyond it is
+		// out of range; the cases below stay within the tracked window unless they
+		// explicitly probe the out-of-range rejection.
+		s.JustifiedSlots = types.NewBitlistSSZ(8)
 		return s
 	}
 	cp := func(slot uint64, root [types.RootSize]byte) *types.Checkpoint {
@@ -29,11 +34,12 @@ func TestVoteInvalidReason(t *testing.T) {
 	}
 
 	cases := []struct {
-		name   string
-		setup  func(s *types.State)
-		source *types.Checkpoint
-		target *types.Checkpoint
-		want   string
+		name    string
+		setup   func(s *types.State)
+		source  *types.Checkpoint
+		target  *types.Checkpoint
+		want    string
+		wantErr bool
 	}{
 		{
 			name:   "valid",
@@ -73,11 +79,13 @@ func TestVoteInvalidReason(t *testing.T) {
 			want:   VoteReasonChainMismatch,
 		},
 		{
-			name:   "chain_mismatch_takes_priority_over_already_justified",
+			// leanSpec checks target justification before chain membership, so an
+			// already-justified target is skipped before the chain mismatch is seen.
+			name:   "already_justified_takes_priority_over_chain_mismatch",
 			setup:  func(s *types.State) { setSlotJustified(s, 0, 1) },
 			source: cp(0, roots[0]),
 			target: cp(1, roots[2]),
-			want:   VoteReasonChainMismatch,
+			want:   VoteReasonTargetAlreadyJustified,
 		},
 		{
 			name:   "target_not_after_source",
@@ -92,6 +100,23 @@ func TestVoteInvalidReason(t *testing.T) {
 			target: cp(7, roots[7]),
 			want:   VoteReasonTargetNotJustifiable,
 		},
+		{
+			// Source slot past the tracked window is a hard block rejection, not a
+			// silently dropped vote. The source root is irrelevant: the justification
+			// query raises before any chain check runs.
+			name:    "source_slot_out_of_range",
+			source:  cp(9, roots[0]),
+			target:  cp(1, roots[1]),
+			wantErr: true,
+		},
+		{
+			// Target slot past the tracked window likewise rejects the block, after
+			// the in-range source clears its justification query.
+			name:    "target_slot_out_of_range",
+			source:  cp(0, roots[0]),
+			target:  cp(9, roots[1]),
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range cases {
@@ -100,7 +125,20 @@ func TestVoteInvalidReason(t *testing.T) {
 			if tc.setup != nil {
 				tc.setup(s)
 			}
-			got := VoteInvalidReason(s, tc.source, tc.target)
+			got, err := VoteInvalidReason(s, tc.source, tc.target)
+			if tc.wantErr {
+				var oorErr *JustifiedSlotOutOfRangeError
+				if !errors.As(err, &oorErr) {
+					t.Fatalf("VoteInvalidReason err = %v, want JustifiedSlotOutOfRangeError", err)
+				}
+				if IsValidVote(s, tc.source, tc.target) {
+					t.Fatal("IsValidVote must be false on out-of-range rejection")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("VoteInvalidReason unexpected error: %v", err)
+			}
 			if got != tc.want {
 				t.Fatalf("VoteInvalidReason = %q, want %q", got, tc.want)
 			}
@@ -111,8 +149,8 @@ func TestVoteInvalidReason(t *testing.T) {
 	}
 
 	t.Run("nil_state", func(t *testing.T) {
-		if got := VoteInvalidReason(nil, cp(0, roots[0]), cp(1, roots[1])); got != VoteReasonNilInput {
-			t.Fatalf("VoteInvalidReason(nil state) = %q, want %q", got, VoteReasonNilInput)
+		if got, err := VoteInvalidReason(nil, cp(0, roots[0]), cp(1, roots[1])); err != nil || got != VoteReasonNilInput {
+			t.Fatalf("VoteInvalidReason(nil state) = %q (err %v), want %q", got, err, VoteReasonNilInput)
 		}
 		if IsValidVote(nil, cp(0, roots[0]), cp(1, roots[1])) {
 			t.Fatalf("IsValidVote(nil state) = true, want false")

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -34,7 +34,6 @@ const (
 	ErrMissingTargetState
 	ErrNotProposer
 	ErrDuplicateAttestationData
-	ErrTooManyAttestationData
 	ErrJustifiedDivergenceNotClosed
 	ErrSourceNotAncestorOfTarget
 	ErrTargetNotAncestorOfHead


### PR DESCRIPTION
Bumps the pinned spec from \`e913ec9\` to \`46f9532\` and brings gean into compliance with the two consensus-behaviour changes in that range. Builds on the merged \`e913ec9\` work (#360); the spec-pin bump is isolated in its own commit.

## Changes
- **chore(spec):** bump \`LEAN_SPEC_COMMIT_HASH\` to \`46f9532\`.
- **fix(statetransition): distinct-AttestationData cap (leanSpec #1102).** The per-block cap on distinct \`AttestationData\` now lives inside \`ProcessAttestations\`, so the bound holds for the raw state transition and block-production trial blocks — not only the import caller. The now-duplicated cap (and its orphaned error kind) is removed from block import, which keeps only the wire-level exact-duplicate prohibition.
- **fix(statetransition): JUSTIFIED_SLOT_OUT_OF_RANGE rejection (leanSpec #1100).** An attestation that queries the justification status of an active slot beyond the tracked bitfield now rejects the block, instead of silently dropping the vote and accepting it (which let gean accept a block the spec rejects). The justification queries are ordered ahead of the chain checks to match the spec; block production still skips such votes rather than failing.

## Spec mapping
The whole \`e913ec9..46f9532\` range is ~90% docstring/reference-node refactors; these two are the only consensus-behaviour items. \`SignedBlock\` SSZ and the rest of the wire layout are unchanged. Compliance notes were produced via \`/spec-compliant\`.

## Verification
- \`make build\`, \`make test\`, \`make lint\` green.
- \`make test-spec\` green at the new pin, including the two new state-transition vectors (\`test_attestation_data_limits\`, \`test_justified_slot_out_of_range\`) that previously had no gean coverage.
- Unit tests updated to use realistically-sized justification windows (the prior fixtures used states header-processing never produces).