### PR TITLE
fix: attestation target clamp + sync fetch dedup (interop stall recovery)

### DIFF
--- a/internal/attestation/produce.go
+++ b/internal/attestation/produce.go
@@ -32,9 +32,13 @@ func ProduceAttestationData(s *store.ConsensusStore, slot uint64) *types.Attesta
 	if types.IsZeroRoot(source.Root) {
 		source.Root = headRoot
 	}
+	// The target walk is bounded by the store's safe target, which can momentarily lag
+	// the head state's justified checkpoint while the node catches up on imports. When it
+	// does, the walk stops below the source; clamp the target up to the source so the vote
+	// stays valid (source <= target, the spec's produce_attestation_data invariant) rather
+	// than dropping the attestation and starving fork choice of the head vote.
 	if source.Slot > target.Slot {
-		logger.Error(logger.Chain, "ProduceAttestation: source slot %d exceeds target slot %d", source.Slot, target.Slot)
-		return nil
+		target = &types.Checkpoint{Root: source.Root, Slot: source.Slot}
 	}
 
 	logger.Info(logger.Chain, "ProduceAttestation: slot=%d head=0x%x source=0x%x/%d target=0x%x/%d",

--- a/internal/attestation/produce_test.go
+++ b/internal/attestation/produce_test.go
@@ -114,3 +114,42 @@ func TestProduceAttestationDataNormalSource(t *testing.T) {
 		t.Fatalf("head root = %x, want %x", data.Head.Root, head)
 	}
 }
+
+// During catch-up the store's safe target can lag the head state's justified
+// checkpoint, so the target walk stops below the source. The vote must clamp its
+// target up to the source (keeping source <= target) rather than being dropped —
+// dropping it starves fork choice of the head vote exactly when the node is behind.
+func TestProduceAttestationDataClampsTargetToSource(t *testing.T) {
+	s := makeValidationStore()
+	head := [32]byte{0xAA}
+	parent := [32]byte{0xBB}
+
+	s.SetHead(head)
+	// Safe target lags at slot 5, so the target walk cannot climb above it.
+	s.SetSafeTarget(parent)
+	s.SetLatestJustified(&types.Checkpoint{Root: parent, Slot: 5})
+	s.SetLatestFinalized(&types.Checkpoint{Slot: 0})
+	s.InsertBlockHeader(head, &types.BlockHeader{Slot: 6, ParentRoot: parent})
+	s.InsertBlockHeader(parent, &types.BlockHeader{Slot: 5})
+	// Head state's justified sits at the head slot (6) — ahead of the slot-5 target
+	// the walk can reach.
+	s.InsertState(head, &types.State{
+		Config:                   &types.ChainConfig{GenesisTime: 1000},
+		LatestBlockHeader:        &types.BlockHeader{Slot: 6},
+		LatestJustified:          &types.Checkpoint{Root: head, Slot: 6},
+		LatestFinalized:          &types.Checkpoint{Slot: 0},
+		JustifiedSlots:           types.NewBitlistSSZ(0),
+		JustificationsValidators: types.NewBitlistSSZ(0),
+	})
+
+	data := attestation.ProduceAttestationData(s, 7)
+	if data == nil {
+		t.Fatal("expected clamped attestation data, got nil — the vote was dropped")
+	}
+	if data.Source.Slot > data.Target.Slot {
+		t.Fatalf("invariant violated: source slot %d > target slot %d", data.Source.Slot, data.Target.Slot)
+	}
+	if data.Target.Root != head || data.Target.Slot != 6 {
+		t.Fatalf("target = %x/%d, want clamped to source %x/6", data.Target.Root, data.Target.Slot, head)
+	}
+}

