### PR TITLE
fix(recovery): source-filter votes and gate deconstruction on synced aggregator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ NUM_NODES ?= 3
 # Pinned leanSpec revision for spec fixtures. Must be defined before the test-spec/test-all
 # rules that reference it: Make expands a rule's prerequisites when it reads the rule, so a
 # definition placed after those rules would expand to empty in their prerequisites.
-LEAN_SPEC_COMMIT_HASH := 4ca7d27e46b9b978c4f0a9b7e8eb6fd06be8286d
+LEAN_SPEC_COMMIT_HASH := eca701efeb5931010fe63925cd203c9ee55b2dbc
 
 help: ## Show help for each Makefile recipe
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/internal/forkchoice/forkchoice_test.go
+++ b/internal/forkchoice/forkchoice_test.go
@@ -404,6 +404,86 @@ func TestProtoArrayPrune(t *testing.T) {
 	}
 }
 
+// buildLinearChain inserts a linear chain (node k = root(k+1) at slot k, parent
+// root(k), anchored at root(1)). reverse=true inserts children before parents, so
+// orphan linking leaves interior nodes with a parent at a higher array index — the
+// reverse-topological ordering that made the old fixed-point Prune O(N^2).
+func buildLinearChain(depth int, reverse bool) *ForkChoice {
+	fc := New(0, root(1), [32]byte{})
+	insertK := func(k int) {
+		parent := root(1)
+		if k > 1 {
+			parent = root(byte(k))
+		}
+		fc.OnBlock(uint64(k), root(byte(k+1)), parent)
+	}
+	if reverse {
+		for k := depth; k >= 1; k-- {
+			insertK(k)
+		}
+		return fc
+	}
+	for k := 1; k <= depth; k++ {
+		insertK(k)
+	}
+	return fc
+}
+
+func countParentBackEdges(pa *ProtoArray) int {
+	n := 0
+	for i, node := range pa.nodes {
+		if node.Parent > i {
+			n++
+		}
+	}
+	return n
+}
+
+// Prune must depend only on the tree, not on block arrival order: a chain built
+// child-first (heavy parent back-edges) must prune to the exact same layout as the
+// same chain built parent-first.
+func TestPruneIndependentOfArrivalOrder(t *testing.T) {
+	const depth = 10
+	const finalizedAt = 4 // keep nodes 4..10, i.e. root(5)..root(11)
+	finalizedRoot := root(byte(finalizedAt + 1))
+
+	forward := buildLinearChain(depth, false)
+	reverse := buildLinearChain(depth, true)
+
+	// The two orderings must genuinely differ, or the test proves nothing.
+	if got := countParentBackEdges(forward.array); got != 0 {
+		t.Fatalf("forward chain should be topologically ordered, got %d back-edges", got)
+	}
+	if countParentBackEdges(reverse.array) == 0 {
+		t.Fatal("reverse chain should have parent back-edges to exercise the O(N^2) path")
+	}
+
+	forward.Prune(finalizedRoot)
+	reverse.Prune(finalizedRoot)
+
+	fwd, rev := forward.array.Nodes(), reverse.array.Nodes()
+	if len(fwd) != depth-finalizedAt+1 {
+		t.Fatalf("kept %d nodes, want %d", len(fwd), depth-finalizedAt+1)
+	}
+	if len(fwd) != len(rev) {
+		t.Fatalf("forward kept %d nodes, reverse kept %d", len(fwd), len(rev))
+	}
+	for i := range fwd {
+		if fwd[i].Root != rev[i].Root || fwd[i].Parent != rev[i].Parent {
+			t.Fatalf("node %d differs: forward{root=%x parent=%d} reverse{root=%x parent=%d}",
+				i, fwd[i].Root[:1], fwd[i].Parent, rev[i].Root[:1], rev[i].Parent)
+		}
+	}
+
+	// The finalized root anchors the pruned array; pre-finalized nodes are gone.
+	if idx := forward.NodeIndex(finalizedRoot); idx != 0 {
+		t.Fatalf("finalized root index=%d, want 0", idx)
+	}
+	if forward.NodeIndex(root(byte(finalizedAt))) != -1 {
+		t.Fatal("pre-finalized node should be pruned")
+	}
+}
+
 func TestCanonicalAnalysisSeparatesFinalizedForks(t *testing.T) {
 	anchor, a, b, c, forkBefore, forkAfter := root(1), root(2), root(3), root(4), root(5), root(6)
 	fc := New(0, anchor, [32]byte{})

--- a/internal/forkchoice/protoarray.go
+++ b/internal/forkchoice/protoarray.go
@@ -173,6 +173,21 @@ func (pa *ProtoArray) descendingSlotOrder() []int {
 	return order
 }
 
+func (pa *ProtoArray) ascendingSlotOrder() []int {
+	order := make([]int, len(pa.nodes))
+	for i := range order {
+		order[i] = i
+	}
+	sort.SliceStable(order, func(i, j int) bool {
+		left, right := pa.nodes[order[i]], pa.nodes[order[j]]
+		if left.Slot != right.Slot {
+			return left.Slot < right.Slot
+		}
+		return order[i] < order[j]
+	})
+	return order
+}
+
 func (pa *ProtoArray) FindHead(justifiedRoot [32]byte) [32]byte {
 	if pa == nil {
 		return justifiedRoot
@@ -197,34 +212,23 @@ func (pa *ProtoArray) Prune(finalizedRoot [32]byte) map[int]int {
 		return nil
 	}
 
+	// Ascending-slot order is a topological order of the parent forest: every parent
+	// edge is strictly slot-increasing (OnBlock and linkOrphanChildren reject a child
+	// whose slot is not above its parent's), so a node's parent is always visited first.
+	// One pass then keeps exactly the finalized subtree — pre-finalized ancestors, sibling
+	// forks, and unlinked orphans fall out. Iterating in this order also leaves kept sorted,
+	// so no separate sort is needed. This replaces a fixed-point iteration that degraded to
+	// O(N^2) when out-of-order arrivals placed a child ahead of its parent in the array.
+	order := pa.ascendingSlotOrder()
 	keep := make([]bool, len(pa.nodes))
-	keep[finalizedIdx] = true
-	for changed := true; changed; {
-		changed = false
-		for i, node := range pa.nodes {
-			if keep[i] || node.Parent < 0 || node.Parent >= len(pa.nodes) {
-				continue
-			}
-			if keep[node.Parent] {
-				keep[i] = true
-				changed = true
-			}
-		}
-	}
-
 	kept := make([]int, 0, len(pa.nodes)-finalizedIdx)
-	for i, keepNode := range keep {
-		if keepNode {
+	for _, i := range order {
+		parent := pa.nodes[i].Parent
+		if i == finalizedIdx || (parent >= 0 && parent < len(pa.nodes) && keep[parent]) {
+			keep[i] = true
 			kept = append(kept, i)
 		}
 	}
-	sort.SliceStable(kept, func(i, j int) bool {
-		left, right := pa.nodes[kept[i]], pa.nodes[kept[j]]
-		if left.Slot != right.Slot {
-			return left.Slot < right.Slot
-		}
-		return kept[i] < kept[j]
-	})
 
 	indexMap := make(map[int]int, len(kept))
 	newNodes := make([]ProtoNode, 0, len(kept))

--- a/internal/node/recovery.go
+++ b/internal/node/recovery.go
@@ -68,9 +68,8 @@ func (e *Engine) recoverBlockProofs(ctx context.Context, signedBlock *types.Sign
 	if state == nil {
 		return
 	}
-	// Filter votes against the head's justified checkpoint: a future block on this head
-	// can only pack votes whose source equals it, so votes with any other source can no
-	// longer advance justification and are not worth recovering.
+	// The head post-state's justified checkpoint is the source selectRecoveryCandidates
+	// filters votes against.
 	headState := e.Store.GetState(e.Store.Head())
 	if headState == nil || headState.LatestJustified == nil {
 		return

--- a/internal/node/recovery.go
+++ b/internal/node/recovery.go
@@ -48,8 +48,12 @@ func (e *Engine) runRecoveryWorker(ctx context.Context) {
 }
 
 func (e *Engine) recoverBlockProofs(ctx context.Context, signedBlock *types.SignedBlock) {
-	if e.GetSyncStatus() != syncer.SyncSynced || signedBlock == nil ||
-		signedBlock.Block == nil || signedBlock.Block.Body == nil ||
+	// Only a synced aggregator deconstructs blocks: it re-broadcasts the recovered
+	// proofs, while non-aggregators rely on the gossip path. Recovery is skipped while
+	// syncing, when historical blocks flood this path and the justified anchor is still
+	// moving, so recovered votes would not match a live head.
+	if e.AggCtl == nil || !e.AggCtl.Get() || e.GetSyncStatus() != syncer.SyncSynced ||
+		signedBlock == nil || signedBlock.Block == nil || signedBlock.Block.Body == nil ||
 		signedBlock.Proof == nil || len(signedBlock.Proof.Proof) == 0 {
 		return
 	}
@@ -64,6 +68,13 @@ func (e *Engine) recoverBlockProofs(ctx context.Context, signedBlock *types.Sign
 	if state == nil {
 		return
 	}
+	// Filter votes against the head's justified checkpoint: a future block on this head
+	// can only pack votes whose source equals it, so votes with any other source can no
+	// longer advance justification and are not worth recovering.
+	headState := e.Store.GetState(e.Store.Head())
+	if headState == nil || headState.LatestJustified == nil {
+		return
+	}
 	pubkeys, err := e.blockProofPubkeys(block, state)
 	if err != nil {
 		return
@@ -71,33 +82,7 @@ func (e *Engine) recoverBlockProofs(ctx context.Context, signedBlock *types.Sign
 
 	newEntries := e.Store.NewPayloads.Entries()
 	knownEntries := e.Store.KnownPayloads.Entries()
-	justified := e.Store.LatestJustified().Slot
-	candidates := make([]recoveryCandidate, 0, len(block.Body.Attestations))
-	for _, att := range block.Body.Attestations {
-		if att == nil || att.Data == nil || att.Data.Target == nil || att.Data.Target.Slot <= justified {
-			continue
-		}
-		root, err := att.Data.HashTreeRoot()
-		if err != nil {
-			continue
-		}
-		covered := localCoverage(newEntries[root], knownEntries[root])
-		newCount := 0
-		for _, index := range types.BitlistIndices(att.AggregationBits) {
-			if !covered[index] {
-				newCount++
-			}
-		}
-		if newCount > 0 {
-			candidates = append(candidates, recoveryCandidate{att: att, root: root, newCount: newCount})
-		}
-	}
-	sort.SliceStable(candidates, func(i, j int) bool {
-		return candidates[i].newCount > candidates[j].newCount
-	})
-	if len(candidates) > maxRecoverySplits {
-		candidates = candidates[:maxRecoverySplits]
-	}
+	candidates := selectRecoveryCandidates(block.Body.Attestations, headState.LatestJustified, newEntries, knownEntries)
 
 	for _, candidate := range candidates {
 		if ctx.Err() != nil {
@@ -143,7 +128,7 @@ func (e *Engine) recoverBlockProofs(ctx context.Context, signedBlock *types.Sign
 			metrics.IncProofOperation("recovery", "success")
 			metrics.ObserveProofSize("type1", len(proof))
 			e.Store.NewPayloads.Push(candidate.root, candidate.att.Data, recovered)
-			if e.AggCtl != nil && e.AggCtl.Get() && e.P2P != nil {
+			if e.P2P != nil {
 				_ = e.P2P.PublishAggregatedAttestation(ctx, &types.SignedAggregatedAttestation{
 					Data:  candidate.att.Data,
 					Proof: recovered,
@@ -151,6 +136,45 @@ func (e *Engine) recoverBlockProofs(ctx context.Context, signedBlock *types.Sign
 			}
 		}
 	}
+}
+
+// selectRecoveryCandidates picks the block attestations worth splitting back into
+// per-attestation proofs. Only votes whose source equals the head's justified
+// checkpoint can be packed into a future block on this head, so any other source is
+// dropped. Attestations that add no participants beyond the locally-held proofs are
+// skipped, and the rest are ranked by new participants and capped to bound proving work.
+func selectRecoveryCandidates(
+	attestations []*types.AggregatedAttestation,
+	headJustified *types.Checkpoint,
+	newEntries, knownEntries map[[32]byte]*store.PayloadEntry,
+) []recoveryCandidate {
+	candidates := make([]recoveryCandidate, 0, len(attestations))
+	for _, att := range attestations {
+		if att == nil || att.Data == nil || att.Data.Source == nil || *att.Data.Source != *headJustified {
+			continue
+		}
+		root, err := att.Data.HashTreeRoot()
+		if err != nil {
+			continue
+		}
+		covered := localCoverage(newEntries[root], knownEntries[root])
+		newCount := 0
+		for _, index := range types.BitlistIndices(att.AggregationBits) {
+			if !covered[index] {
+				newCount++
+			}
+		}
+		if newCount > 0 {
+			candidates = append(candidates, recoveryCandidate{att: att, root: root, newCount: newCount})
+		}
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return candidates[i].newCount > candidates[j].newCount
+	})
+	if len(candidates) > maxRecoverySplits {
+		candidates = candidates[:maxRecoverySplits]
+	}
+	return candidates
 }
 
 func coversParticipants(proof *types.SingleMessageAggregate, participants []byte) bool {

--- a/internal/node/recovery_test.go
+++ b/internal/node/recovery_test.go
@@ -1,0 +1,115 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/geanlabs/gean/internal/store"
+	"github.com/geanlabs/gean/internal/types"
+)
+
+func aggAttWithSource(source *types.Checkpoint, headTag byte, bits []uint64) *types.AggregatedAttestation {
+	return &types.AggregatedAttestation{
+		AggregationBits: types.BitlistFromIndices(bits),
+		Data: &types.AttestationData{
+			Slot:   10,
+			Head:   &types.Checkpoint{Root: [32]byte{headTag}, Slot: 9},
+			Target: &types.Checkpoint{Root: [32]byte{0x0a}, Slot: 10},
+			Source: source,
+		},
+	}
+}
+
+func noEntries() map[[32]byte]*store.PayloadEntry {
+	return map[[32]byte]*store.PayloadEntry{}
+}
+
+// Only votes whose source equals the head's justified checkpoint are recoverable;
+// any other source (different root, different slot, or nil) is dropped.
+func TestSelectRecoveryCandidatesSourceFilter(t *testing.T) {
+	root := [32]byte{0x33}
+	head := &types.Checkpoint{Root: root, Slot: 3}
+
+	attestations := []*types.AggregatedAttestation{
+		aggAttWithSource(&types.Checkpoint{Root: root, Slot: 3}, 0x01, []uint64{0, 1}),           // match
+		aggAttWithSource(&types.Checkpoint{Root: [32]byte{0x44}, Slot: 3}, 0x02, []uint64{0, 1}), // wrong root
+		aggAttWithSource(&types.Checkpoint{Root: root, Slot: 4}, 0x03, []uint64{0, 1}),           // wrong slot
+		aggAttWithSource(nil, 0x04, []uint64{0, 1}),                                              // nil source
+	}
+
+	candidates := selectRecoveryCandidates(attestations, head, noEntries(), noEntries())
+
+	if len(candidates) != 1 {
+		t.Fatalf("expected 1 candidate matching head justified, got %d", len(candidates))
+	}
+	if *candidates[0].att.Data.Source != *head {
+		t.Fatalf("candidate source %+v != head justified %+v", candidates[0].att.Data.Source, head)
+	}
+}
+
+// An attestation adding no participants beyond the locally-held proofs is skipped.
+func TestSelectRecoveryCandidatesSkipsFullyCovered(t *testing.T) {
+	head := &types.Checkpoint{Root: [32]byte{0x33}, Slot: 3}
+	att := aggAttWithSource(&types.Checkpoint{Root: [32]byte{0x33}, Slot: 3}, 0x01, []uint64{0, 1, 2})
+
+	root, err := att.Data.HashTreeRoot()
+	if err != nil {
+		t.Fatalf("hash tree root: %v", err)
+	}
+	known := map[[32]byte]*store.PayloadEntry{
+		root: {Proofs: []*types.SingleMessageAggregate{
+			{Participants: types.BitlistFromIndices([]uint64{0, 1, 2})},
+		}},
+	}
+
+	candidates := selectRecoveryCandidates([]*types.AggregatedAttestation{att}, head, noEntries(), known)
+	if len(candidates) != 0 {
+		t.Fatalf("expected fully-covered attestation to be skipped, got %d candidates", len(candidates))
+	}
+}
+
+// Candidates are ranked by new participants and capped to maxRecoverySplits to bound
+// proving work.
+func TestSelectRecoveryCandidatesRanksAndCaps(t *testing.T) {
+	head := &types.Checkpoint{Root: [32]byte{0x33}, Slot: 3}
+
+	// Six matching attestations with 1..6 participants each, distinct data roots via
+	// the head tag so none collide in the coverage maps.
+	var attestations []*types.AggregatedAttestation
+	for i := 1; i <= maxRecoverySplits+2; i++ {
+		bits := make([]uint64, i)
+		for j := range bits {
+			bits[j] = uint64(j)
+		}
+		attestations = append(attestations, aggAttWithSource(&types.Checkpoint{Root: [32]byte{0x33}, Slot: 3}, byte(i), bits))
+	}
+
+	candidates := selectRecoveryCandidates(attestations, head, noEntries(), noEntries())
+
+	if len(candidates) != maxRecoverySplits {
+		t.Fatalf("expected cap of %d candidates, got %d", maxRecoverySplits, len(candidates))
+	}
+	for i := 1; i < len(candidates); i++ {
+		if candidates[i-1].newCount < candidates[i].newCount {
+			t.Fatalf("candidates not ranked by new participants: %d before %d",
+				candidates[i-1].newCount, candidates[i].newCount)
+		}
+	}
+	if candidates[0].newCount != maxRecoverySplits+2 {
+		t.Fatalf("expected highest newCount %d first, got %d", maxRecoverySplits+2, candidates[0].newCount)
+	}
+}
+
+// Malformed attestations are dropped without panicking.
+func TestSelectRecoveryCandidatesNilSafe(t *testing.T) {
+	head := &types.Checkpoint{Root: [32]byte{0x33}, Slot: 3}
+	attestations := []*types.AggregatedAttestation{
+		nil,
+		{Data: nil},
+		{Data: &types.AttestationData{Source: nil}},
+	}
+
+	candidates := selectRecoveryCandidates(attestations, head, noEntries(), noEntries())
+	if len(candidates) != 0 {
+		t.Fatalf("expected malformed attestations to be dropped, got %d", len(candidates))
+	}
+}

--- a/internal/spectests/forkchoice_test.go
+++ b/internal/spectests/forkchoice_test.go
@@ -35,6 +35,18 @@ func carriesMockedProof(proof []byte) bool {
 	return bytes.HasPrefix(proof, mockedProofSentinel)
 }
 
+// earliestAdmissibleInterval is the lowest store time at which a slot-N attestation
+// clears ValidateAttestationData's future check: admission allows
+// slot*INTERVALS_PER_SLOT <= time + GOSSIP_DISPARITY_INTERVALS, so the vote is
+// admissible one disparity interval before its slot starts.
+func earliestAdmissibleInterval(slot uint64) uint64 {
+	start := slot * types.IntervalsPerSlot
+	if start < types.GossipDisparityIntervals {
+		return 0
+	}
+	return start - types.GossipDisparityIntervals
+}
+
 type fcTest struct {
 	Network     string   `json:"network"`
 	LeanEnv     string   `json:"leanEnv"`
@@ -147,22 +159,23 @@ type fcAggregatedAttestation struct {
 }
 
 type fcChecks struct {
-	Time                     *uint64              `json:"time,omitempty"`
-	HeadSlot                 *uint64              `json:"headSlot,omitempty"`
-	HeadRoot                 *string              `json:"headRoot,omitempty"`
-	HeadRootLabel            *string              `json:"headRootLabel,omitempty"`
-	LatestJustifiedSlot      *uint64              `json:"latestJustifiedSlot,omitempty"`
-	LatestJustifiedRoot      *string              `json:"latestJustifiedRoot,omitempty"`
-	LatestJustifiedRootLabel *string              `json:"latestJustifiedRootLabel,omitempty"`
-	LatestFinalizedSlot      *uint64              `json:"latestFinalizedSlot,omitempty"`
-	LatestFinalizedRoot      *string              `json:"latestFinalizedRoot,omitempty"`
-	LatestFinalizedRootLabel *string              `json:"latestFinalizedRootLabel,omitempty"`
-	SafeTarget               *string              `json:"safeTarget,omitempty"`
-	SafeTargetSlot           *uint64              `json:"safeTargetSlot,omitempty"`
-	SafeTargetRootLabel      *string              `json:"safeTargetRootLabel,omitempty"`
-	AttestationTargetSlot    *uint64              `json:"attestationTargetSlot,omitempty"`
-	AttestationChecks        []fcAttestationCheck `json:"attestationChecks,omitempty"`
-	LexicographicHeadAmong   []string             `json:"lexicographicHeadAmong,omitempty"`
+	Time                           *uint64              `json:"time,omitempty"`
+	HeadSlot                       *uint64              `json:"headSlot,omitempty"`
+	HeadRoot                       *string              `json:"headRoot,omitempty"`
+	HeadRootLabel                  *string              `json:"headRootLabel,omitempty"`
+	LatestJustifiedSlot            *uint64              `json:"latestJustifiedSlot,omitempty"`
+	LatestJustifiedRoot            *string              `json:"latestJustifiedRoot,omitempty"`
+	LatestJustifiedRootLabel       *string              `json:"latestJustifiedRootLabel,omitempty"`
+	LatestFinalizedSlot            *uint64              `json:"latestFinalizedSlot,omitempty"`
+	LatestFinalizedRoot            *string              `json:"latestFinalizedRoot,omitempty"`
+	LatestFinalizedRootLabel       *string              `json:"latestFinalizedRootLabel,omitempty"`
+	SafeTarget                     *string              `json:"safeTarget,omitempty"`
+	SafeTargetSlot                 *uint64              `json:"safeTargetSlot,omitempty"`
+	SafeTargetRootLabel            *string              `json:"safeTargetRootLabel,omitempty"`
+	AttestationTargetSlot          *uint64              `json:"attestationTargetSlot,omitempty"`
+	AttestationChecks              []fcAttestationCheck `json:"attestationChecks,omitempty"`
+	LexicographicHeadAmong         []string             `json:"lexicographicHeadAmong,omitempty"`
+	CanonicalEquivocationHeadAmong []string             `json:"canonicalEquivocationHeadAmong,omitempty"`
 }
 
 // fcAttestationCheck mirrors the spec's per-validator attestation-state
@@ -524,13 +537,14 @@ func runForkChoiceTest(t *testing.T, tt *fcTest) {
 				Source: &types.Checkpoint{Root: parseHexRoot(att.Data.Source.Root), Slot: att.Data.Source.Slot},
 			}
 
-			// For valid steps, advance time so attestation passes the future check.
-			// Invalid steps keep current time so the time-bound branch of
-			// ValidateAttestationData fires as expected on fixtures designed to
-			// exercise that rejection path.
+			// For valid steps, advance time just enough for the attestation to clear
+			// the future-admission check. Stop at the earliest admissible interval
+			// (one gossip-disparity interval before the vote's slot start), never at
+			// the slot start itself: landing there would coincide with a following
+			// tick's target and swallow that tick's promotion. Invalid steps keep the
+			// current time so the rejection path still fires.
 			if step.Valid {
-				minTime := attData.Slot * types.IntervalsPerSlot
-				if s.Time() < minTime {
+				if minTime := earliestAdmissibleInterval(attData.Slot); s.Time() < minTime {
 					s.SetTime(minTime)
 				}
 			}
@@ -602,11 +616,11 @@ func runForkChoiceTest(t *testing.T, tt *fcTest) {
 				Source: &types.Checkpoint{Root: parseHexRoot(att.Data.Source.Root), Slot: att.Data.Source.Slot},
 			}
 
-			// For valid steps, advance time so attestation passes the future check.
-			// Invalid steps keep current time to exercise the time-bound branch.
+			// Advance only to the earliest admissible interval (see the individual
+			// attestation case): stopping short of the vote's slot start keeps a later
+			// tick's promotion from being skipped. Invalid steps keep the current time.
 			if step.Valid {
-				minTime := attData.Slot * types.IntervalsPerSlot
-				if s.Time() < minTime {
+				if minTime := earliestAdmissibleInterval(attData.Slot); s.Time() < minTime {
 					s.SetTime(minTime)
 				}
 			}
@@ -669,40 +683,52 @@ func runForkChoiceTest(t *testing.T, tt *fcTest) {
 
 		case "tick":
 			// step.Time is wall-clock seconds since the UNIX epoch; step.Interval
-			// is a raw interval count. Convert seconds to intervals before storing
-			// so subsequent assertions on store.time match the simulator's
-			// checks.time field.
+			// is a raw interval count. Convert to a target interval count.
+			var target uint64
 			switch {
 			case step.Time != nil:
 				genesisMs := s.Config().GenesisTime * 1000
 				timestampMs := *step.Time * 1000
-				if timestampMs < genesisMs {
-					s.SetTime(0)
-				} else {
-					s.SetTime((timestampMs - genesisMs) / types.MillisecondsPerInterval)
+				if timestampMs >= genesisMs {
+					target = (timestampMs - genesisMs) / types.MillisecondsPerInterval
 				}
 			case step.Interval != nil:
-				s.SetTime(*step.Interval)
+				target = *step.Interval
 			default:
 				t.Fatalf("step %d: tick step without time or interval", i)
 			}
 
-			// Mirror the interval responsibilities Engine.onTick drives in the
-			// running node. Promotion of the new-vote pool into the known pool is
-			// what flips the head onto freshly gossiped votes, and it only happens
-			// at the slot boundary: interval 4 always, interval 0 when this slot is
-			// ours to propose. The head is then recomputed at interval 0/4.
-			interval := s.Time() % types.IntervalsPerSlot
+			// Advance one interval at a time, mirroring leanSpec on_tick. Stepping is
+			// load-bearing: jumping straight to the target would skip the intervening
+			// slot-boundary intervals whose actions promote the new-vote pool into the
+			// known pool and recompute the head. Promotion happens at interval 4 always,
+			// and at interval 0 when a proposal has landed — the latter only on the final
+			// interval, matching the spec's should_signal_proposal gate.
 			hasProposal := step.HasProposal != nil && *step.HasProposal
-			if interval == 4 || (interval == 0 && hasProposal) {
-				s.PromoteNewToKnown()
-			}
-			if interval == 0 || interval == 4 {
-				knownAtts := s.ExtractLatestKnownAttestations()
-				for vid, data := range knownAtts {
-					fc.SetKnownVote(vid, data.Head.Root, data.Slot, data)
+			for s.Time() < target {
+				next := s.Time() + 1
+				s.SetTime(next)
+				interval := next % types.IntervalsPerSlot
+				signalProposal := hasProposal && next == target
+				if interval == 4 || (interval == 0 && signalProposal) {
+					s.PromoteNewToKnown()
 				}
-				simulateUpdateHead(s, fc, s.LatestJustified().Root)
+				if interval == 0 || interval == 4 {
+					knownAtts := s.ExtractLatestKnownAttestations()
+					for vid, data := range knownAtts {
+						fc.SetKnownVote(vid, data.Head.Root, data.Slot, data)
+					}
+					simulateUpdateHead(s, fc, s.LatestJustified().Root)
+				}
+			}
+			// A tick to at or behind the clock still pins store.time so a later
+			// time check reads the fixture's value.
+			if target < s.Time() {
+				s.SetTime(target)
+			}
+
+			if step.Checks != nil {
+				validateChecks(t, i, step.Checks, s, fc, labelRoots)
 			}
 
 		default:
@@ -838,8 +864,75 @@ func validateChecks(t *testing.T, stepIdx int, checks *fcChecks, s *store.Consen
 		}
 	}
 
+	if len(checks.CanonicalEquivocationHeadAmong) > 0 {
+		validateCanonicalEquivocationHead(t, stepIdx, checks.CanonicalEquivocationHeadAmong, s, headRoot, labelRoots)
+	}
+
 	for _, ac := range checks.AttestationChecks {
 		validateAttestationCheck(t, stepIdx, s, fc, ac)
+	}
+}
+
+// validateCanonicalEquivocationHead mirrors leanSpec _validate_canonical_equivocation_head:
+// the equal-slot equivocation tie breaks toward the fork carrying the largest
+// attestation-data root, read from the accepted aggregated pool rather than hardcoded,
+// so the assertion is independent of the signature scheme (roots embed validator keys).
+func validateCanonicalEquivocationHead(t *testing.T, stepIdx int, forkLabels []string, s *store.ConsensusStore, headRoot [32]byte, labelRoots map[string][32]byte) {
+	t.Helper()
+	if len(forkLabels) < 2 {
+		t.Fatalf("step %d check: canonicalEquivocationHeadAmong needs >=2 forks, got %v", stepIdx, forkLabels)
+	}
+
+	forkRoots := make(map[string][32]byte, len(forkLabels))
+	for _, label := range forkLabels {
+		root, ok := labelRoots[label]
+		if !ok {
+			t.Fatalf("step %d check: canonicalEquivocationHeadAmong label %q not in block registry", stepIdx, label)
+		}
+		forkRoots[label] = root
+	}
+
+	// Largest attestation-data root per fork — the key ExtractLatestAttestations sorts on.
+	// Scan the whole accepted aggregated pool (new + promoted): a tick check may run
+	// before the slot-boundary promotion moves votes from the new pool into the known one.
+	maxAttRoot := make(map[string][32]byte, len(forkLabels))
+	scan := func(entries map[[32]byte]*store.PayloadEntry) {
+		for _, entry := range entries {
+			if entry.Data == nil || entry.Data.Target == nil {
+				continue
+			}
+			dataRoot, err := entry.Data.HashTreeRoot()
+			if err != nil {
+				t.Fatalf("step %d check: attestation-data root: %v", stepIdx, err)
+			}
+			for label, forkRoot := range forkRoots {
+				if entry.Data.Target.Root != forkRoot {
+					continue
+				}
+				if cur, seen := maxAttRoot[label]; !seen || bytes.Compare(dataRoot[:], cur[:]) > 0 {
+					maxAttRoot[label] = dataRoot
+				}
+			}
+		}
+	}
+	scan(s.NewPayloads.Entries())
+	scan(s.KnownPayloads.Entries())
+
+	var winner string
+	var winnerRoot [32]byte
+	for _, label := range forkLabels {
+		root, ok := maxAttRoot[label]
+		if !ok {
+			t.Fatalf("step %d check: canonicalEquivocationHeadAmong fork %q has no attestation targeting it in the accepted aggregated pool", stepIdx, label)
+		}
+		if winner == "" || bytes.Compare(root[:], winnerRoot[:]) > 0 {
+			winner, winnerRoot = label, root
+		}
+	}
+
+	if headRoot != forkRoots[winner] {
+		t.Fatalf("step %d check: canonical equivocation tiebreak: head 0x%x, want fork %q 0x%x (largest attestation-data root)",
+			stepIdx, headRoot, winner, forkRoots[winner])
 	}
 }
 

--- a/internal/store/payloads_test.go
+++ b/internal/store/payloads_test.go
@@ -32,6 +32,41 @@ func TestPayloadBufferPushAndExtract(t *testing.T) {
 	}
 }
 
+// An equivocator can cast two distinct votes at one slot. Resolving that tie by the
+// larger canonical data root (leanSpec #1181) must make the extracted LMD view a pure
+// function of the pool, independent of insertion order, so every node runs fork choice
+// on the same set.
+func TestPayloadBufferEqualSlotTieKeepsLargerDataRoot(t *testing.T) {
+	small := [32]byte{0x01}
+	large := [32]byte{0x02}
+	smallData := &types.AttestationData{Slot: 7, Head: &types.Checkpoint{Root: small, Slot: 6}}
+	largeData := &types.AttestationData{Slot: 7, Head: &types.Checkpoint{Root: large, Slot: 6}}
+	bits := types.BitlistFromIndices([]uint64{0})
+
+	for _, largeFirst := range []bool{false, true} {
+		pb := store.NewPayloadBuffer(10)
+		push := func(root [32]byte, d *types.AttestationData) {
+			pb.Push(root, d, &types.SingleMessageAggregate{Participants: bits, Proof: []byte{0x01}})
+		}
+		if largeFirst {
+			push(large, largeData)
+			push(small, smallData)
+		} else {
+			push(small, smallData)
+			push(large, largeData)
+		}
+
+		got := pb.ExtractLatestAttestations()[0]
+		if got == nil {
+			t.Fatalf("largeFirst=%v: validator 0 has no extracted vote", largeFirst)
+		}
+		if got.Head.Root != large {
+			t.Fatalf("largeFirst=%v: kept vote with head 0x%x, want larger-root vote 0x%x",
+				largeFirst, got.Head.Root[:2], large[:2])
+		}
+	}
+}
+
 func TestPayloadBufferDataOnlyHasNoWeight(t *testing.T) {
 	pb := store.NewPayloadBuffer(10)
 	root := [32]byte{1}


### PR DESCRIPTION
## Summary

Mirrors leanSpec **Smart block deconstruction (#1170)** and bumps the spec pin to `eca701e`.

The recovery worker (`internal/node/recovery.go`) splits an imported block's aggregated (Type-2) attestations back into per-attestation (Type-1) proofs for aggregators to re-broadcast. Two behaviors drifted from the updated spec:

1. **Source-based vote filter.** A future block on a given head can only pack votes whose `source` equals that head's justified checkpoint; any other source can no longer advance justification. Recovery now selects votes by `att.Data.Source == headState.LatestJustified` (read from the just-imported block's head post-state), replacing the older `target.slot <= latest_justified.slot` proxy that kept stale-source votes and read the store-global justified checkpoint rather than this head's.
2. **Gate deconstruction on a synced aggregator.** The whole deconstruction now short-circuits unless the node is an aggregator *and* synced, so non-aggregators no longer spend XMSS proving on proofs they never re-broadcast. The now-redundant aggregator check at the publish site is dropped.

The pure candidate-selection logic is extracted into `selectRecoveryCandidates` and covered by table-driven tests.

## Spec mapping

- `src/lean_spec/node/sync/service.py` — `process_block` gate (`is_aggregator and state == SYNCED`) and `_deconstruct_block_into_store` source filter (leanSpec #1170).
- Pin bump `8b4ebbea` → `eca701e` also picks up #1189 (scheme-independent equivocation fixtures), which requires no gean code change — it only documents the equal-slot canonical-root tie already implemented here (#1181 / `ExtractLatestAttestations`).

## Testing

- `go test ./internal/node/` — green, incl. new `recovery_test.go` (source filter keep/drop, fully-covered skip, rank-and-cap, nil-safety).
- `go build ./...`, `go vet`, `gofmt` — clean.
- `make test-spec` at `eca701e`: prod-scheme fixture generation regenerates fully green (554 passed), including the equivocation vectors that previously failed under `--scheme=prod` at `8b4ebbea` (now fixed by #1189).

## Notes

- The recovery change is node-runtime behavior with no spec-fixture coverage; correctness is exercised by the unit tests.
- Pin bump is split into its own commit.
