### PR TITLE
fix(sync): stop a lagging node from being marooned on its own fork

### DIFF
--- a/internal/node/duties.go
+++ b/internal/node/duties.go
@@ -16,7 +16,7 @@ func (e *Engine) produceAttestations(slot uint64) {
 		return
 	}
 
-	if e.DutyGate != nil && !e.DutyGate.Decide("attestation", slot, e.Store.HeadSlot(), e.Store.MaxStoredBlockSlot()) {
+	if e.DutyGate != nil && !e.DutyGate.Decide("attestation", slot, e.Store.HeadSlot(), e.networkSeenSlot()) {
 		metrics.IncAttestationsSkippedLag()
 		return
 	}

--- a/internal/node/engine.go
+++ b/internal/node/engine.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/geanlabs/gean/internal/aggregation"
@@ -57,6 +58,11 @@ type Engine struct {
 	lastTick time.Time
 
 	warnedMissingJustified [32]byte
+
+	// maxSeenGossipSlot is the highest plausible slot heard on gossip, whether
+	// or not the block was admitted. Written from the p2p goroutine, read on
+	// the tick loop by the duty gate.
+	maxSeenGossipSlot atomic.Uint64
 
 	// fetchInFlight tracks block roots already queued for by-root fetch so a single
 	// missing parent cannot flood FetchRootCh with duplicate requests. Accessed only

--- a/internal/node/engine.go
+++ b/internal/node/engine.go
@@ -75,17 +75,20 @@ func New(
 ) *Engine {
 	p2p.SetClientGitCommit(gitCommit)
 	e := &Engine{
-		Store:                 s,
-		FC:                    fc,
-		P2P:                   p2pHost,
-		Keys:                  keys,
-		AggCtl:                aggCtl,
-		DutyGate:              dutygate.New(logDutyGateEvent),
-		CommitteeCount:        committeeCount,
-		Shadow:                shadowRates,
-		Pending:               pending.NewBlockBuffer(),
-		PendingAttestations:   pending.NewAttestationBuffer(PendingAttestationsPerRootCap, PendingAttestationsTotalCap),
-		BlockCh:               make(chan *types.SignedBlock, 64),
+		Store:               s,
+		FC:                  fc,
+		P2P:                 p2pHost,
+		Keys:                keys,
+		AggCtl:              aggCtl,
+		DutyGate:            dutygate.New(logDutyGateEvent),
+		CommitteeCount:      committeeCount,
+		Shadow:              shadowRates,
+		Pending:             pending.NewBlockBuffer(),
+		PendingAttestations: pending.NewAttestationBuffer(PendingAttestationsPerRootCap, PendingAttestationsTotalCap),
+		// Sized so gossip keeps flowing while the dispatch loop chews through a
+		// fetched batch: sync delivery blocks when full, but gossip drops, and a
+		// large import burst can take minutes of XMSS verification.
+		BlockCh:               make(chan *types.SignedBlock, 256),
 		AttestationCh:         make(chan *types.SignedAttestation, 256),
 		AggregationCh:         make(chan *types.SignedAggregatedAttestation, 64),
 		FailedRootCh:          make(chan [32]byte, 64),

--- a/internal/node/events.go
+++ b/internal/node/events.go
@@ -1,6 +1,8 @@
 package node
 
 import (
+	"context"
+
 	"github.com/geanlabs/gean/internal/logger"
 	"github.com/geanlabs/gean/internal/types"
 )
@@ -10,6 +12,20 @@ func (e *Engine) OnBlock(block *types.SignedBlock) {
 	case e.BlockCh <- block:
 	default:
 		logger.Warn(logger.Chain, "block channel full, dropping")
+	}
+}
+
+// OnSyncBlock delivers a block this node itself requested (range backfill or
+// by-root parent fetch). Unlike gossip delivery it blocks until the dispatch
+// loop accepts the block: a requested block dropped on the floor is a gap the
+// requester believes it already covered, so it is never re-requested and the
+// chain can no longer connect. Returns false only if ctx ends first.
+func (e *Engine) OnSyncBlock(ctx context.Context, block *types.SignedBlock) bool {
+	select {
+	case e.BlockCh <- block:
+		return true
+	case <-ctx.Done():
+		return false
 	}
 }
 

--- a/internal/node/events.go
+++ b/internal/node/events.go
@@ -2,16 +2,39 @@ package node
 
 import (
 	"context"
+	"time"
 
 	"github.com/geanlabs/gean/internal/logger"
 	"github.com/geanlabs/gean/internal/types"
 )
 
 func (e *Engine) OnBlock(block *types.SignedBlock) {
+	e.noteGossipSlot(block)
 	select {
 	case e.BlockCh <- block:
 	default:
 		logger.Warn(logger.Chain, "block channel full, dropping")
+	}
+}
+
+// noteGossipSlot records the highest slot heard on gossip as evidence that the
+// network is producing blocks — counted before admission, because a node that
+// drops or rejects what it hears must not mistake its own import stall for a
+// network-wide one. Far-future slots are ignored so a hostile peer cannot pin
+// the duty gate shut with a fabricated slot.
+func (e *Engine) noteGossipSlot(block *types.SignedBlock) {
+	if block == nil || block.Block == nil {
+		return
+	}
+	slot := block.Block.Slot
+	if slot > e.currentSlot(uint64(time.Now().UnixMilli()))+1 {
+		return
+	}
+	for {
+		cur := e.maxSeenGossipSlot.Load()
+		if slot <= cur || e.maxSeenGossipSlot.CompareAndSwap(cur, slot) {
+			return
+		}
 	}
 }
 

--- a/internal/node/fetch.go
+++ b/internal/node/fetch.go
@@ -52,8 +52,13 @@ func (e *Engine) fireBatchFetch(ctx context.Context, roots [][32]byte) {
 	if err != nil {
 		logger.Warn(logger.Sync, "batched fetch failed count=%d err=%v", len(roots), err)
 	}
+	// Fetched parents fill gaps the dispatch loop is waiting on; deliver with
+	// backpressure so none are dropped while their in-flight markers say the
+	// fetch succeeded.
 	for _, b := range blocks {
-		e.OnBlock(b)
+		if !e.OnSyncBlock(ctx, b) {
+			return
+		}
 	}
 	for _, r := range missing {
 		select {

--- a/internal/node/gate.go
+++ b/internal/node/gate.go
@@ -5,6 +5,21 @@ import (
 	"github.com/geanlabs/gean/internal/logger"
 )
 
+// networkSeenSlot is the highest slot this node has evidence the network
+// reached: stored blocks plus gossip it heard, admitted or not. The duty
+// gate's network-stall carve-out keys off this value; feeding it stored slots
+// alone lets a node whose imports are failing conclude the whole network is
+// stalled and keep proposing on a stale head — observed on devnet as a node
+// extending a dead fork for a day with its pending cache rejecting every
+// block it heard.
+func (e *Engine) networkSeenSlot() uint64 {
+	stored := e.Store.MaxStoredBlockSlot()
+	if seen := e.maxSeenGossipSlot.Load(); seen > stored {
+		return seen
+	}
+	return stored
+}
+
 func logDutyGateEvent(event dutygate.Event) {
 	switch event.Reason {
 	case dutygate.ReasonNetworkStall:

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -555,3 +555,49 @@ func TestBufferMissingParentKeepsImmediateParentLink(t *testing.T) {
 		t.Fatalf("pending count=%d, want only parentRoot waiting on missingRoot", e.Pending.Count())
 	}
 }
+
+// A full pending buffer must admit blocks near the connect frontier by
+// evicting the farthest-out entry, and keep rejecting blocks that sit no
+// closer than what it already holds.
+func TestBufferMissingParentEvictsFarthestWhenFull(t *testing.T) {
+	e := makeTestEngine()
+	var queue []*types.SignedBlock
+
+	mkRoot := func(slot uint64, tag byte) [32]byte {
+		return [32]byte{byte(slot), byte(slot >> 8), byte(slot >> 16), tag}
+	}
+	buffer := func(slot uint64) [32]byte {
+		blk := &types.SignedBlock{Block: &types.Block{Slot: slot, ParentRoot: mkRoot(slot, 0xBB), Body: &types.BlockBody{}}}
+		root := mkRoot(slot, 0xCC)
+		e.bufferMissingParentBlock(blk, root, blk.Block.ParentRoot, &queue)
+		return root
+	}
+
+	for i := 0; i < MaxPendingBlocks; i++ {
+		buffer(uint64(1000 + i))
+	}
+	if got := e.Pending.Count(); got != MaxPendingBlocks {
+		t.Fatalf("expected buffer filled to %d, got %d", MaxPendingBlocks, got)
+	}
+
+	// Nearer than everything held: admitted, farthest entry evicted.
+	nearRoot := buffer(10)
+	if _, ok := e.Pending.Depth(nearRoot); !ok {
+		t.Fatal("near-frontier block was rejected by a full buffer")
+	}
+	if got := e.Pending.Count(); got != MaxPendingBlocks {
+		t.Fatalf("expected count to stay at cap after eviction, got %d", got)
+	}
+	if _, slot, ok := e.Pending.HighestSlotEntry(); !ok || slot >= uint64(1000+MaxPendingBlocks-1) {
+		t.Fatalf("expected farthest entry evicted, highest tracked slot=%d ok=%v", slot, ok)
+	}
+
+	// Farther than everything held: still rejected.
+	farRoot := buffer(1 << 20)
+	if _, ok := e.Pending.Depth(farRoot); ok {
+		t.Fatal("farther-than-all block should have been rejected")
+	}
+	if got := e.Pending.Count(); got != MaxPendingBlocks {
+		t.Fatalf("expected count unchanged after rejection, got %d", got)
+	}
+}

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/geanlabs/gean/internal/dutygate"
 	"github.com/geanlabs/gean/internal/forkchoice"
 	"github.com/geanlabs/gean/internal/logger"
 	"github.com/geanlabs/gean/internal/role"
@@ -599,5 +600,52 @@ func TestBufferMissingParentEvictsFarthestWhenFull(t *testing.T) {
 	}
 	if got := e.Pending.Count(); got != MaxPendingBlocks {
 		t.Fatalf("expected count unchanged after rejection, got %d", got)
+	}
+}
+
+// networkSeenSlot must reflect gossip the node heard but could not import, so a
+// node whose own chain is stalled doesn't mistake its stall for the network's.
+func TestNetworkSeenSlotPrefersGossipWhenAheadOfStored(t *testing.T) {
+	e := makeTestEngine()
+	// Genesis ~100 slots ago so realistic gossip slots sit inside the horizon.
+	e.Store.SetConfig(&types.ChainConfig{GenesisTime: uint64(time.Now().Unix()) - 400})
+
+	stored := e.Store.MaxStoredBlockSlot()
+	e.noteGossipSlot(&types.SignedBlock{Block: &types.Block{Slot: stored + 50}})
+
+	if got := e.networkSeenSlot(); got != stored+50 {
+		t.Fatalf("networkSeenSlot=%d, want gossip-seen %d", got, stored+50)
+	}
+}
+
+// A far-future gossip slot must not move the network-seen marker; otherwise a
+// hostile peer could pin the duty gate's network-stall carve-out shut.
+func TestNoteGossipSlotIgnoresFarFuture(t *testing.T) {
+	e := makeTestEngine()
+	e.Store.SetConfig(&types.ChainConfig{GenesisTime: uint64(time.Now().Unix()) - 400})
+
+	e.noteGossipSlot(&types.SignedBlock{Block: &types.Block{Slot: 50}})
+	e.noteGossipSlot(&types.SignedBlock{Block: &types.Block{Slot: 1_000_000}})
+
+	if got := e.maxSeenGossipSlot.Load(); got != 50 {
+		t.Fatalf("far-future gossip slot should be ignored, max=%d want 50", got)
+	}
+}
+
+// Regression: a marooned node (own fork advancing with wall clock, live network
+// far ahead on gossip) must stay gated off duties. Feeding the duty gate stored
+// fork slots triggered the network-stall carve-out and kept it proposing on the
+// dead fork; feeding it the gossip-seen slot keeps the gate shut.
+func TestDutyGateClosedForMaroonedNodeViaGossipSeenSlot(t *testing.T) {
+	const wallSlot, forkHead, forkStored, gossipSeen = 64185, 63663, 63663, 64185
+
+	stale := dutygate.New()
+	if !stale.Decide("block", wallSlot, forkHead, forkStored) {
+		t.Fatal("precondition: stored-slot wiring wrongly reopens via network-stall carve-out")
+	}
+
+	fixed := dutygate.New()
+	if fixed.Decide("block", wallSlot, forkHead, gossipSeen) {
+		t.Fatal("marooned node should be gated off its dead fork with gossip-seen slot")
 	}
 }

--- a/internal/node/pending.go
+++ b/internal/node/pending.go
@@ -12,7 +12,7 @@ func (e *Engine) bufferMissingParentBlock(
 	queue *[]*types.SignedBlock,
 ) {
 	block := signedBlock.Block
-	if e.Pending.Count() >= MaxPendingBlocks {
+	if e.Pending.Count() >= MaxPendingBlocks && !e.evictFarthestPending(block.Slot) {
 		logger.Warn(logger.Chain, "pending block cache full (%d), rejecting block slot=%d block_root=0x%x",
 			MaxPendingBlocks, block.Slot, blockRoot)
 		return
@@ -32,6 +32,7 @@ func (e *Engine) bufferMissingParentBlock(
 		block.Slot, blockRoot, parentRoot, depth)
 
 	e.Pending.SetDepth(blockRoot, depth)
+	e.Pending.SetSlot(blockRoot, block.Slot)
 	missingRoot := e.Pending.ResolveAncestor(parentRoot)
 	e.Pending.SetParent(blockRoot, parentRoot)
 	e.Store.StorePendingBlock(blockRoot, signedBlock)
@@ -42,6 +43,24 @@ func (e *Engine) bufferMissingParentBlock(
 		return
 	}
 	e.queueMissingBlockFetch(missingRoot)
+}
+
+// evictFarthestPending frees a slot in the full pending buffer for a block at
+// incomingSlot by discarding the entry farthest from the known chain. A full
+// buffer must not reject blocks near the connect frontier: those are the only
+// ones that can turn into imports, and turning them away is how a lagging
+// node's buffer stays poisoned with an unconnectable tail forever. When the
+// incoming block sits no closer than everything already held, it is the one
+// that loses.
+func (e *Engine) evictFarthestPending(incomingSlot uint64) bool {
+	evictRoot, evictSlot, ok := e.Pending.HighestSlotEntry()
+	if !ok || evictSlot <= incomingSlot {
+		return false
+	}
+	logger.Warn(logger.Chain, "pending block cache full (%d), evicting slot=%d block_root=0x%x to admit slot=%d",
+		MaxPendingBlocks, evictSlot, evictRoot, incomingSlot)
+	e.Pending.DiscardSubtree(evictRoot)
+	return true
 }
 
 func (e *Engine) queueStoredAncestor(missingRoot [32]byte, queue *[]*types.SignedBlock) ([32]byte, bool) {

--- a/internal/node/proposal.go
+++ b/internal/node/proposal.go
@@ -33,7 +33,7 @@ func (e *Engine) maybePropose(slot, validatorID uint64) {
 	if e.Store.HeadSlot() >= slot {
 		return
 	}
-	if e.DutyGate != nil && !e.DutyGate.Decide("block", slot, e.Store.HeadSlot(), e.Store.MaxStoredBlockSlot()) {
+	if e.DutyGate != nil && !e.DutyGate.Decide("block", slot, e.Store.HeadSlot(), e.networkSeenSlot()) {
 		metrics.IncBlocksSkippedLag()
 		return
 	}

--- a/internal/node/tick.go
+++ b/internal/node/tick.go
@@ -70,7 +70,7 @@ func (e *Engine) dispatchAggregationCycle(currentSlot uint64, isAggregator bool)
 	// also applies it to aggregation. Aggregating on a stale view only produces
 	// best-effort aggregates that get dropped, so gating when lagging is safe and
 	// surfaces the not_synced skip reason.
-	if e.DutyGate != nil && !e.DutyGate.Decide("aggregation", currentSlot, e.Store.HeadSlot(), e.Store.MaxStoredBlockSlot()) {
+	if e.DutyGate != nil && !e.DutyGate.Decide("aggregation", currentSlot, e.Store.HeadSlot(), e.networkSeenSlot()) {
 		metrics.IncAggregatorSkipped(metrics.AggregatorSkipNotSynced)
 		return
 	}

--- a/internal/pending/blocks.go
+++ b/internal/pending/blocks.go
@@ -4,6 +4,7 @@ type BlockBuffer struct {
 	children map[[32]byte]map[[32]byte]bool
 	parents  map[[32]byte][32]byte
 	depths   map[[32]byte]int
+	slots    map[[32]byte]uint64
 }
 
 func NewBlockBuffer() *BlockBuffer {
@@ -64,6 +65,31 @@ func (b *BlockBuffer) ClearDepth(root [32]byte) {
 		return
 	}
 	delete(b.depths, root)
+}
+
+func (b *BlockBuffer) SetSlot(root [32]byte, slot uint64) {
+	if !b.ensureMaps() {
+		return
+	}
+	b.slots[root] = slot
+}
+
+// HighestSlotEntry returns the tracked entry farthest from the known chain —
+// the natural eviction victim when the buffer is full, since entries closer
+// to a known state are the ones that can actually connect.
+func (b *BlockBuffer) HighestSlotEntry() ([32]byte, uint64, bool) {
+	if b == nil || len(b.slots) == 0 {
+		return [32]byte{}, 0, false
+	}
+	var maxRoot [32]byte
+	var maxSlot uint64
+	found := false
+	for root, slot := range b.slots {
+		if !found || slot > maxSlot {
+			maxRoot, maxSlot, found = root, slot, true
+		}
+	}
+	return maxRoot, maxSlot, found
 }
 
 func (b *BlockBuffer) ResolveAncestor(start [32]byte) [32]byte {
@@ -136,6 +162,7 @@ func (b *BlockBuffer) ClearEntry(root [32]byte) {
 	}
 	delete(b.parents, root)
 	delete(b.depths, root)
+	delete(b.slots, root)
 }
 
 func (b *BlockBuffer) Pairs() [][2][32]byte {
@@ -174,6 +201,7 @@ func (b *BlockBuffer) discardSubtree(root [32]byte) {
 	}
 	delete(b.parents, root)
 	delete(b.depths, root)
+	delete(b.slots, root)
 	set, ok := b.children[root]
 	if !ok {
 		return
@@ -196,6 +224,9 @@ func (b *BlockBuffer) ensureMaps() bool {
 	}
 	if b.depths == nil {
 		b.depths = make(map[[32]byte]int)
+	}
+	if b.slots == nil {
+		b.slots = make(map[[32]byte]uint64)
 	}
 	return true
 }

--- a/internal/pending/blocks_test.go
+++ b/internal/pending/blocks_test.go
@@ -192,3 +192,57 @@ func TestBlockBuffer_ZeroValueAndNilGuards(t *testing.T) {
 		t.Fatalf("nil pairs=%v, want nil", pairs)
 	}
 }
+
+func TestBlockBuffer_HighestSlotEntry(t *testing.T) {
+	b := NewBlockBuffer()
+
+	if _, _, ok := b.HighestSlotEntry(); ok {
+		t.Fatal("expected no entry on empty buffer")
+	}
+
+	near := [32]byte{0x01}
+	mid := [32]byte{0x02}
+	far := [32]byte{0x03}
+	b.SetSlot(near, 10)
+	b.SetSlot(mid, 50)
+	b.SetSlot(far, 90)
+
+	root, slot, ok := b.HighestSlotEntry()
+	if !ok || root != far || slot != 90 {
+		t.Fatalf("expected far entry (slot 90), got root=%x slot=%d ok=%v", root, slot, ok)
+	}
+
+	// Discarding the current maximum must promote the next-farthest entry.
+	b.DiscardSubtree(far)
+	root, slot, ok = b.HighestSlotEntry()
+	if !ok || root != mid || slot != 50 {
+		t.Fatalf("expected mid entry (slot 50) after discard, got root=%x slot=%d ok=%v", root, slot, ok)
+	}
+
+	b.ClearEntry(mid)
+	root, slot, ok = b.HighestSlotEntry()
+	if !ok || root != near || slot != 10 {
+		t.Fatalf("expected near entry (slot 10) after clear, got root=%x slot=%d ok=%v", root, slot, ok)
+	}
+}
+
+func TestBlockBuffer_DiscardSubtreeClearsSlots(t *testing.T) {
+	b := NewBlockBuffer()
+
+	parent := [32]byte{0x01}
+	child := [32]byte{0x02}
+	grandchild := [32]byte{0x03}
+
+	b.AddChild(parent, child)
+	b.SetParent(child, parent)
+	b.SetSlot(child, 5)
+	b.AddChild(child, grandchild)
+	b.SetParent(grandchild, child)
+	b.SetSlot(grandchild, 6)
+
+	b.DiscardSubtree(child)
+
+	if _, _, ok := b.HighestSlotEntry(); ok {
+		t.Fatal("expected slot tracking cleared for the whole discarded subtree")
+	}
+}

--- a/internal/syncer/backfill.go
+++ b/internal/syncer/backfill.go
@@ -45,7 +45,7 @@ func (sd *SyncDriver) checkAndBackfill(ctx context.Context, peerID libp2ppeer.ID
 			return
 		}
 
-		lastSlot, ok := sd.feedBlocks(peerID, blocks, startSlot)
+		lastSlot, ok := sd.feedBlocks(ctx, peerID, blocks, startSlot)
 		if !ok {
 			return
 		}
@@ -84,13 +84,13 @@ func (sd *SyncDriver) fallbackHeadByRoot(ctx context.Context, peerID libp2ppeer.
 		return
 	}
 	for _, block := range rootBlocks {
-		if validFetchedBlock(block) {
-			sd.node.OnBlock(block)
+		if validFetchedBlock(block) && !sd.node.OnSyncBlock(ctx, block) {
+			return
 		}
 	}
 }
 
-func (sd *SyncDriver) feedBlocks(peerID libp2ppeer.ID, blocks []*types.SignedBlock, startSlot uint64) (uint64, bool) {
+func (sd *SyncDriver) feedBlocks(ctx context.Context, peerID libp2ppeer.ID, blocks []*types.SignedBlock, startSlot uint64) (uint64, bool) {
 	if sd == nil || sd.node == nil {
 		return 0, false
 	}
@@ -102,8 +102,14 @@ func (sd *SyncDriver) feedBlocks(peerID libp2ppeer.ID, blocks []*types.SignedBlo
 		return 0, false
 	}
 
+	// Delivery blocks until the engine accepts each block, so advancing the
+	// range cursor past this batch is safe: every slot in it was handed over,
+	// not just attempted. Advancing past dropped blocks is what strands a
+	// lagging node — the gap is never re-requested and nothing connects.
 	for _, block := range blocks {
-		sd.node.OnBlock(block)
+		if !sd.node.OnSyncBlock(ctx, block) {
+			return 0, false
+		}
 	}
 	return lastSlot, true
 }

--- a/internal/syncer/backfill_test.go
+++ b/internal/syncer/backfill_test.go
@@ -251,3 +251,60 @@ func TestSyncDriver_CheckAndBackfill_PerPeerDedup(t *testing.T) {
 	<-done1
 	_ = drainBlockCh(t, n, 1, 100*time.Millisecond)
 }
+
+// A full engine channel must stall the backfill, not drop blocks: dropped
+// blocks are never re-requested (the range cursor advances past them), which
+// permanently disconnects the chain.
+func TestSyncDriver_CheckAndBackfill_BackpressuresInsteadOfDropping(t *testing.T) {
+	n, store := makeTestSyncHarness()
+	n.BlockCh = make(chan *types.SignedBlock, 1)
+	blocks := makeSyncRange(store.Head(), 1, 2, 3, 4)
+	mock := &mockSyncP2P{
+		rangeBatches: [][]*types.SignedBlock{blocks},
+	}
+	sd := NewSyncDriver(context.Background(), n, store, mock)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		sd.checkAndBackfill(context.Background(), libp2ppeer.ID("p1"), &p2p.StatusMessage{HeadSlot: 100})
+	}()
+
+	got := drainBlockCh(t, n, 4, time.Second)
+	if len(got) != 4 {
+		t.Fatalf("expected all 4 blocks delivered despite capacity-1 channel, got %d", len(got))
+	}
+	<-done
+}
+
+// Cancellation while delivery is stalled must abort the backfill cleanly
+// rather than advance to the next range.
+func TestSyncDriver_CheckAndBackfill_CancelAbortsStalledDelivery(t *testing.T) {
+	n, store := makeTestSyncHarness()
+	n.BlockCh = make(chan *types.SignedBlock, 1)
+	blocks := makeSyncRange(store.Head(), 1, 2, 3)
+	mock := &mockSyncP2P{
+		rangeBatches: [][]*types.SignedBlock{blocks, blocks},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	sd := NewSyncDriver(ctx, n, store, mock)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		sd.checkAndBackfill(ctx, libp2ppeer.ID("p1"), &p2p.StatusMessage{HeadSlot: 100})
+	}()
+
+	// One block fits the channel; the feed is now stalled on the second.
+	_ = drainBlockCh(t, n, 1, time.Second)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("backfill did not abort after cancellation")
+	}
+	if got := mock.rangeCalls.Load(); got != 1 {
+		t.Errorf("expected no further range fetches after aborted delivery, got %d calls", got)
+	}
+}

--- a/internal/syncer/harness_test.go
+++ b/internal/syncer/harness_test.go
@@ -80,6 +80,15 @@ func (n *testNode) OnBlock(block *types.SignedBlock) {
 	n.BlockCh <- block
 }
 
+func (n *testNode) OnSyncBlock(ctx context.Context, block *types.SignedBlock) bool {
+	select {
+	case n.BlockCh <- block:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
 func makeTestSyncHarness() (*testNode, *store.ConsensusStore) {
 	store := store.NewConsensusStore(storage.NewInMemoryBackend())
 	header := &types.BlockHeader{Slot: 0}

--- a/internal/syncer/ports.go
+++ b/internal/syncer/ports.go
@@ -19,4 +19,7 @@ type SyncDriverP2P interface {
 type LocalNode interface {
 	GetSyncStatus() SyncStatus
 	OnBlock(*types.SignedBlock)
+	// OnSyncBlock delivers a requested block with backpressure; it blocks until
+	// the node accepts it and returns false only if ctx ends first.
+	OnSyncBlock(context.Context, *types.SignedBlock) bool
 }


### PR DESCRIPTION
## Problem

On the multi-client devnet, `gean_15`'s **justified slot froze at 43072** (with its head state's internal justified stuck at 42382) while its **head kept advancing** with the wall clock. The node was marooned on its own single-validator fork since a checkpoint-sync restart ~22h earlier and imported **zero canonical blocks** in that window, yet kept proposing on the dead fork — eroding the network's 2/3 finalization margin. `zeam_4` (49721) and `zeam_6` (46997) showed the same signature.

The "advancing head" was a mirage: gean proposes on its own fork every 16 slots (its `slot mod 16` proposer slot, `63663 mod 16 = 15`), so the head-slot metric tracks time and looks healthy. Justification only advances from imported blocks' post-states (leanSpec `fork_choice.py`: `store.latest_justified.advance_to(post_state.latest_justified)`), and a 1-of-16 private fork can never reach the ceil(2/3·16)=11-vote supermajority — so justified is frozen at the fork point forever.

### Root causes (verified against build `693c40f` and the devnet logs)

1. **Lossy backfill contract.** Range sync fed every fetched block through the drop-on-full gossip path (`block channel full, dropping` ×369 in 20s) and then advanced its cursor to the end of the batch *regardless of drops*. The dropped slots were never re-requested — the node re-fetched ranges it believed it had covered while its chain stayed disconnected. The by-root parent fetcher lost blocks the same way while its in-flight markers recorded success.
2. **Undersized block channel.** `BlockCh` cap 64 vs. range batches up to 1024 guaranteed loss during any catch-up burst.
3. **Pending-cache admission policy.** A full pending buffer (`MaxPendingBlocks = 1024`) *rejected incoming blocks outright* (`pending block cache full, rejecting` ×64). On a lagging node the buffer fills with an unconnectable tail, and the rejected blocks are exactly the frontier ones adjacent to known states — the only ones that could become imports. Once poisoned it never recovered.
4. **Duty-gate self-poisoning.** The duty gate's network-stall carve-out (which reopens duties so a behind node still helps recover) was fed `MaxStoredBlockSlot()` as the network-progress signal. A marooned node's stored slots advance with its own fork, so the carve-out concluded *the whole network* was stalled, reopened the gate, and kept the node extending its dead fork indefinitely.

## Fixes (one per commit)

1. `fix(sync)` — sync-requested blocks (range backfill + by-root parent fetch) now go through a blocking `OnSyncBlock` delivery, so the cursor only ever advances past blocks the engine **actually accepted**. Gossip keeps the non-blocking drop path.
2. `fix(node)` — `BlockCh` 64 → 256, so live gossip keeps flowing while the dispatch loop imports a fetched batch (pointers only; negligible memory).
3. `fix(node)` — the pending buffer tracks each entry's slot and, when full, **evicts the farthest-out subtree** to admit a nearer block; a block no closer than everything held is still rejected.
4. `fix(node)` — track the highest slot heard on **gossip** (counted before admission, bounded to the future horizon so a hostile peer can't pin the gate) and feed `max(stored, gossip-seen)` to the duty gate. A marooned node now sees the live network advancing on gossip, keeps its gate shut, and **stops polluting the network** with dead-fork blocks until an operator re-syncs it.

## ethlambda cross-check

Confirmed against ethlambda's implementation: it gates duties the same way (`SyncStatusTracker` with a network-wide-stall carve-out that resumes duties), and its checkpoint sync is **startup-only** with no runtime auto-resync. This PR keeps gean aligned with that architecture — it fixes the *signal* the gate consumes rather than adding a risky auto-resync feature. (ethlambda's backfill is also fire-and-forget and advances on the requested range, not imported blocks — so it shares root cause #1; gean is now stricter here.)

## Not included (follow-up)

Automatic re-checkpoint-sync on unrecoverable divergence (justified trailing peers' finalized beyond the 3600-slot serving horizon). No interop peer implements this; it's a larger, riskier change best done on its own. **Operational recovery remains: restart with `--checkpoint-sync-url` and a fresh `--data-dir`** — a plain restart re-anchors fork choice on the poisoned justified checkpoint and re-maroons within minutes.

## Testing

- New coverage: backpressure delivery over a capacity-1 channel, cancel-aborts-stalled-delivery, pending eviction (admit-frontier + reject-farther-than-all), buffer slot-tracking cleanup, gossip-seen max, far-future-slot ignore, and a marooned-node duty-gate regression.
- `make build`, `make test`, `make lint` all green. Race detector clean on `node`/`syncer`/`pending`/`dutygate`.
- No consensus state-transition or fork-choice logic touched; fork-choice weights, vote-index remap, and `state_root` verification are untouched, so spec fixtures are unaffected.
