### PR TITLE
fix(node): keep recovery splits out of the aggregation window

### DIFF
--- a/internal/aggregation/worker.go
+++ b/internal/aggregation/worker.go
@@ -22,11 +22,16 @@ type Dispatch struct {
 	Slot     uint64
 }
 
-// sessionBudget caps one aggregation session's proving time. Dispatch fires
+// SessionBudget caps one aggregation session's proving time. Dispatch fires
 // at interval 2, so two intervals of proving still leaves interval 4 for the
 // results to be promoted and gossiped, and bounds how long the proving gate
-// is held away from proposals.
-const sessionBudget = 2 * types.MillisecondsPerInterval * time.Millisecond
+// is held away from proposals. Exported so other prover users can stay clear
+// of the window this session occupies rather than fork the constant.
+const SessionBudget = 2 * types.MillisecondsPerInterval * time.Millisecond
+
+// AcquirePatience is how long a dispatched session waits for the prover before
+// giving up on the slot's aggregate.
+const AcquirePatience = 750 * time.Millisecond
 
 func RunWorker(
 	ctx context.Context,
@@ -53,7 +58,7 @@ func RunWorker(
 			if dispatch.Snapshot == nil {
 				continue
 			}
-			acquireCtx, cancelAcquire := context.WithTimeout(ctx, 750*time.Millisecond)
+			acquireCtx, cancelAcquire := context.WithTimeout(ctx, AcquirePatience)
 			if gate != nil && !gate.Acquire(acquireCtx, false) {
 				cancelAcquire()
 				metrics.IncProofOperation("aggregation", "canceled")
@@ -68,7 +73,7 @@ func RunWorker(
 			// (and their signature deletes) regrows the next snapshot until
 			// no session can ever finish inside a slot.
 			workerStart := time.Now()
-			aggs, payloads, deletes, truncated := aggregateFromSnapshot(dispatch.Snapshot, cache, workerStart.Add(sessionBudget), shadowRates, estimator)
+			aggs, payloads, deletes, truncated := aggregateFromSnapshot(dispatch.Snapshot, cache, workerStart.Add(SessionBudget), shadowRates, estimator)
 			if gate != nil {
 				gate.Release(false)
 			}

--- a/internal/node/clock.go
+++ b/internal/node/clock.go
@@ -15,3 +15,10 @@ func (e *Engine) currentInterval(timestampMs uint64) uint64 {
 	}
 	return types.CurrentInterval(e.Store.Config().GenesisTime, timestampMs)
 }
+
+func (e *Engine) millisIntoSlot(timestampMs uint64) uint64 {
+	if e == nil || e.Store == nil {
+		return 0
+	}
+	return types.MillisIntoSlot(e.Store.Config().GenesisTime, timestampMs)
+}

--- a/internal/node/recovery.go
+++ b/internal/node/recovery.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/geanlabs/gean/internal/aggregation"
 	"github.com/geanlabs/gean/internal/attestationproof"
 	"github.com/geanlabs/gean/internal/metrics"
 	"github.com/geanlabs/gean/internal/store"
@@ -15,6 +16,36 @@ import (
 )
 
 const maxRecoverySplits = 4
+
+const (
+	// recoverySplitBudget is how long one Type-2 split is assumed to hold the prover.
+	// Measured at roughly 700ms, rounded up to a full interval so the estimate errs
+	// toward yielding.
+	recoverySplitBudget = types.MillisecondsPerInterval * time.Millisecond
+	// aggregationDispatchOffset is how far into a slot aggregation is dispatched;
+	// onTick fires it at interval 2.
+	aggregationDispatchOffset = 2 * types.MillisecondsPerInterval * time.Millisecond
+)
+
+// splitFitsBeforeAggregation reports whether a Type-2 split started now would be done
+// with the prover before aggregation next needs it. A split takes about as long as
+// aggregation is willing to wait for the gate, so one running across the dispatch costs
+// the slot its aggregate — and a missed aggregate slows justification, the very thing
+// recovery exists to help. Recovery is best-effort and the aggregate is duty work, so
+// recovery yields the window rather than racing for it.
+func (e *Engine) splitFitsBeforeAggregation(nowMs uint64) bool {
+	intoSlot := time.Duration(e.millisIntoSlot(nowMs)) * time.Millisecond
+	windowEnd := aggregationDispatchOffset + aggregation.SessionBudget
+	if intoSlot >= aggregationDispatchOffset && intoSlot < windowEnd {
+		return false
+	}
+	untilDispatch := aggregationDispatchOffset - intoSlot
+	if intoSlot >= windowEnd {
+		// Past this slot's session; the next dispatch is in the following slot.
+		untilDispatch = types.MillisecondsPerSlot*time.Millisecond - intoSlot + aggregationDispatchOffset
+	}
+	return untilDispatch >= recoverySplitBudget
+}
 
 type recoveryCandidate struct {
 	att      *types.AggregatedAttestation
@@ -90,6 +121,10 @@ func (e *Engine) recoverBlockProofs(ctx context.Context, signedBlock *types.Sign
 		now = uint64(time.Now().UnixMilli())
 		currentSlot = e.currentSlot(now)
 		if _, proposesNext := e.getOurProposer(currentSlot + 1); proposesNext {
+			return
+		}
+		if !e.splitFitsBeforeAggregation(now) {
+			metrics.IncProofOperation("recovery", "canceled")
 			return
 		}
 		if e.ProvingGate != nil && !e.ProvingGate.Acquire(ctx, false) {

--- a/internal/node/recovery_window_test.go
+++ b/internal/node/recovery_window_test.go
@@ -1,0 +1,43 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/geanlabs/gean/internal/types"
+)
+
+// Recovery is best-effort; the slot's aggregate is duty work. A split takes about as
+// long as aggregation waits for the prover, so recovery must not start one that would
+// still be running when aggregation dispatches at interval 2, nor while the aggregation
+// session itself holds the prover.
+func TestSplitFitsBeforeAggregation(t *testing.T) {
+	e := makeTestEngine()
+	genesisMs := e.Store.Config().GenesisTime * 1000
+
+	const interval = types.MillisecondsPerInterval
+
+	tests := []struct {
+		name     string
+		intoSlot uint64
+		want     bool
+	}{
+		{"slot start, two intervals of room", 0, true},
+		{"start of interval 1, exactly one interval of room", interval, true},
+		{"mid interval 1, split would run past dispatch", interval + 400, false},
+		{"dispatch instant", 2 * interval, false},
+		{"inside aggregation session", 3 * interval, false},
+		{"session budget just elapsed, prover free again", 4 * interval, true},
+		{"late interval 4, next dispatch still far", 4*interval + 400, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Probe a later slot so the check is independent of the genesis boundary.
+			nowMs := genesisMs + 10*types.MillisecondsPerSlot + tc.intoSlot
+			if got := e.splitFitsBeforeAggregation(nowMs); got != tc.want {
+				t.Fatalf("splitFitsBeforeAggregation(+%dms into slot) = %t, want %t",
+					tc.intoSlot, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/types/clock.go
+++ b/internal/types/clock.go
@@ -11,7 +11,8 @@ func CurrentSlot(genesisTime, currentTimeMs uint64) uint64 {
 	return (currentTimeMs - genesisMs) / MillisecondsPerSlot
 }
 
-func CurrentInterval(genesisTime, currentTimeMs uint64) uint64 {
+// MillisIntoSlot returns how far the clock has advanced into the current slot.
+func MillisIntoSlot(genesisTime, currentTimeMs uint64) uint64 {
 	genesisMs, ok := unixMillis(genesisTime)
 	if !ok {
 		return 0
@@ -19,8 +20,11 @@ func CurrentInterval(genesisTime, currentTimeMs uint64) uint64 {
 	if currentTimeMs < genesisMs {
 		return 0
 	}
-	msIntoSlot := (currentTimeMs - genesisMs) % MillisecondsPerSlot
-	return msIntoSlot / MillisecondsPerInterval
+	return (currentTimeMs - genesisMs) % MillisecondsPerSlot
+}
+
+func CurrentInterval(genesisTime, currentTimeMs uint64) uint64 {
+	return MillisIntoSlot(genesisTime, currentTimeMs) / MillisecondsPerInterval
 }
 
 func TotalIntervals(genesisTime, currentTimeMs uint64) uint64 {


### PR DESCRIPTION
## Problem

Recovery acquires the prover with an **unbounded** context (`recovery.go:95`) and holds it for one `SplitType2Proof` at a time. An aggregation session waits **750ms** for the gate before giving up on the slot's aggregate (`worker.go:56`).

`proving.Gate` ranks proposals above background work, but gives two *background* users no ordering relative to each other. Recovery and aggregation therefore simply raced — and since recovery re-acquires immediately for its next candidate (up to `maxRecoverySplits = 4`), it could win repeatedly.

## Measurement

The severity turns entirely on how long one split takes, so I measured it against the real FFI rather than inferring:

| operation | measured |
|---|---|
| `SplitType2Proof`, 4 groups | **671ms / 677ms / 723ms** |
| `VerifyType2Proof`, 4 groups | 39ms |
| `MergeType1Proofs`, 4 groups | 2.97s |

A single split is **~670–720ms against a 750ms patience** — roughly 4% headroom. With up to 4 candidates back-to-back that is ~2.8s of near-continuous occupancy, spanning the interval-2 dispatch. A missed aggregate slows justification, which is the thing recovery exists to help.

Caveat: measured on arm64 macOS. Production amd64 builds with `-Ctarget-cpu=haswell` for AVX2 and should be faster, but real blocks carry more validators per group than this single-key probe, so I would expect production to be tighter rather than looser relative to the budget.

## Fix

Recovery is best-effort; the slot's aggregate is duty work. Recovery now starts a split only when it would be done with the prover before aggregation next needs it, and never while the session already owns it.

This extends the yield-check the candidate loop already performs for an upcoming proposal duty (`recovery.go:92`) rather than adding a priority level to `Gate` — the gate's existing `proposalPending` flag stops background *acquirers*, but does not preempt a background *holder*, so a new level would not have fixed this anyway.

`SessionBudget` and `AcquirePatience` are exported from `internal/aggregation` so the window is derived from the real values instead of a forked copy, and `MillisIntoSlot` is factored out of `CurrentInterval` for the offset math.

## Trade-off

Recovery loses throughput: it effectively gets interval 0, the start of interval 1, and interval 4. That is intended — a recovered proof is an optimisation, a missed aggregate is not — but it is a real reduction and worth stating plainly rather than burying.

## Testing

`TestSplitFitsBeforeAggregation` is table-driven across the slot: start-of-slot, the exact interval-1 boundary, mid-interval-1 (must yield), the dispatch instant, inside the session, and after the budget elapses. Probed at a later slot so the result is independent of the genesis boundary.

`make test` passes, `go vet ./...` clean, gofmt clean, `-race` clean on `internal/node`, `internal/aggregation`, `internal/types`.

## Scope

No spec surface touched — no changes to `internal/statetransition/` or `internal/forkchoice/`. leanSpec has no notion of a proving gate; this is gean-local scheduling.

Independent of #382 (different files); either can merge first.
