### PR TITLE
Perf/protoarray prune slot order

### DIFF
--- a/internal/forkchoice/forkchoice_test.go
+++ b/internal/forkchoice/forkchoice_test.go
@@ -404,6 +404,86 @@ func TestProtoArrayPrune(t *testing.T) {
 	}
 }
 
+// buildLinearChain inserts a linear chain (node k = root(k+1) at slot k, parent
+// root(k), anchored at root(1)). reverse=true inserts children before parents, so
+// orphan linking leaves interior nodes with a parent at a higher array index — the
+// reverse-topological ordering that made the old fixed-point Prune O(N^2).
+func buildLinearChain(depth int, reverse bool) *ForkChoice {
+	fc := New(0, root(1), [32]byte{})
+	insertK := func(k int) {
+		parent := root(1)
+		if k > 1 {
+			parent = root(byte(k))
+		}
+		fc.OnBlock(uint64(k), root(byte(k+1)), parent)
+	}
+	if reverse {
+		for k := depth; k >= 1; k-- {
+			insertK(k)
+		}
+		return fc
+	}
+	for k := 1; k <= depth; k++ {
+		insertK(k)
+	}
+	return fc
+}
+
+func countParentBackEdges(pa *ProtoArray) int {
+	n := 0
+	for i, node := range pa.nodes {
+		if node.Parent > i {
+			n++
+		}
+	}
+	return n
+}
+
+// Prune must depend only on the tree, not on block arrival order: a chain built
+// child-first (heavy parent back-edges) must prune to the exact same layout as the
+// same chain built parent-first.
+func TestPruneIndependentOfArrivalOrder(t *testing.T) {
+	const depth = 10
+	const finalizedAt = 4 // keep nodes 4..10, i.e. root(5)..root(11)
+	finalizedRoot := root(byte(finalizedAt + 1))
+
+	forward := buildLinearChain(depth, false)
+	reverse := buildLinearChain(depth, true)
+
+	// The two orderings must genuinely differ, or the test proves nothing.
+	if got := countParentBackEdges(forward.array); got != 0 {
+		t.Fatalf("forward chain should be topologically ordered, got %d back-edges", got)
+	}
+	if countParentBackEdges(reverse.array) == 0 {
+		t.Fatal("reverse chain should have parent back-edges to exercise the O(N^2) path")
+	}
+
+	forward.Prune(finalizedRoot)
+	reverse.Prune(finalizedRoot)
+
+	fwd, rev := forward.array.Nodes(), reverse.array.Nodes()
+	if len(fwd) != depth-finalizedAt+1 {
+		t.Fatalf("kept %d nodes, want %d", len(fwd), depth-finalizedAt+1)
+	}
+	if len(fwd) != len(rev) {
+		t.Fatalf("forward kept %d nodes, reverse kept %d", len(fwd), len(rev))
+	}
+	for i := range fwd {
+		if fwd[i].Root != rev[i].Root || fwd[i].Parent != rev[i].Parent {
+			t.Fatalf("node %d differs: forward{root=%x parent=%d} reverse{root=%x parent=%d}",
+				i, fwd[i].Root[:1], fwd[i].Parent, rev[i].Root[:1], rev[i].Parent)
+		}
+	}
+
+	// The finalized root anchors the pruned array; pre-finalized nodes are gone.
+	if idx := forward.NodeIndex(finalizedRoot); idx != 0 {
+		t.Fatalf("finalized root index=%d, want 0", idx)
+	}
+	if forward.NodeIndex(root(byte(finalizedAt))) != -1 {
+		t.Fatal("pre-finalized node should be pruned")
+	}
+}
+
 func TestCanonicalAnalysisSeparatesFinalizedForks(t *testing.T) {
 	anchor, a, b, c, forkBefore, forkAfter := root(1), root(2), root(3), root(4), root(5), root(6)
 	fc := New(0, anchor, [32]byte{})

--- a/internal/forkchoice/protoarray.go
+++ b/internal/forkchoice/protoarray.go
@@ -173,6 +173,21 @@ func (pa *ProtoArray) descendingSlotOrder() []int {
 	return order
 }
 
+func (pa *ProtoArray) ascendingSlotOrder() []int {
+	order := make([]int, len(pa.nodes))
+	for i := range order {
+		order[i] = i
+	}
+	sort.SliceStable(order, func(i, j int) bool {
+		left, right := pa.nodes[order[i]], pa.nodes[order[j]]
+		if left.Slot != right.Slot {
+			return left.Slot < right.Slot
+		}
+		return order[i] < order[j]
+	})
+	return order
+}
+
 func (pa *ProtoArray) FindHead(justifiedRoot [32]byte) [32]byte {
 	if pa == nil {
 		return justifiedRoot
@@ -197,34 +212,23 @@ func (pa *ProtoArray) Prune(finalizedRoot [32]byte) map[int]int {
 		return nil
 	}
 
+	// Ascending-slot order is a topological order of the parent forest: every parent
+	// edge is strictly slot-increasing (OnBlock and linkOrphanChildren reject a child
+	// whose slot is not above its parent's), so a node's parent is always visited first.
+	// One pass then keeps exactly the finalized subtree — pre-finalized ancestors, sibling
+	// forks, and unlinked orphans fall out. Iterating in this order also leaves kept sorted,
+	// so no separate sort is needed. This replaces a fixed-point iteration that degraded to
+	// O(N^2) when out-of-order arrivals placed a child ahead of its parent in the array.
+	order := pa.ascendingSlotOrder()
 	keep := make([]bool, len(pa.nodes))
-	keep[finalizedIdx] = true
-	for changed := true; changed; {
-		changed = false
-		for i, node := range pa.nodes {
-			if keep[i] || node.Parent < 0 || node.Parent >= len(pa.nodes) {
-				continue
-			}
-			if keep[node.Parent] {
-				keep[i] = true
-				changed = true
-			}
-		}
-	}
-
 	kept := make([]int, 0, len(pa.nodes)-finalizedIdx)
-	for i, keepNode := range keep {
-		if keepNode {
+	for _, i := range order {
+		parent := pa.nodes[i].Parent
+		if i == finalizedIdx || (parent >= 0 && parent < len(pa.nodes) && keep[parent]) {
+			keep[i] = true
 			kept = append(kept, i)
 		}
 	}
-	sort.SliceStable(kept, func(i, j int) bool {
-		left, right := pa.nodes[kept[i]], pa.nodes[kept[j]]
-		if left.Slot != right.Slot {
-			return left.Slot < right.Slot
-		}
-		return kept[i] < kept[j]
-	})
 
 	indexMap := make(map[int]int, len(kept))
 	newNodes := make([]ProtoNode, 0, len(kept))


### PR DESCRIPTION
## Summary

Fixes the O(N²) worst-case in `ProtoArray.Prune()` reported in #368, using a single slot-ordered pass instead of the issue's proposed children-index + BFS.

`Prune` determined the finalized subtree with a fixed-point iteration that repeated full passes until nothing changed. When out-of-order block arrivals place a child ahead of its parent in the array — orphan linking (`linkOrphanChildren`) back-links the parent at a *higher* index — each pass advanced reachability by only one level, so a reverse-ordered chain of depth D took D passes → **O(N²)**. On the tick loop, a large proto-array (e.g. accumulated during a finalization stall) would make this a visible stall.

## Approach

Every parent edge in the proto-array is **strictly slot-increasing** — `OnBlock` and `linkOrphanChildren` both reject a child whose slot is not above its parent's. So **ascending-slot order is a topological order of the parent forest**, and a single pass over it marks the finalized subtree correctly (parents are always visited before children). That pass also leaves the kept set slot-sorted, so the previous separate sort is dropped.

This deliberately reuses the existing slot-monotonic invariant rather than adding a maintained `Children` index (the approach suggested in #368) — **O(N log N) with zero new per-block bookkeeping**, and a net reduction in code.

## Behavior preservation

The computed `keep` set and its ordering (ascending slot, original-index tiebreak) are identical to the old loop+sort for every input, so the pruned array layout, `indexMap`, and vote-index remap are byte-for-byte unchanged. This is a complexity fix only — no semantic change, so fork-choice spec fixtures are unaffected.

## Testing

- Full `internal/forkchoice` suite passes unchanged, including `TestPruneReparentedOrphanKeepsDescendantAndRemapsVote` and the vote-remap tests.
- New `TestPruneIndependentOfArrivalOrder`: builds the same chain parent-first vs fully child-first, asserts the reverse build actually carries parent back-edges (so the pathological ordering is exercised), prunes both, and asserts identical pruned layout + correct kept set and anchor.
- `go build ./...`, `go vet`, `gofmt`, and `internal/node` consumer tests all green.

Empirically (throwaway benchmark, since removed): forward/parent-first prune stayed ~linear (~0.27ms at N=4000) while the old reverse-ordered prune scaled quadratically (~54ms at N=4000, ~4× per doubling). The new pass keeps both linear-ish.

Refs #368.
