### PR TITLE
chore: fix the three failing CI checks (spec-tests toolchain, Go + Rust advisories)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  GO_VERSION: "1.25.11"
+  GO_VERSION: "1.25.12"
   RUST_VERSION: "1.92"
 
 jobs:

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 env:
-  GO_VERSION: "1.25.11"
+  GO_VERSION: "1.25.12"
   RUST_VERSION: "1.92"
 
 jobs:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.25.11"
+  GO_VERSION: "1.25.12"
   RUST_VERSION: "1.92"
 
 jobs:

--- a/.github/workflows/spec-tests.yml
+++ b/.github/workflows/spec-tests.yml
@@ -11,7 +11,7 @@ on:
       - "Makefile"
 
 env:
-  GO_VERSION: "1.25.11"
+  GO_VERSION: "1.25.12"
   RUST_VERSION: "1.92"
 
 jobs:

--- a/.github/workflows/spec-tests.yml
+++ b/.github/workflows/spec-tests.yml
@@ -12,7 +12,11 @@ on:
 
 env:
   GO_VERSION: "1.25.12"
-  RUST_VERSION: "1.92"
+  # Fixture generation compiles the spec's prover toolchain (lean-multisig-py ->
+  # leanMultisig -> Plonky3), which uses nightly-only features (e.g.
+  # maybe_uninit_slice). This job builds no gean FFI — that stays pinned to
+  # 1.92 via xmss/rust/rust-toolchain.toml — so nightly here is isolated.
+  RUST_VERSION: "nightly"
 
 jobs:
   spec-tests:

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/libp2p/go-libp2p-pubsub v0.16.0
 	github.com/multiformats/go-multiaddr v0.16.0
 	github.com/prometheus/client_golang v1.22.0
-	golang.org/x/sync v0.19.0
+	github.com/prometheus/client_model v0.6.2
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -90,11 +90,10 @@ require (
 	github.com/pion/turn/v4 v4.0.2 // indirect
 	github.com/pion/webrtc/v4 v4.1.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.64.0 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
-	github.com/quic-go/quic-go v0.59.0 // indirect
+	github.com/quic-go/quic-go v0.59.1 // indirect
 	github.com/quic-go/webtransport-go v0.10.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
@@ -108,6 +107,7 @@ require (
 	golang.org/x/exp v0.0.0-20250606033433-dcc06ee1d476 // indirect
 	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/net v0.50.0 // indirect
+	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260109210033-bd525da824e2 // indirect
 	golang.org/x/text v0.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -208,8 +208,8 @@ github.com/prysmaticlabs/gohashtree v0.0.4-beta h1:H/EbCuXPeTV3lpKeXGPpEV9gsUpkq
 github.com/prysmaticlabs/gohashtree v0.0.4-beta/go.mod h1:BFdtALS+Ffhg3lGQIHv9HDWuHS8cTvHZzrHWxwOtGOs=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
-github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SAw=
-github.com/quic-go/quic-go v0.59.0/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
+github.com/quic-go/quic-go v0.59.1 h1:0Gmua0HW1Tv7ANR7hUYwRyD0MG5OJfgvYSZasGZzBic=
+github.com/quic-go/quic-go v0.59.1/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/quic-go/webtransport-go v0.10.0 h1:LqXXPOXuETY5Xe8ITdGisBzTYmUOy5eSj+9n4hLTjHI=
 github.com/quic-go/webtransport-go v0.10.0/go.mod h1:LeGIXr5BQKE3UsynwVBeQrU1TPrbh73MGoC6jd+V7ow=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=

--- a/xmss/rust/Cargo.lock
+++ b/xmss/rust/Cargo.lock
@@ -643,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## CI housekeeping: clear the three red checks on `devnet-5`

Three CI checks have been failing on `devnet-5` (visible on the milestone PR #380). None are regressions from recent feature/fix work — Build & Test and both Lint jobs are green. This PR fixes all three; one commit each.

### 1. Rust Dependency Audit — `RUSTSEC-2026-0204` (crossbeam-epoch)
`cargo audit` errors on an invalid-pointer-dereference advisory in `crossbeam-epoch` 0.9.18's `fmt::Pointer` impl (pulled into the XMSS FFI via the leanVM prover's rayon dep). Bumped to **0.9.20** (lock-only). FFI rebuilds clean under `--locked`.

### 2. Go Vulnerability Check — two 2026 advisories
- **GO-2026-5856** — `crypto/tls` ECH privacy leak, fixed in the **go1.25.12** stdlib. CI provisioned go1.25.11 → bumped `GO_VERSION` to `1.25.12` across all workflows.
- **GO-2026-5676** — `quic-go` (indirect, via libp2p QUIC), fixed in **v0.59.1** → `go get`'d.

Verified locally: after the quic-go bump `govulncheck` no longer reports GO-2026-5676, and every remaining stdlib finding is fixed at or below go1.25.12, so the toolchain bump clears them.

### 3. Consensus Spec Tests — `E0658: maybe_uninit_slice` (nightly feature on stable)
Fixture generation compiles the spec's prover toolchain (`lean-multisig-py` → leanMultisig via a floating branch ref → Plonky3), which uses nightly-only features. The job installed **stable 1.92**, so the build aborted — this job has been red for weeks, independent of any code change. Switched **only this job** to **nightly**. It builds no gean FFI (`test-spec` excludes it, and `xmss/rust/rust-toolchain.toml` pins 1.92), so the change is isolated to fixture generation.

### Notes
- These workflows trigger on PRs to `main` (+ schedule), so the green run lands when `devnet-5` → `main` (#380) re-runs after merge.
- Split from the milestone-promotion PR deliberately: unrelated to consensus behavior, and each is a self-contained dependency/toolchain bump.
