### PR TITLE
chore(spec): bump leanSpec pin to c2a842d

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ NUM_NODES ?= 3
 # Pinned leanSpec revision for spec fixtures. Must be defined before the test-spec/test-all
 # rules that reference it: Make expands a rule's prerequisites when it reads the rule, so a
 # definition placed after those rules would expand to empty in their prerequisites.
-LEAN_SPEC_COMMIT_HASH := 46f9532d0e0adcaa9aa372c42c2b0d54bfe20ea5
+LEAN_SPEC_COMMIT_HASH := c2a842d599a021235212646c5ab289b0d84ce4a1
 
 help: ## Show help for each Makefile recipe
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
Closes #362.

Bumps `LEAN_SPEC_COMMIT_HASH` from `46f9532` to leanSpec HEAD `c2a842d599a021235212646c5ab289b0d84ce4a1` (52 commits).

## Compliance summary

A spec-compliance pass over `46f9532..c2a842d` found gean **already functionally compliant** — the two behavioral changes in this window predate this catch-up, so this is the mechanical pin bump.

- **#1147 — `Validators` registry index must equal list position.** Already enforced on the untrusted ingest path (`internal/checkpoint/verify.go`) and constructed correctly at genesis (`internal/genesis/validators.go`). ✅
- **#974 — `GET /lean/v0/blocks/finalized`.** Already served (`internal/api/routes.go`, `FinalizedBlockHandler`). ✅
- **#1148 — fork-choice stale-vote prune ancestry guard** (`perf`). gean prunes pools by slot only; not a correctness gap — the spec notes orphaned-branch votes never change the chosen chain, and gean's GHOST head walk already ignores them. Optional. 🟡
- **#1114 — post-block reaggregation test vectors.** Underlying logic exists in gean; no spectest runner consumes the new fixture category yet (coverage-only). ⚠️
- **#1157 — explicit proposer-index 0** in the fixture generator; picked up on regeneration. ✅

Remaining ~48 commits are docs/refactor/style/chore with no effect on gean.

## Verification

`make test-spec` run to completion at the new pin — **green**:

- Prod-scheme fixture generation: **542 passed, 0 failures** (incl. cross-hash-seed determinism check), fixtures regenerated cleanly from scratch.
- Go spectests: `ok github.com/geanlabs/gean/internal/spectests` (`-tags=spectests`).

## Optional follow-ups (not required for compliance)

- Reaggregation spectest runner to consume #1114's vectors.
- #1148 ancestry guard in pool pruning to track the spec exactly.