### PR TITLE
fix(aggregation): bound per-pass aggregation to the session budget

### DIFF
--- a/internal/aggregation/aggregate.go
+++ b/internal/aggregation/aggregate.go
@@ -48,9 +48,56 @@ func orderedGroups(snap *Snapshot) []aggregationGroup {
 	return groups
 }
 
-func aggregateFromSnapshot(snap *Snapshot, cache *xmss.PubKeyCache, deadline time.Time) ([]*types.SignedAggregatedAttestation, []store.PayloadKV, []store.AttestationDeleteKey, bool) {
+// seedPerUnitSeconds is a conservative starting cost for one aggregation unit
+// (one raw signature or one child proof). It only governs the first pass, before
+// any real timing is observed: a high seed makes that pass trim rather than risk
+// spending the whole session budget on a single group. The estimate then
+// converges to the real prover cost of whatever hardware runs the node.
+const seedPerUnitSeconds = 0.1
+
+// unitCostEstimator tracks observed per-unit aggregation-proving time so each pass
+// can be sized to the remaining session budget. The single-threaded worker holds
+// one across dispatches. No fixed unit cap would hold across machines and
+// validator-set sizes, so it self-calibrates instead.
+type unitCostEstimator struct {
+	perUnitSeconds float64
+}
+
+func newUnitCostEstimator() *unitCostEstimator {
+	return &unitCostEstimator{perUnitSeconds: seedPerUnitSeconds}
+}
+
+// maxUnitsWithin reports how many units fit in the remaining budget at the current
+// estimate. It never returns below the spec minimum of two, so a group can always
+// still produce a valid aggregate.
+func (e *unitCostEstimator) maxUnitsWithin(budget time.Duration) int {
+	if e == nil || e.perUnitSeconds <= 0 || budget <= 0 {
+		return 2
+	}
+	fit := int(budget.Seconds() / e.perUnitSeconds)
+	if fit < 2 {
+		return 2
+	}
+	return fit
+}
+
+// observe folds a completed aggregation's realized per-unit cost into the estimate
+// with an exponential moving average, damping single-pass noise.
+func (e *unitCostEstimator) observe(duration time.Duration, units int) {
+	if e == nil || units <= 0 || duration <= 0 {
+		return
+	}
+	const alpha = 0.3
+	sample := duration.Seconds() / float64(units)
+	e.perUnitSeconds = alpha*sample + (1-alpha)*e.perUnitSeconds
+}
+
+func aggregateFromSnapshot(snap *Snapshot, cache *xmss.PubKeyCache, deadline time.Time, estimator *unitCostEstimator) ([]*types.SignedAggregatedAttestation, []store.PayloadKV, []store.AttestationDeleteKey, bool) {
 	if snap == nil || cache == nil {
 		return nil, nil, nil, false
+	}
+	if estimator == nil {
+		estimator = newUnitCostEstimator()
 	}
 
 	var newAggregates []*types.SignedAggregatedAttestation
@@ -86,9 +133,16 @@ func aggregateFromSnapshot(snap *Snapshot, cache *xmss.PubKeyCache, deadline tim
 				return
 			}
 
+			// Bound this pass to what fits the remaining session budget at the
+			// current per-unit estimate. Child proofs go in first (most coverage
+			// per unit); fresh raw signatures take whatever budget is left and the
+			// rest are deferred to the next pass. A smaller aggregate over the
+			// included participants is still spec-valid.
+			remaining := estimator.maxUnitsWithin(time.Until(deadline))
+
 			covered := make(map[uint64]bool)
-			selectChildProofs(newEntry, targetState, childProofsBuf, covered, cache)
-			selectChildProofs(knownEntry, targetState, childProofsBuf, covered, cache)
+			selectChildProofs(newEntry, targetState, childProofsBuf, covered, cache, &remaining)
+			selectChildProofs(knownEntry, targetState, childProofsBuf, covered, cache, &remaining)
 
 			if gossipEntry != nil && len(gossipEntry.Signatures) > 0 {
 				sortedSigs := make([]store.AttestationSignatureEntry, len(gossipEntry.Signatures))
@@ -98,6 +152,9 @@ func aggregateFromSnapshot(snap *Snapshot, cache *xmss.PubKeyCache, deadline tim
 				})
 
 				for _, sigEntry := range sortedSigs {
+					if remaining <= 0 {
+						break
+					}
 					if covered[sigEntry.ValidatorID] {
 						continue
 					}
@@ -123,6 +180,7 @@ func aggregateFromSnapshot(snap *Snapshot, cache *xmss.PubKeyCache, deadline tim
 					*rawPubkeysBuf = append(*rawPubkeysBuf, pk)
 					*rawSigsBuf = append(*rawSigsBuf, sigHandle)
 					*rawIDsBuf = append(*rawIDsBuf, sigEntry.ValidatorID)
+					remaining--
 				}
 			}
 
@@ -146,6 +204,7 @@ func aggregateFromSnapshot(snap *Snapshot, cache *xmss.PubKeyCache, deadline tim
 					slot, len(*rawIDsBuf), len(*childProofsBuf), aggDuration, err)
 				return
 			}
+			estimator.observe(aggDuration, len(*rawIDsBuf)+len(*childProofsBuf))
 
 			allIDs := make([]uint64, 0, len(*rawIDsBuf)+len(covered))
 			allIDs = append(allIDs, (*rawIDsBuf)...)
@@ -177,8 +236,18 @@ func aggregateFromSnapshot(snap *Snapshot, cache *xmss.PubKeyCache, deadline tim
 				Proof:    proof,
 			})
 
