### PR TITLE
fix(specfixtures): match hive validator public-key field names

### DIFF
--- a/internal/specfixtures/parse_test.go
+++ b/internal/specfixtures/parse_test.go
@@ -172,3 +172,24 @@ func minimalTestState() TestState {
 func hexOfLen(n int) string {
 	return "0x" + hex.EncodeToString(make([]byte, n))
 }
+
+// TestValidator must map the fixture's public-key fields, which are serialized as
+// attestationPublicKey / proposalPublicKey. A tag mismatch here leaves both empty,
+// so ToState falls through to the single-key path and rejects every anchor with
+// "pubkey: missing" — silently failing the entire hive spec-test driver at init.
+func TestTestValidatorMapsCanonicalPublicKeyFields(t *testing.T) {
+	const raw = `{"attestationPublicKey":"0xaa","proposalPublicKey":"0xbb","index":7}`
+	var v TestValidator
+	if err := json.Unmarshal([]byte(raw), &v); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if v.AttestationPubkey != "0xaa" {
+		t.Fatalf("attestationPublicKey not mapped: got %q", v.AttestationPubkey)
+	}
+	if v.ProposalPubkey != "0xbb" {
+		t.Fatalf("proposalPublicKey not mapped: got %q", v.ProposalPubkey)
+	}
+	if v.Index != 7 {
+		t.Fatalf("index not mapped: got %d", v.Index)
+	}
+}

--- a/internal/specfixtures/types.go
+++ b/internal/specfixtures/types.go
@@ -60,8 +60,8 @@ type TestDataList struct {
 }
 
 type TestValidator struct {
-	AttestationPubkey string `json:"attestationPubkey"`
-	ProposalPubkey    string `json:"proposalPubkey"`
+	AttestationPubkey string `json:"attestationPublicKey"`
+	ProposalPubkey    string `json:"proposalPublicKey"`
 	Pubkey            string `json:"pubkey"`
 	Index             uint64 `json:"index"`
 }


### PR DESCRIPTION
## Problem

The hive lean spec-test driver decodes each fixture's anchor validators through `specfixtures.TestValidator`, whose JSON tags read `attestationPubkey` / `proposalPubkey`. The devnet5 fixtures (and gean's own `internal/spectests` loader) serialize these as **`attestationPublicKey` / `proposalPublicKey`**.

With the tags mismatched, both fields decoded empty, so `ToState` fell through to the single-key path and rejected every anchor with `pubkey: missing`. `fork_choice/init` then returned **HTTP 400** for essentially every fixture — and because all three suites parse validators through the same `TestState.ToState()` (`transition.go:21`, `verify.go:23`, fork-choice init), the failure sank fork-choice, state-transition, and verify-signatures alike. It was anchor ingestion, not consensus logic.

This is why the driver scored ~1/123 fork-choice, 0/74 state-transition, 0/3 verify-signatures once the routes were reachable at all (after the `hive_testdriver` packaging fix).

## Fix

Align the tags with the fixture schema and the local `spectests` loader (which already uses the correct names — that's why `make test-spec` was green while hive was red; the two are separate type sets and only the driver's was stale).

Two-line tag change plus a regression test. The existing driver tests only used empty validator lists, so they never exercised this path — the test asserts the canonical field names map, and was verified to fail on the old tags.

## Validation

Reproduced against a real devnet5 fixture: with the fix, gean's computed state root **matches** the fixture's `anchorBlock.stateRoot`, so `init` returns 204.

Confirmed end-to-end in a hive run of all three spec suites (gean + ethlambda + ream + zeam):

| suite | before | after |
|---|---|---|
| fork-choice | 1/123 | 78/123 |
| state-transition | 0/74 | 73/74 |
| verify-signatures | 0/3 | 2/3 |

`init` HTTP 400s dropped from 122 to 0. Remaining fork-choice failures are a separate, unrelated layer (fork-choice step behavior) tracked for follow-up.

## Scope

Isolated to the hive test-driver ingestion path (`internal/specfixtures`); no consensus, SSZ, or production code touched. Builds plain and `-tags hive_testdriver`; `specfixtures` and `testdriver` tests pass.