--- a/internal/node/engine.go
+++ b/internal/node/engine.go
@@ -57,6 +57,11 @@ type Engine struct {
 	lastTick time.Time
 
 	warnedMissingJustified [32]byte
+
+	// fetchInFlight tracks block roots already queued for by-root fetch so a single
+	// missing parent cannot flood FetchRootCh with duplicate requests. Accessed only
+	// on the dispatch loop (queue on onBlock, clear on receive/exhaustion), so no lock.
+	fetchInFlight map[[32]byte]bool
 }
 
 func New(
@@ -90,6 +95,7 @@ func New(
 		ProposalResultCh:      make(chan *proposalResult, 1),
 		RecoveryCh:            make(chan *types.SignedBlock, 8),
 		ProvingGate:           proving.NewGate(),
+		fetchInFlight:         make(map[[32]byte]bool),
 	}
 	e.configureP2PHooks()
 	return e

--- a/internal/node/fetch.go
+++ b/internal/node/fetch.go
@@ -68,9 +68,17 @@ func (e *Engine) queueMissingBlockFetch(root [32]byte) {
 	if e.P2P == nil {
 		return
 	}
-	logger.Info(logger.Sync, "queueing missing block block_root=0x%x for batched fetch", root)
+	// A missing parent is re-derived on every child that arrives referencing it, so the
+	// same root would otherwise be queued hundreds of times and saturate FetchRootCh with
+	// duplicates — starving the fetch and freezing the head while far behind. Queue each
+	// root at most once until its block is received or its fetch is exhausted.
+	if e.fetchInFlight[root] {
+		return
+	}
 	select {
 	case e.FetchRootCh <- root:
+		e.fetchInFlight[root] = true
+		logger.Info(logger.Sync, "queueing missing block block_root=0x%x for batched fetch", root)
 	default:
 		logger.Warn(logger.Sync, "fetch root channel full, dropping request for 0x%x", root)
 	}

--- a/internal/node/fetch_test.go
+++ b/internal/node/fetch_test.go
@@ -1,0 +1,65 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/geanlabs/gean/internal/p2p"
+	"github.com/geanlabs/gean/internal/types"
+)
+
+// A missing parent is re-derived on every child that references it, so without dedup the
+// same root floods FetchRootCh and starves the fetch. Each root must be queued at most
+// once until its block is received or its fetch is exhausted.
+func TestQueueMissingBlockFetchDedupes(t *testing.T) {
+	e := makeTestEngine()
+	e.P2P = &p2p.Host{} // non-nil so the fetch path runs; queueMissingBlockFetch calls no P2P method
+
+	var root [32]byte
+	root[0] = 0x77
+
+	for i := 0; i < 10; i++ {
+		e.queueMissingBlockFetch(root)
+	}
+	if got := len(e.FetchRootCh); got != 1 {
+		t.Fatalf("FetchRootCh has %d requests after 10 queues, want 1 (deduped)", got)
+	}
+	if !e.fetchInFlight[root] {
+		t.Fatal("queued root should be marked in-flight")
+	}
+
+	// Exhausting the fetch clears the marker so a later gap can re-request the root.
+	e.onFailedRoot(root)
+	if e.fetchInFlight[root] {
+		t.Fatal("onFailedRoot should clear the in-flight marker")
+	}
+	<-e.FetchRootCh // drain the first request so the channel has room
+	e.queueMissingBlockFetch(root)
+	if got := len(e.FetchRootCh); got != 1 {
+		t.Fatalf("re-queue after exhaustion: FetchRootCh has %d, want 1", got)
+	}
+}
+
+// Receiving the block for a queued root clears its in-flight marker regardless of whether
+// it imports or gets buffered — we hold it now, so there is nothing left to fetch.
+func TestProcessOneBlockClearsFetchMarker(t *testing.T) {
+	e := makeTestEngine()
+
+	var parentRoot [32]byte
+	parentRoot[0] = 0x99 // unknown parent → the block will be buffered, not imported
+	signed := &types.SignedBlock{
+		Block: &types.Block{Slot: 5, ParentRoot: parentRoot, Body: &types.BlockBody{}},
+		Proof: &types.MultiMessageAggregate{},
+	}
+	blockRoot, err := signed.Block.HashTreeRoot()
+	if err != nil {
+		t.Fatalf("block root: %v", err)
+	}
+	e.fetchInFlight[blockRoot] = true
+
+	var queue []*types.SignedBlock
+	e.processOneBlock(signed, &queue)
+
+	if e.fetchInFlight[blockRoot] {
+		t.Fatal("receiving the block should clear its fetch marker")
+	}
+}

--- a/internal/node/import.go
+++ b/internal/node/import.go
@@ -33,6 +33,10 @@ func (e *Engine) processOneBlock(signedBlock *types.SignedBlock, queue *[]*types
 	}
 	parentRoot := block.ParentRoot
 
+	// We now hold this block (whether it imports or gets buffered), so any pending by-root
+	// fetch for it is done — drop the in-flight marker so a future gap can re-request it.
+	delete(e.fetchInFlight, blockRoot)
+
 	if e.Store.HasState(blockRoot) {
 		return
 	}

--- a/internal/node/pending.go
+++ b/internal/node/pending.go
@@ -105,6 +105,10 @@ func (e *Engine) discardFinalizedPending(finalizedSlot uint64) {
 }
 
 func (e *Engine) onFailedRoot(failedRoot [32]byte) {
+	// The fetch for this root is exhausted; drop its in-flight marker so it can be
+	// re-requested if a later child reintroduces the gap.
+	delete(e.fetchInFlight, failedRoot)
+
 	children, ok := e.Pending.RemoveBucket(failedRoot)
 	if !ok {
 		return


### PR DESCRIPTION
Two related fixes from the 2026-07-14 multi-client PQ interop investigation (temporary network-wide finalization stalls that self-heal — the pattern Partha raised on last week's interop call). Both are gean-specific defects that made gean recover slower/worse than peers.

## 1. Attestation: clamp target to source instead of dropping the vote

gean sources the vote from the head state's justified checkpoint (per spec), but the target walk is bounded by the store's safe target, which can lag that checkpoint during catch-up — so the walk stops below the source. gean logged `ERROR ProduceAttestation: source slot N exceeds target slot N` and returned `nil`, dropping the attestation (and the head vote from fork choice) exactly when behind.

Now it clamps the target up to the source, keeping the spec's `produce_attestation_data` invariant (`source <= target`) — matching how ethlambda handles the same lag (clamp, don't error).

## 2. Sync: dedup in-flight by-root fetches

A missing parent is re-derived on every buffered child referencing it, and each derivation re-queued the same root onto `FetchRootCh` (cap 256). In the run, one missing block was queued **2300+ times**, saturating the channel (2100+ drops) and starving the fetch — gean's head **froze for ~26 minutes**, then recovered in a burst while peers kept following.

Now each root is queued at most once until its block is received or its fetch is exhausted. Touched only on the dispatch loop, so no lock.

## Testing

- New `TestProduceAttestationDataClampsTargetToSource`, `TestQueueMissingBlockFetchDedupes`, `TestProcessOneBlockClearsFetchMarker`.
- `internal/attestation`, `internal/node`, and related consensus unit tests green.

## Out of scope

- The **network-wide aggregation-vs-slot-budget ceiling** (the actual cause of the finalization stalls) — tracked in #371.
- The **XMSS aggregation prover crash** (#377) is **upstream** in `lean-multisig` / leanEthereum/leanVM (`xmss_aggregate.py:merkle_p24_one_level`), which gean already panic-guards; not fixable in this repo.

Closes #378.