+			// Only retire gossip signatures whose vote made it into this proof.
+			// Signatures the budget deferred stay in the store for the next pass;
+			// retiring them here would drop those votes silently.
 			if gossipEntry != nil {
+				represented := make(map[uint64]bool, len(allIDs))
+				for _, vid := range allIDs {
+					represented[vid] = true
+				}
 				for _, sig := range gossipEntry.Signatures {
+					if !represented[sig.ValidatorID] {
+						continue
+					}
 					keysToDelete = append(keysToDelete, store.AttestationDeleteKey{
 						ValidatorID: sig.ValidatorID,
 						DataRoot:    dataRoot,

--- a/internal/aggregation/aggregate_test.go
+++ b/internal/aggregation/aggregate_test.go
@@ -92,7 +92,7 @@ func TestAggregateFromSnapshotExpiredDeadlineReportsTruncation(t *testing.T) {
 	snap := aggregateTestSnapshot(5)
 	cache := xmss.NewPubKeyCache()
 
-	aggs, payloads, deletes, truncated := aggregateFromSnapshot(snap, cache, time.Now().Add(-time.Second))
+	aggs, payloads, deletes, truncated := aggregateFromSnapshot(snap, cache, time.Now().Add(-time.Second), newUnitCostEstimator())
 
 	if !truncated {
 		t.Fatal("expected truncation with expired deadline")
@@ -105,9 +105,47 @@ func TestAggregateFromSnapshotExpiredDeadlineReportsTruncation(t *testing.T) {
 func TestAggregateFromSnapshotZeroDeadlineProcessesAll(t *testing.T) {
 	snap := aggregateTestSnapshot(5)
 
-	_, _, _, truncated := aggregateFromSnapshot(snap, xmss.NewPubKeyCache(), time.Time{})
+	_, _, _, truncated := aggregateFromSnapshot(snap, xmss.NewPubKeyCache(), time.Time{}, newUnitCostEstimator())
 
 	if truncated {
 		t.Fatal("zero deadline must never truncate")
+	}
+}
+
+func TestUnitCostEstimatorMaxUnitsWithin(t *testing.T) {
+	e := newUnitCostEstimator() // seed 0.1s/unit
+
+	if got := e.maxUnitsWithin(time.Second); got != 10 {
+		t.Fatalf("maxUnitsWithin(1s)=%d, want 10", got)
+	}
+	// Never below the spec minimum of two, even for a tiny or expired budget.
+	if got := e.maxUnitsWithin(time.Millisecond); got != 2 {
+		t.Fatalf("maxUnitsWithin(1ms)=%d, want 2 (floor)", got)
+	}
+	if got := e.maxUnitsWithin(-time.Second); got != 2 {
+		t.Fatalf("maxUnitsWithin(-1s)=%d, want 2 (floor)", got)
+	}
+}
+
+func TestUnitCostEstimatorObserveConverges(t *testing.T) {
+	e := newUnitCostEstimator() // seed 0.1s/unit
+
+	// A cheaper-than-seed observation must pull the estimate down, letting more
+	// units fit the budget on the next pass.
+	before := e.maxUnitsWithin(time.Second)
+	for range 20 {
+		e.observe(200*time.Millisecond, 10) // 0.02s/unit
+	}
+	after := e.maxUnitsWithin(time.Second)
+	if after <= before {
+		t.Fatalf("estimate did not converge down: before=%d after=%d units/sec", before, after)
+	}
+
+	// Degenerate inputs are ignored, not divided by.
+	steady := e.perUnitSeconds
+	e.observe(0, 10)
+	e.observe(time.Second, 0)
+	if e.perUnitSeconds != steady {
+		t.Fatalf("degenerate observe mutated estimate: %v -> %v", steady, e.perUnitSeconds)
 	}
 }

--- a/internal/aggregation/proofs.go
+++ b/internal/aggregation/proofs.go
@@ -6,18 +6,26 @@ import (
 	"github.com/geanlabs/gean/xmss"
 )
 
+// selectChildProofs folds coverage-adding child proofs into the aggregation
+// inputs. remaining caps how many more units this pass may take; child proofs
+// are preferred over raw signatures because each carries many validators, so
+// they buy the most coverage per unit of prover budget.
 func selectChildProofs(
 	entry *store.PayloadEntry,
 	state *types.State,
 	children *[]xmss.ChildProof,
 	covered map[uint64]bool,
 	cache *xmss.PubKeyCache,
+	remaining *int,
 ) {
 	if entry == nil || state == nil || cache == nil || len(entry.Proofs) == 0 {
 		return
 	}
 
 	for _, proof := range entry.Proofs {
+		if *remaining <= 0 {
+			return
+		}
 		bitsLen := types.BitlistLen(proof.Participants)
 		if countNewCoverage(proof.Participants, covered) == 0 {
 			continue
@@ -54,6 +62,7 @@ func selectChildProofs(
 			Pubkeys: pubkeys,
 			Proof:   proof.Proof,
 		})
+		*remaining--
 	}
 }
 

--- a/internal/aggregation/proofs_test.go
+++ b/internal/aggregation/proofs_test.go
@@ -21,12 +21,37 @@ func TestSelectChildProofsSkipsOutOfRangeParticipant(t *testing.T) {
 
 	var children []xmss.ChildProof
 	covered := make(map[uint64]bool)
-	selectChildProofs(entry, state, &children, covered, xmss.NewPubKeyCache())
+	remaining := 8
+	selectChildProofs(entry, state, &children, covered, xmss.NewPubKeyCache(), &remaining)
 
 	if len(children) != 0 {
 		t.Fatalf("children=%d, want 0", len(children))
 	}
 	if covered[2] {
 		t.Fatal("out-of-range validator marked covered")
+	}
+}
+
+func TestSelectChildProofsStopsAtBudget(t *testing.T) {
+	entry := &store.PayloadEntry{
+		Proofs: []*types.SingleMessageAggregate{{
+			Participants: types.BitlistFromIndices([]uint64{0}),
+			Proof:        []byte{1},
+		}},
+	}
+	state := &types.State{
+		Validators: []*types.Validator{{Index: 0}},
+	}
+
+	var children []xmss.ChildProof
+	covered := make(map[uint64]bool)
+	remaining := 0
+	selectChildProofs(entry, state, &children, covered, xmss.NewPubKeyCache(), &remaining)
+
+	if len(children) != 0 {
+		t.Fatalf("children=%d, want 0 (budget exhausted)", len(children))
+	}
+	if len(covered) != 0 {
+		t.Fatal("exhausted budget must not process any proof")
 	}
 }

--- a/internal/aggregation/worker.go
+++ b/internal/aggregation/worker.go
@@ -35,6 +35,10 @@ func RunWorker(
 	publisher Publisher,
 	gate *proving.Gate,
 ) {
+	// One estimator lives across dispatches so it keeps calibrating to this
+	// node's real per-unit prover cost. The worker is single-threaded, so no
+	// locking is needed.
+	estimator := newUnitCostEstimator()
 	for {
 		select {
 		case <-ctx.Done():
@@ -62,7 +66,7 @@ func RunWorker(
 			// (and their signature deletes) regrows the next snapshot until
 			// no session can ever finish inside a slot.
 			workerStart := time.Now()
-			aggs, payloads, deletes, truncated := aggregateFromSnapshot(dispatch.Snapshot, cache, workerStart.Add(sessionBudget))
+			aggs, payloads, deletes, truncated := aggregateFromSnapshot(dispatch.Snapshot, cache, workerStart.Add(sessionBudget), estimator)
 			if gate != nil {
 				gate.Release(false)
 			}


### PR DESCRIPTION
## Problem

On devnet5, gean's attestation-aggregate throughput is falling (Partha's report): aggregation **mean ~0.8–1.2 s, p95 up to ~3.2 s** against the **~1.6 s session budget**, while zeam/ethlambda run ~0.2 s. When a pass exceeds the budget the worker truncates the whole remaining set, so fewer aggregates are produced. Cost scales with `raw signatures + child proofs` merged per pass, and one fat group starves the rest (the deadline is only checked *between* groups).

Investigation (Shadow stress matrix + leanSpec@43246bd review + XMSS-API check):
- Shadow reproduced the cliff — aggregation crossing ~1.6 s → finalization strain → stall.
- **Flatter aggregation is not buildable** (`xmss_aggregate_type_1` mandates merging all children in one call; `log_inv_rate` is a fixed spec constant, no depth knob).
- **Raw sigs in a block are spec-invalid**, but **a valid aggregate over a subset of participants is spec-legal** (`verify_signatures` checks whatever participants the proof names). So bounded coverage is the spec-safe lever.

## Change

Size each aggregation to the remaining session budget via a **self-calibrating per-unit cost estimate** (EMA of realized prover time — no fixed cap, adapts to the host). **Child proofs first** (most coverage per unit); fresh raw signatures take the leftover budget and the rest **defer to the next pass**.

Companion correctness fix: **retire only the gossip signatures actually represented in the produced proof**, so budget-deferred votes retry next pass rather than being dropped (also a latent all-or-nothing bug).

**Spec-safe:** output is a valid aggregate over the included participants; trimmed children stay in the payload pool, deferred sigs stay in the store, and the block builder selects/merges proofs independently — so no coverage is permanently lost.

## Testing
- `make build`, `go test ./internal/aggregation/`, `make test-ffi`, `make lint`, and the spec fixtures (12 real prod categories) all green — **no consensus-semantics change** (no STF/type/fixture touched).
- New unit tests cover the estimator (budget math + EMA convergence) and the child-selection budget gate.

## Needs devnet validation before merge
Whether this actually pulls gean toward ~0.2 s **without shrinking finality contribution** must be confirmed on the **live devnet** — the raw-vs-children split and per-unit XMSS cost are server-specific. Please build + run this on devnet5 and check aggregation mean/p95 + finalization. If child-heavy groups still dominate, a follow-up can also trim least-coverage children.