### PR TITLE
fix(node): deliver exhausted fetch roots with backpressure

### DIFF
--- a/internal/aggregation/worker.go
+++ b/internal/aggregation/worker.go
@@ -62,6 +62,10 @@ func RunWorker(
 			if gate != nil && !gate.Acquire(acquireCtx, false) {
 				cancelAcquire()
 				metrics.IncProofOperation("aggregation", "canceled")
+				// Losing the prover costs this slot its aggregate, which slows
+				// justification. Log it: without a line here the loss is visible
+				// only in metrics, and an operator reading logs sees a silent gap.
+				logger.Warn(logger.Signature, "aggregation skipped: prover unavailable slot=%d", dispatch.Slot)
 				continue
 			}
 			cancelAcquire()

--- a/internal/aggregation/worker.go
+++ b/internal/aggregation/worker.go
@@ -22,11 +22,16 @@ type Dispatch struct {
 	Slot     uint64
 }
 
-// sessionBudget caps one aggregation session's proving time. Dispatch fires
+// SessionBudget caps one aggregation session's proving time. Dispatch fires
 // at interval 2, so two intervals of proving still leaves interval 4 for the
 // results to be promoted and gossiped, and bounds how long the proving gate
-// is held away from proposals.
-const sessionBudget = 2 * types.MillisecondsPerInterval * time.Millisecond
+// is held away from proposals. Exported so other prover users can stay clear
+// of the window this session occupies rather than fork the constant.
+const SessionBudget = 2 * types.MillisecondsPerInterval * time.Millisecond
+
+// AcquirePatience is how long a dispatched session waits for the prover before
+// giving up on the slot's aggregate.
+const AcquirePatience = 750 * time.Millisecond
 
 func RunWorker(
 	ctx context.Context,
@@ -53,7 +58,7 @@ func RunWorker(
 			if dispatch.Snapshot == nil {
 				continue
 			}
-			acquireCtx, cancelAcquire := context.WithTimeout(ctx, 750*time.Millisecond)
+			acquireCtx, cancelAcquire := context.WithTimeout(ctx, AcquirePatience)
 			if gate != nil && !gate.Acquire(acquireCtx, false) {
 				cancelAcquire()
 				metrics.IncProofOperation("aggregation", "canceled")
@@ -68,7 +73,7 @@ func RunWorker(
 			// (and their signature deletes) regrows the next snapshot until
 			// no session can ever finish inside a slot.
 			workerStart := time.Now()
-			aggs, payloads, deletes, truncated := aggregateFromSnapshot(dispatch.Snapshot, cache, workerStart.Add(sessionBudget), shadowRates, estimator)
+			aggs, payloads, deletes, truncated := aggregateFromSnapshot(dispatch.Snapshot, cache, workerStart.Add(SessionBudget), shadowRates, estimator)
 			if gate != nil {
 				gate.Release(false)
 			}

--- a/internal/node/clock.go
+++ b/internal/node/clock.go
@@ -15,3 +15,10 @@ func (e *Engine) currentInterval(timestampMs uint64) uint64 {
 	}
 	return types.CurrentInterval(e.Store.Config().GenesisTime, timestampMs)
 }
+
+func (e *Engine) millisIntoSlot(timestampMs uint64) uint64 {
+	if e == nil || e.Store == nil {
+		return 0
+	}
+	return types.MillisIntoSlot(e.Store.Config().GenesisTime, timestampMs)
+}

--- a/internal/node/fetch.go
+++ b/internal/node/fetch.go
@@ -60,11 +60,23 @@ func (e *Engine) fireBatchFetch(ctx context.Context, roots [][32]byte) {
 			return
 		}
 	}
-	for _, r := range missing {
+	e.notifyFailedRoots(ctx, missing)
+}
+
+// notifyFailedRoots hands exhausted roots to the dispatch loop, blocking until each
+// is accepted. Dropping one is not a lost log line: a root's in-flight marker clears
+// only when its block arrives or this notification is handled, so a dropped root is
+// never re-requested and its gap never closes. Range backfill cannot cover for it —
+// that only runs against a peer whose head is ahead, which is untrue of a node
+// marooned on its own fork. The marker map belongs to the dispatch loop, so the
+// batcher cannot clear it here; backpressure is the only safe option, and the loop
+// never sends on this channel, so blocking cannot deadlock.
+func (e *Engine) notifyFailedRoots(ctx context.Context, roots [][32]byte) {
+	for _, r := range roots {
 		select {
 		case e.FailedRootCh <- r:
-		default:
-			logger.Warn(logger.Sync, "failed root channel full, dropping notification for 0x%x", r)
+		case <-ctx.Done():
+			return
 		}
 	}
 }

--- a/internal/node/fetch_test.go
+++ b/internal/node/fetch_test.go
@@ -1,7 +1,9 @@
 package node
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/geanlabs/gean/internal/p2p"
 	"github.com/geanlabs/gean/internal/types"
@@ -36,6 +38,71 @@ func TestQueueMissingBlockFetchDedupes(t *testing.T) {
 	e.queueMissingBlockFetch(root)
 	if got := len(e.FetchRootCh); got != 1 {
 		t.Fatalf("re-queue after exhaustion: FetchRootCh has %d, want 1", got)
+	}
+}
+
+// A dropped failed-root notification strands its in-flight marker set forever, so the
+// root is never re-requested and the gap never closes. Delivery must wait for the
+// dispatch loop rather than drop.
+func TestNotifyFailedRootsBlocksInsteadOfDropping(t *testing.T) {
+	e := makeTestEngine()
+	for len(e.FailedRootCh) < cap(e.FailedRootCh) {
+		e.FailedRootCh <- [32]byte{}
+	}
+
+	var root [32]byte
+	root[0] = 0xAB
+
+	done := make(chan struct{})
+	go func() {
+		e.notifyFailedRoots(context.Background(), [][32]byte{root})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("notifyFailedRoots returned with a full channel; the notification was dropped")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	<-e.FailedRootCh // dispatch loop makes room
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("notifyFailedRoots did not deliver after the channel drained")
+	}
+
+	// Drain the backlog to reach the root that was waiting.
+	var delivered bool
+	for len(e.FailedRootCh) > 0 {
+		if <-e.FailedRootCh == root {
+			delivered = true
+		}
+	}
+	if !delivered {
+		t.Fatal("failed root was never delivered to the dispatch loop")
+	}
+}
+
+// Shutdown must not wedge the fetch batcher on a dispatch loop that has already stopped.
+func TestNotifyFailedRootsAbortsOnContextCancel(t *testing.T) {
+	e := makeTestEngine()
+	for len(e.FailedRootCh) < cap(e.FailedRootCh) {
+		e.FailedRootCh <- [32]byte{}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		e.notifyFailedRoots(ctx, [][32]byte{{0xCD}})
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("notifyFailedRoots ignored context cancellation")
 	}
 }
 

--- a/internal/node/recovery.go
+++ b/internal/node/recovery.go
@@ -131,6 +131,17 @@ func (e *Engine) recoverBlockProofs(ctx context.Context, signedBlock *types.Sign
 			metrics.IncProofOperation("recovery", "canceled")
 			return
 		}
+		// Acquire blocks for as long as the current holder keeps the prover, so the
+		// check above describes when recovery asked, not when it was handed over.
+		// Sessions routinely run past their nominal budget, so re-check before
+		// spending the gate and give it back if the window closed while waiting.
+		if !e.splitFitsBeforeAggregation(uint64(time.Now().UnixMilli())) {
+			if e.ProvingGate != nil {
+				e.ProvingGate.Release(false)
+			}
+			metrics.IncProofOperation("recovery", "canceled")
+			return
+		}
 		started := time.Now()
 		proof, err := xmss.SplitType2Proof(signedBlock.Proof.Proof, pubkeys, candidate.root)
 		var recovered *types.SingleMessageAggregate

--- a/internal/node/recovery.go
+++ b/internal/node/recovery.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/geanlabs/gean/internal/aggregation"
 	"github.com/geanlabs/gean/internal/attestationproof"
 	"github.com/geanlabs/gean/internal/metrics"
 	"github.com/geanlabs/gean/internal/store"
@@ -15,6 +16,36 @@ import (
 )
 
 const maxRecoverySplits = 4
+
+const (
+	// recoverySplitBudget is how long one Type-2 split is assumed to hold the prover.
+	// Measured at roughly 700ms, rounded up to a full interval so the estimate errs
+	// toward yielding.
+	recoverySplitBudget = types.MillisecondsPerInterval * time.Millisecond
+	// aggregationDispatchOffset is how far into a slot aggregation is dispatched;
+	// onTick fires it at interval 2.
+	aggregationDispatchOffset = 2 * types.MillisecondsPerInterval * time.Millisecond
+)
+
+// splitFitsBeforeAggregation reports whether a Type-2 split started now would be done
+// with the prover before aggregation next needs it. A split takes about as long as
+// aggregation is willing to wait for the gate, so one running across the dispatch costs
+// the slot its aggregate — and a missed aggregate slows justification, the very thing
+// recovery exists to help. Recovery is best-effort and the aggregate is duty work, so
+// recovery yields the window rather than racing for it.
+func (e *Engine) splitFitsBeforeAggregation(nowMs uint64) bool {
+	intoSlot := time.Duration(e.millisIntoSlot(nowMs)) * time.Millisecond
+	windowEnd := aggregationDispatchOffset + aggregation.SessionBudget
+	if intoSlot >= aggregationDispatchOffset && intoSlot < windowEnd {
+		return false
+	}
+	untilDispatch := aggregationDispatchOffset - intoSlot
+	if intoSlot >= windowEnd {
+		// Past this slot's session; the next dispatch is in the following slot.
+		untilDispatch = types.MillisecondsPerSlot*time.Millisecond - intoSlot + aggregationDispatchOffset
+	}
+	return untilDispatch >= recoverySplitBudget
+}
 
 type recoveryCandidate struct {
 	att      *types.AggregatedAttestation
@@ -90,6 +121,10 @@ func (e *Engine) recoverBlockProofs(ctx context.Context, signedBlock *types.Sign
 		now = uint64(time.Now().UnixMilli())
 		currentSlot = e.currentSlot(now)
 		if _, proposesNext := e.getOurProposer(currentSlot + 1); proposesNext {
+			return
+		}
+		if !e.splitFitsBeforeAggregation(now) {
+			metrics.IncProofOperation("recovery", "canceled")
 			return
 		}
 		if e.ProvingGate != nil && !e.ProvingGate.Acquire(ctx, false) {

--- a/internal/node/recovery_window_test.go
+++ b/internal/node/recovery_window_test.go
@@ -1,0 +1,43 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/geanlabs/gean/internal/types"
+)
+
+// Recovery is best-effort; the slot's aggregate is duty work. A split takes about as
+// long as aggregation waits for the prover, so recovery must not start one that would
+// still be running when aggregation dispatches at interval 2, nor while the aggregation
+// session itself holds the prover.
+func TestSplitFitsBeforeAggregation(t *testing.T) {
+	e := makeTestEngine()
+	genesisMs := e.Store.Config().GenesisTime * 1000
+
+	const interval = types.MillisecondsPerInterval
+
+	tests := []struct {
+		name     string
+		intoSlot uint64
+		want     bool
+	}{
+		{"slot start, two intervals of room", 0, true},
+		{"start of interval 1, exactly one interval of room", interval, true},
+		{"mid interval 1, split would run past dispatch", interval + 400, false},
+		{"dispatch instant", 2 * interval, false},
+		{"inside aggregation session", 3 * interval, false},
+		{"session budget just elapsed, prover free again", 4 * interval, true},
+		{"late interval 4, next dispatch still far", 4*interval + 400, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Probe a later slot so the check is independent of the genesis boundary.
+			nowMs := genesisMs + 10*types.MillisecondsPerSlot + tc.intoSlot
+			if got := e.splitFitsBeforeAggregation(nowMs); got != tc.want {
+				t.Fatalf("splitFitsBeforeAggregation(+%dms into slot) = %t, want %t",
+					tc.intoSlot, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/node/recovery_window_test.go
+++ b/internal/node/recovery_window_test.go
@@ -41,3 +41,21 @@ func TestSplitFitsBeforeAggregation(t *testing.T) {
 		})
 	}
 }
+
+// The window check runs before the gate is acquired, and Acquire blocks for as long as
+// the current holder keeps the prover. A stale pass must not authorise a split: the
+// check is re-evaluated on acquisition, so a window that closed while waiting is caught.
+func TestSplitFitsBeforeAggregationRejectsWindowClosedWhileWaiting(t *testing.T) {
+	e := makeTestEngine()
+	genesisMs := e.Store.Config().GenesisTime * 1000
+	base := genesisMs + 10*types.MillisecondsPerSlot
+
+	// Cleared at the start of the slot...
+	if !e.splitFitsBeforeAggregation(base) {
+		t.Fatal("split at slot start should be cleared")
+	}
+	// ...but a wait spanning into the dispatch window must no longer be cleared.
+	if e.splitFitsBeforeAggregation(base + 2*types.MillisecondsPerInterval) {
+		t.Fatal("split must not be cleared once the aggregation window has opened")
+	}
+}

--- a/internal/types/clock.go
+++ b/internal/types/clock.go
@@ -11,7 +11,8 @@ func CurrentSlot(genesisTime, currentTimeMs uint64) uint64 {
 	return (currentTimeMs - genesisMs) / MillisecondsPerSlot
 }
 
-func CurrentInterval(genesisTime, currentTimeMs uint64) uint64 {
+// MillisIntoSlot returns how far the clock has advanced into the current slot.
+func MillisIntoSlot(genesisTime, currentTimeMs uint64) uint64 {
 	genesisMs, ok := unixMillis(genesisTime)
 	if !ok {
 		return 0
@@ -19,8 +20,11 @@ func CurrentInterval(genesisTime, currentTimeMs uint64) uint64 {
 	if currentTimeMs < genesisMs {
 		return 0
 	}
-	msIntoSlot := (currentTimeMs - genesisMs) % MillisecondsPerSlot
-	return msIntoSlot / MillisecondsPerInterval
+	return (currentTimeMs - genesisMs) % MillisecondsPerSlot
+}
+
+func CurrentInterval(genesisTime, currentTimeMs uint64) uint64 {
+	return MillisIntoSlot(genesisTime, currentTimeMs) / MillisecondsPerInterval
 }
 
 func TotalIntervals(genesisTime, currentTimeMs uint64) uint64 {


### PR DESCRIPTION
## Problem

A block root's in-flight marker (`fetchInFlight`) is cleared in exactly two places: when the block arrives (`import.go:38`) and when its failed-fetch notification is handled (`pending.go:129`). The notification send in `fireBatchFetch` dropped on a full channel, which stranded the marker set — `queueMissingBlockFetch` then returned early for that root **forever**, so the gap it guarded was never re-requested.

This partially undoes #379. Range backfill cannot cover for it: `shouldBackfill` requires `peerHead > ourHead`, which is untrue of a node marooned on its own fork (its head tracks wall clock on the private chain). In exactly the scenario #379 targets, the by-root path is the only way back, and the leak closed it.

## Reachability

`MaxBlocksPerRequest = 10` against a 64-slot channel, with a single sequential batcher, so ordinary load drains fine. The realistic trigger is `onBlock`'s inner queue loop: `collectPendingChildren` can feed a whole pending subtree into one `onBlock` call that never returns to `select`.

Sizing that window, measured rather than inferred (`BenchmarkVerifyBlockSignatures`, real FFI): block signature verification is **~39ms at 1 attestation and ~44ms at 8** — it barely scales with attestation count. Draining a full 1024-block pending buffer is therefore on the order of **~41s**, not the "multi-minute" figure an earlier revision of this description claimed.

Overflowing `FailedRootCh` needs roughly 7 consecutive fully-failed batches; at ~5s of retry backoff each (`MaxFetchRetries = 10`, 5ms doubling) that is ~36s, which fits inside that window. So the bug is reachable, but the margin is tighter than a first read suggests — worth stating precisely rather than hand-waving.

## Fix

`fetchInFlight` is an unguarded map owned by the dispatch loop, so the batcher goroutine cannot clear the marker itself — that would race. Backpressure is the only safe option, mirroring how sync-requested blocks are already handed over via `OnSyncBlock`.

The dispatch loop never sends on `FailedRootCh`, so blocking cannot deadlock. The send aborts on context cancellation so shutdown does not wedge the batcher.

## Testing

Two tests in `internal/node/fetch_test.go`, both verified to fail against the previous drop behavior:
- `TestNotifyFailedRootsBlocksInsteadOfDropping` — waits for the dispatch loop instead of dropping, and the root is actually delivered
- `TestNotifyFailedRootsAbortsOnContextCancel` — shutdown does not wedge

`make test` passes, `go vet ./...` clean, gofmt clean, and the fetch tests pass under `-race`.

## Scope

No spec surface touched — no changes to `internal/statetransition/` or `internal/forkchoice/`. This is gean-local scheduling; leanSpec has no notion of a fetch queue or dispatch loop.


---

## Scope note

This branch also carries the recovery/aggregation prover-contention fix, merged in via #384 (originally proposed as #383 against `devnet-5`, retargeted here). Two commits:

- `a2aa974` — keep recovery splits out of the aggregation window
- `1a57140` — re-check that window after acquiring the prover, plus a log when aggregation loses it

## Devnet log audit (gean:55a5af3 = the #384 merge)

A ~58 minute 3-client run (gean + ethlambda + zeam, 859 slots) on this exact build. Note the binary already contained `a2aa974`, so the numbers below describe behaviour *with* the recovery yield in place.

**Chain health was good.** 0 ERROR / 67 WARN over 11,752 lines. Justified lag steady at 3–4 slots (max 15, transient), finalized tracking 3 behind. Block processing p50 43ms / p95 78ms / p99 209ms — consistent with the ~40ms `VerifyBlockSignatures` benchmark. 550 of 557 `blocks_by_root` requests served.

**What the audit found, and why `1a57140` exists.** Aggregation sessions do not respect their nominal budget. Over 279 sessions: p50 406ms, p90 933ms, p99 2154ms, **max 2476ms** against a 1600ms `SessionBudget` — 12 sessions (4.3%) overran. The budget is a deadline checked *between* proof groups, so a group starting just under the line overshoots by its full duration.

That defeated `a2aa974`: the window check ran *before* `ProvingGate.Acquire`, which blocks for as long as the holder keeps the prover. A split cleared to start could be handed the gate up to ~2.4s later, well outside its window — failing in exactly the contended case it exists for. `1a57140` re-checks on acquisition and hands the prover back if the window closed, and logs when a dispatched session loses the prover (previously metrics-only, so a lost aggregate was a silent gap and this PR's behaviour could not be confirmed from a log at all).

43 of 279 sessions (15%) held the prover longer than the 750ms other users wait, which is what makes this worth arbitrating rather than leaving to chance.

## Known gap not addressed here

`gossip.go:32` pushes attestation head roots straight into `FetchRootCh`, bypassing `queueMissingBlockFetch` and its `fetchInFlight` dedup — the flooding that dedup exists to prevent — and drops silently where the other path logs.

Benign at this scale (113 buffered attestations produced 97 fetches, ~1.16x) but it scales badly: N validators attesting to one unknown head queue N duplicate fetches for the same root. `onGossipAttestation` runs in its own goroutine (`workers.go:23`), so it cannot touch the dispatch-loop-owned `fetchInFlight` map — the same ownership constraint that shaped this PR. Needs a concurrency-safe dedup; deliberately left as separate work.

## Devnet caveat on the run itself

zeam was effectively absent — 11 blocks against ~286 expected, never joined gean's gossip mesh (every topic showed 1 mesh peer across 8,550 samples despite 2 connected peers), with QUIC handshake timeouts from both other clients. The chain finalized on exactly 2/3 with zero fault tolerance. Not a gean defect, but it bounds how much this run proves about multi-peer behaviour.
