### PR TITLE
fix(testdriver): align fork-choice step semantics with the spec harness

### DIFF
--- a/internal/api/testdriver/forkchoice.go
+++ b/internal/api/testdriver/forkchoice.go
@@ -113,6 +113,11 @@ func (sess *Session) ForkChoiceInitHandler() http.HandlerFunc {
 	}
 }
 
+func stepChecksSafeTarget(step *specfixtures.ForkChoiceStep) bool {
+	c := step.Checks
+	return c != nil && (c.SafeTarget != nil || c.SafeTargetSlot != nil || c.SafeTargetRootLabel != nil)
+}
+
 func writeInitFailure(w http.ResponseWriter, msg string) {
 	resp := driverStepResponse{Accepted: false, Error: &msg, Snapshot: driverSnapshot{}}
 	writeJSON(w, http.StatusBadRequest, resp)
@@ -151,7 +156,12 @@ func (sess *Session) ForkChoiceStepHandler() http.HandlerFunc {
 			stepErr = fmt.Errorf("unknown stepType %q", step.StepType)
 		}
 
-		sess.refreshSafeTarget()
+		// Safe target mutates the protoarray with the supermajority threshold, which
+		// would corrupt the next step's head deltas. Compute it only when the step
+		// actually checks it, and after the head is already stored for this step.
+		if stepChecksSafeTarget(&step) {
+			sess.refreshSafeTarget()
+		}
 		snap := sess.loadSnapshot()
 		accepted := stepErr == nil
 		var errPtr *string

--- a/internal/api/testdriver/forkchoice_replay_test.go
+++ b/internal/api/testdriver/forkchoice_replay_test.go
@@ -1,0 +1,285 @@
+//go:build hive_testdriver
+
+package testdriver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geanlabs/gean/internal/specfixtures"
+)
+
+// TestForkChoiceReplayLocalFixtures drives the local fork-choice spec fixtures
+// through the HTTP step handlers exactly as the hive simulator does, then asserts
+// the returned snapshot with label resolution — the same checks the local
+// spectests harness makes. It is the fast, hive-free guard that the driver's
+// step semantics match the fork-choice engine the local harness already proves
+// correct. Skips when the fixtures have not been generated.
+func TestForkChoiceReplayLocalFixtures(t *testing.T) {
+	root := forkChoiceFixtureRoot(t)
+	files := collectJSON(t, root)
+	if len(files) == 0 {
+		t.Skipf("no fork-choice fixtures under %s (run make test-spec)", root)
+	}
+
+	for _, file := range files {
+		raw, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		var wrapper map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &wrapper); err != nil {
+			t.Fatalf("parse %s: %v", file, err)
+		}
+		for name, caseRaw := range wrapper {
+			name := name
+			caseRaw := caseRaw
+			t.Run(shortName(file, name), func(t *testing.T) {
+				runReplayCase(t, caseRaw)
+			})
+		}
+	}
+}
+
+type replayFixture struct {
+	AnchorState json.RawMessage   `json:"anchorState"`
+	AnchorBlock json.RawMessage   `json:"anchorBlock"`
+	Steps       []json.RawMessage `json:"steps"`
+}
+
+func runReplayCase(t *testing.T, caseRaw json.RawMessage) {
+	var rc replayFixture
+	if err := json.Unmarshal(caseRaw, &rc); err != nil {
+		t.Fatalf("decode case: %v", err)
+	}
+
+	sess := NewSession()
+
+	// Init.
+	genesisTime := pointerU64(caseRaw, "anchorState", "config", "genesisTime")
+	init := map[string]any{"anchorState": rc.AnchorState, "anchorBlock": rc.AnchorBlock}
+	if genesisTime != nil {
+		init["genesisTime"] = *genesisTime
+	}
+	initRec := post(t, sess.ForkChoiceInitHandler(), init)
+	if len(rc.Steps) == 0 && initRec.Code != http.StatusNoContent {
+		return // negative anchor fixture: init rejection is the expected outcome
+	}
+	if initRec.Code != http.StatusNoContent {
+		t.Fatalf("init failed: status=%d body=%s", initRec.Code, initRec.Body.String())
+	}
+
+	// Resolve label -> root and root -> slot on the test side, mirroring the
+	// blockRootLabel the fixtures reference in their checks.
+	labelToRoot := map[string]string{}
+	rootToSlot := map[string]uint64{}
+	if r, s := anchorRootSlot(t, rc.AnchorBlock); r != "" {
+		rootToSlot[r] = s
+	}
+
+	for i, stepRaw := range rc.Steps {
+		var step specfixtures.ForkChoiceStep
+		if err := json.Unmarshal(stepRaw, &step); err != nil {
+			t.Fatalf("step %d decode: %v", i, err)
+		}
+		if step.StepType == "block" && step.Block != nil {
+			if root, slot, ok := blockRootSlot(step.Block); ok {
+				rootToSlot[root] = slot
+				if step.Block.BlockRootLabel != "" {
+					labelToRoot[step.Block.BlockRootLabel] = root
+				}
+			}
+		}
+
+		var resp driverStepResponse
+		rec := post(t, sess.ForkChoiceStepHandler(), stepRaw)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("step %d: status=%d body=%s", i, rec.Code, rec.Body.String())
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("step %d decode response: %v", i, err)
+		}
+
+		// Acceptance: the driver reports actual acceptance; it must match the
+		// fixture's declared expectation.
+		if hasField(stepRaw, "valid") && resp.Accepted != step.Valid {
+			t.Fatalf("step %d (%s) acceptance: got %v want %v (err=%v)",
+				i, step.StepType, resp.Accepted, step.Valid, resp.Error)
+		}
+		if !resp.Accepted {
+			continue
+		}
+		if step.Checks != nil {
+			assertChecks(t, i, step.Checks, resp.Snapshot, labelToRoot, rootToSlot)
+		}
+	}
+}
+
+func assertChecks(t *testing.T, idx int, c *specfixtures.FCChecks, snap driverSnapshot, labelToRoot map[string]string, rootToSlot map[string]uint64) {
+	if c.HeadSlot != nil && snap.HeadSlot != *c.HeadSlot {
+		t.Fatalf("step %d headSlot: got %d want %d", idx, snap.HeadSlot, *c.HeadSlot)
+	}
+	if c.HeadRoot != nil && norm(snap.HeadRoot) != norm(*c.HeadRoot) {
+		t.Fatalf("step %d headRoot: got %s want %s", idx, norm(snap.HeadRoot), norm(*c.HeadRoot))
+	}
+	if c.HeadRootLabel != nil {
+		if want, ok := labelToRoot[*c.HeadRootLabel]; ok && norm(snap.HeadRoot) != norm(want) {
+			t.Fatalf("step %d headRootLabel %q: got %s want %s", idx, *c.HeadRootLabel, norm(snap.HeadRoot), norm(want))
+		}
+	}
+	if c.Time != nil && snap.Time != *c.Time {
+		t.Fatalf("step %d time: got %d want %d", idx, snap.Time, *c.Time)
+	}
+	if c.LatestJustifiedSlot != nil && snap.JustifiedCheckpoint.Slot != *c.LatestJustifiedSlot {
+		t.Fatalf("step %d justifiedSlot: got %d want %d", idx, snap.JustifiedCheckpoint.Slot, *c.LatestJustifiedSlot)
+	}
+	if c.LatestJustifiedRootLabel != nil {
+		if want, ok := labelToRoot[*c.LatestJustifiedRootLabel]; ok && norm(snap.JustifiedCheckpoint.Root) != norm(want) {
+			t.Fatalf("step %d justifiedRootLabel %q: got %s want %s", idx, *c.LatestJustifiedRootLabel, norm(snap.JustifiedCheckpoint.Root), norm(want))
+		}
+	}
+	if c.LatestFinalizedSlot != nil && snap.FinalizedCheckpoint.Slot != *c.LatestFinalizedSlot {
+		t.Fatalf("step %d finalizedSlot: got %d want %d", idx, snap.FinalizedCheckpoint.Slot, *c.LatestFinalizedSlot)
+	}
+	if c.LatestFinalizedRootLabel != nil {
+		if want, ok := labelToRoot[*c.LatestFinalizedRootLabel]; ok && norm(snap.FinalizedCheckpoint.Root) != norm(want) {
+			t.Fatalf("step %d finalizedRootLabel %q: got %s want %s", idx, *c.LatestFinalizedRootLabel, norm(snap.FinalizedCheckpoint.Root), norm(want))
+		}
+	}
+	if c.SafeTarget != nil && norm(snap.SafeTarget) != norm(*c.SafeTarget) {
+		t.Fatalf("step %d safeTarget: got %s want %s", idx, norm(snap.SafeTarget), norm(*c.SafeTarget))
+	}
+	if c.SafeTargetRootLabel != nil {
+		if want, ok := labelToRoot[*c.SafeTargetRootLabel]; ok && norm(snap.SafeTarget) != norm(want) {
+			t.Fatalf("step %d safeTargetRootLabel %q: got %s want %s", idx, *c.SafeTargetRootLabel, norm(snap.SafeTarget), norm(want))
+		}
+	}
+	if c.SafeTargetSlot != nil {
+		if got, ok := rootToSlot[norm(snap.SafeTarget)]; ok && got != *c.SafeTargetSlot {
+			t.Fatalf("step %d safeTargetSlot: got %d want %d", idx, got, *c.SafeTargetSlot)
+		}
+	}
+}
+
+// --- helpers ---
+
+func post(t *testing.T, h http.HandlerFunc, payload any) *httptest.ResponseRecorder {
+	t.Helper()
+	var body []byte
+	switch p := payload.(type) {
+	case json.RawMessage:
+		body = p
+	default:
+		b, err := json.Marshal(p)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		body = b
+	}
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(body)))
+	rec := httptest.NewRecorder()
+	h(rec, req)
+	return rec
+}
+
+func blockRootSlot(b *specfixtures.TestBlock) (string, uint64, bool) {
+	block, err := b.ToBlock()
+	if err != nil {
+		return "", 0, false
+	}
+	root, err := block.HashTreeRoot()
+	if err != nil {
+		return "", 0, false
+	}
+	return norm(hex(root[:])), block.Slot, true
+}
+
+func anchorRootSlot(t *testing.T, anchorRaw json.RawMessage) (string, uint64) {
+	var tb specfixtures.TestBlock
+	if err := json.Unmarshal(anchorRaw, &tb); err != nil {
+		return "", 0
+	}
+	r, s, ok := blockRootSlot(&tb)
+	if !ok {
+		return "", 0
+	}
+	return r, s
+}
+
+func norm(s string) string { return strings.ToLower(strings.TrimPrefix(s, "0x")) }
+
+func hex(b []byte) string {
+	const h = "0123456789abcdef"
+	out := make([]byte, len(b)*2)
+	for i, c := range b {
+		out[i*2] = h[c>>4]
+		out[i*2+1] = h[c&0xf]
+	}
+	return string(out)
+}
+
+func hasField(raw json.RawMessage, key string) bool {
+	var m map[string]json.RawMessage
+	if json.Unmarshal(raw, &m) != nil {
+		return false
+	}
+	_, ok := m[key]
+	return ok
+}
+
+func pointerU64(raw json.RawMessage, path ...string) *uint64 {
+	cur := raw
+	for _, k := range path {
+		var m map[string]json.RawMessage
+		if json.Unmarshal(cur, &m) != nil {
+			return nil
+		}
+		next, ok := m[k]
+		if !ok {
+			return nil
+		}
+		cur = next
+	}
+	var v uint64
+	if json.Unmarshal(cur, &v) != nil {
+		return nil
+	}
+	return &v
+}
+
+func forkChoiceFixtureRoot(t *testing.T) string {
+	t.Helper()
+	// package dir internal/api/testdriver -> repo root is three levels up.
+	return filepath.Join("..", "..", "..", "leanSpec", "fixtures", "consensus", "fork_choice", "lstar", "fork_choice")
+}
+
+func collectJSON(t *testing.T, root string) []string {
+	t.Helper()
+	var out []string
+	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !info.IsDir() && strings.HasSuffix(path, ".json") {
+			out = append(out, path)
+		}
+		return nil
+	})
+	return out
+}
+
+func shortName(file, testName string) string {
+	base := strings.TrimSuffix(filepath.Base(file), ".json")
+	if i := strings.Index(testName, "::"); i >= 0 {
+		testName = testName[i+2:]
+	}
+	if i := strings.Index(testName, "["); i >= 0 {
+		testName = testName[:i]
+	}
+	return base + "/" + testName
+}

--- a/internal/api/testdriver/steps.go
+++ b/internal/api/testdriver/steps.go
@@ -1,6 +1,7 @@
 package testdriver
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/geanlabs/gean/internal/attestation"
@@ -10,25 +11,73 @@ import (
 	"github.com/geanlabs/gean/internal/types"
 )
 
+// mockedProofSentinel prefixes the placeholder aggregation proofs the upstream
+// fixtures carry for weight-only vectors. A proof bearing it is not real crypto,
+// so signature verification is skipped for it — mirroring the local spec-test
+// harness so the same fixtures resolve identically through the HTTP driver.
+var mockedProofSentinel = []byte("\x00MOCKED-AGGREGATION-PROOF\x00")
+
+func carriesMockedProof(proof []byte) bool {
+	return bytes.HasPrefix(proof, mockedProofSentinel)
+}
+
+// earliestAdmissibleInterval is the lowest store time at which a slot-N vote
+// clears the future-admission check: admission allows
+// slot*INTERVALS_PER_SLOT <= time + GOSSIP_DISPARITY_INTERVALS, so the vote is
+// admissible one disparity interval before its slot starts. Advancing exactly to
+// this interval — never to the slot start — keeps a following tick's promotion
+// from being swallowed.
+func earliestAdmissibleInterval(slot uint64) uint64 {
+	start := slot * types.IntervalsPerSlot
+	if start < types.GossipDisparityIntervals {
+		return 0
+	}
+	return start - types.GossipDisparityIntervals
+}
+
 func (sess *Session) applyTick(step *specfixtures.ForkChoiceStep) error {
 	cfg := sess.store.Config()
 	if cfg == nil {
 		return fmt.Errorf("tick step before config set")
 	}
-	genesisMs := cfg.GenesisTime * 1000
 
+	var target uint64
 	switch {
 	case step.Time != nil:
+		genesisMs := cfg.GenesisTime * 1000
 		timestampMs := *step.Time * 1000
-		if timestampMs < genesisMs {
-			sess.store.SetTime(0)
-		} else {
-			sess.store.SetTime((timestampMs - genesisMs) / types.MillisecondsPerInterval)
+		if timestampMs >= genesisMs {
+			target = (timestampMs - genesisMs) / types.MillisecondsPerInterval
 		}
 	case step.Interval != nil:
-		sess.store.SetTime(*step.Interval)
+		target = *step.Interval
 	default:
 		return fmt.Errorf("tick step missing time and interval")
+	}
+
+	// Advance one interval at a time, mirroring leanSpec on_tick. Stepping is
+	// load-bearing: jumping to the target would skip the intervening slot-boundary
+	// intervals whose actions promote the new-vote pool into the known pool and
+	// recompute the head. Promotion happens at interval 4 always, and at interval 0
+	// when a proposal has landed — the latter only on the final interval, matching
+	// the spec's should_signal_proposal gate.
+	hasProposal := step.HasProposal != nil && *step.HasProposal
+	for sess.store.Time() < target {
+		next := sess.store.Time() + 1
+		sess.store.SetTime(next)
+		interval := next % types.IntervalsPerSlot
+		signalProposal := hasProposal && next == target
+		if interval == 4 || (interval == 0 && signalProposal) {
+			sess.store.PromoteNewToKnown()
+		}
+		if interval == 0 || interval == 4 {
+			sess.updateHeadFromKnown(sess.store.LatestJustified().Root)
+		}
+	}
+	// A tick to at or behind the clock still pins store.time so a later time check
+	// reads the fixture's value.
+	if target < sess.store.Time() {
+		sess.store.SetTime(target)
 	}
 	return nil
 }
@@ -44,9 +93,14 @@ func (sess *Session) applyBlock(step *specfixtures.ForkChoiceStep) error {
 
 	signedBlock := &types.SignedBlock{Block: block, Proof: &types.MultiMessageAggregate{}}
 
-	minTime := block.Slot * types.IntervalsPerSlot
-	if sess.store.Time() < minTime {
-		sess.store.SetTime(minTime)
+	// Advance the clock to this block's slot unless the fixture delivers it ahead
+	// of the clock (tickToSlot=false). The clock gates attestation future-validation,
+	// so it must reach the slot before subsequent attestations validate.
+	if step.TickToSlot == nil || *step.TickToSlot {
+		minTime := block.Slot * types.IntervalsPerSlot
+		if sess.store.Time() < minTime {
+			sess.store.SetTime(minTime)
+		}
 	}
 
 	if err := blockprocessor.OnBlockWithoutVerification(sess.store, signedBlock); err != nil {
@@ -62,13 +116,37 @@ func (sess *Session) applyBlock(step *specfixtures.ForkChoiceStep) error {
 	}
 	sess.fc.OnBlock(block.Slot, blockRoot, block.ParentRoot)
 
-	attestations := sess.store.ExtractLatestKnownAttestations()
-	for vid, data := range attestations {
+	// Seed the block's on-chain aggregated attestations into the known pool with
+	// their participant sets so the votes carry fork-choice weight. Block import
+	// alone stores the data weightless, which would mis-resolve weight-driven
+	// reorgs. Only participants are read during head computation, so a non-empty
+	// placeholder proof suffices.
+	if block.Body != nil {
+		for _, att := range block.Body.Attestations {
+			if att == nil || att.Data == nil || types.BitlistCount(att.AggregationBits) == 0 {
+				continue
+			}
+			dataRoot, err := att.Data.HashTreeRoot()
+			if err != nil {
+				continue
+			}
+			sess.store.KnownPayloads.Push(dataRoot, att.Data, &types.SingleMessageAggregate{
+				Participants: att.AggregationBits,
+				Proof:        []byte{0x01},
+			})
+		}
+	}
+
+	justifiedRoot := sess.store.LatestJustified().Root
+	sess.updateHeadFromKnown(justifiedRoot)
+
+	// Promote new payloads to known, then reflect the just-promoted votes into the
+	// known tracker — the next head update re-derives known votes from the promoted
+	// pool, so a vote gossiped as "new" would otherwise stay absent from the tracker.
+	sess.store.PromoteNewToKnown()
+	for vid, data := range sess.store.ExtractLatestKnownAttestations() {
 		sess.fc.SetKnownVote(vid, data.Head.Root, data.Slot, data)
 	}
-	justifiedRoot := sess.store.LatestJustified().Root
-	sess.setCanonicalHead(justifiedRoot)
-	sess.store.PromoteNewToKnown()
 	return nil
 }
 
@@ -81,31 +159,50 @@ func (sess *Session) applyAttestation(step *specfixtures.ForkChoiceStep) error {
 		return err
 	}
 
+	// For valid steps advance just enough to clear the future-admission check,
+	// stopping one disparity interval before the slot start. Invalid steps keep the
+	// current time so the rejection path still fires.
 	if step.Valid {
-		minTime := attData.Slot * types.IntervalsPerSlot
-		if sess.store.Time() < minTime {
+		if minTime := earliestAdmissibleInterval(attData.Slot); sess.store.Time() < minTime {
 			sess.store.SetTime(minTime)
 		}
-	}
-	if err := attestation.ValidateAttestationData(sess.store, attData); err != nil {
-		return err
 	}
 
 	dataRoot, err := attData.HashTreeRoot()
 	if err != nil {
 		return err
 	}
-	if err := sess.verifyGossipAttestation(step.Attestation.ValidatorID, attData, dataRoot, step.Attestation.Signature); err != nil {
+	signature, err := specfixtures.ParseHexBytes(step.Attestation.Signature)
+	if err != nil {
+		return fmt.Errorf("decode signature hex: %w", err)
+	}
+
+	// Data/bounds validation always runs so rejection fixtures exercise the
+	// validator. The crypto check is skipped only for mocked placeholder proofs.
+	// A non-nil error reports the step as not accepted; the simulator compares
+	// that against the fixture's expected outcome.
+	if err := attestation.ValidateAttestationData(sess.store, attData); err != nil {
 		return err
+	}
+	if !carriesMockedProof(signature) {
+		if err := attestation.VerifyGossipAttestation(sess.store, step.Attestation.ValidatorID, attData, dataRoot, signature); err != nil {
+			return err
+		}
 	}
 
 	participants := types.BitlistFromIndices([]uint64{step.Attestation.ValidatorID})
-	proof := &types.SingleMessageAggregate{Participants: participants}
-	sess.store.NewPayloads.Push(dataRoot, attData, proof)
+	sess.store.NewPayloads.Push(dataRoot, attData, &types.SingleMessageAggregate{Participants: participants})
+
+	var sig [types.SignatureSize]byte
+	copy(sig[:], signature)
+	sess.store.AttestationSignatures.Insert(dataRoot, attData, step.Attestation.ValidatorID, sig)
 
 	sess.fc.SetNewVote(step.Attestation.ValidatorID, attData.Head.Root, attData.Slot, attData)
 
-	sess.promoteVotesAndUpdateHead()
+	// Gossip lands in the new pool only; the head keeps reflecting the known pool
+	// until a slot-boundary tick promotes these votes, so recompute from the known
+	// pool here without promoting.
+	sess.updateHeadFromKnown(sess.store.LatestJustified().Root)
 	return nil
 }
 
@@ -119,13 +216,9 @@ func (sess *Session) applyAggregatedAttestation(step *specfixtures.ForkChoiceSte
 	}
 
 	if step.Valid {
-		minTime := attData.Slot * types.IntervalsPerSlot
-		if sess.store.Time() < minTime {
+		if minTime := earliestAdmissibleInterval(attData.Slot); sess.store.Time() < minTime {
 			sess.store.SetTime(minTime)
 		}
-	}
-	if err := attestation.ValidateAttestationData(sess.store, attData); err != nil {
-		return err
 	}
 
 	var participants []byte
@@ -142,56 +235,51 @@ func (sess *Session) applyAggregatedAttestation(step *specfixtures.ForkChoiceSte
 	if err != nil {
 		return err
 	}
-	if err := attestation.VerifyAggregatedGossipAttestation(sess.store, attData, participants, proofData); err != nil {
+
+	if err := attestation.ValidateAttestationData(sess.store, attData); err != nil {
 		return err
 	}
+	if !carriesMockedProof(proofData) {
+		if err := attestation.VerifyAggregatedGossipAttestation(sess.store, attData, participants, proofData); err != nil {
+			return err
+		}
+	}
 
-	proof := &types.SingleMessageAggregate{Participants: participants, Proof: proofData}
-	sess.store.NewPayloads.Push(dataRoot, attData, proof)
+	sess.store.NewPayloads.Push(dataRoot, attData, &types.SingleMessageAggregate{Participants: participants, Proof: proofData})
 
 	for _, vid := range types.BitlistIndices(participants) {
 		sess.fc.SetNewVote(vid, attData.Head.Root, attData.Slot, attData)
 	}
 
-	sess.promoteVotesAndUpdateHead()
+	sess.updateHeadFromKnown(sess.store.LatestJustified().Root)
 	return nil
 }
 
-func (sess *Session) verifyGossipAttestation(validatorID uint64, attData *types.AttestationData, dataRoot [32]byte, signatureHex string) error {
-	sigBytes, err := specfixtures.ParseHexBytes(signatureHex)
-	if err != nil {
-		return fmt.Errorf("decode signature hex: %w", err)
-	}
-	return attestation.VerifyGossipAttestation(sess.store, validatorID, attData, dataRoot, sigBytes)
-}
-
-func (sess *Session) promoteVotesAndUpdateHead() {
-	sess.store.PromoteNewToKnown()
-	knownAtts := sess.store.ExtractLatestKnownAttestations()
-	for vid, data := range knownAtts {
+// updateHeadFromKnown reflects the current known-pool votes into fork choice and
+// recomputes the head, without promoting the new pool.
+func (sess *Session) updateHeadFromKnown(justifiedRoot [32]byte) {
+	for vid, data := range sess.store.ExtractLatestKnownAttestations() {
 		sess.fc.SetKnownVote(vid, data.Head.Root, data.Slot, data)
 	}
-	justifiedRoot := sess.store.LatestJustified().Root
-	sess.setCanonicalHead(justifiedRoot)
+	sess.updateHead(justifiedRoot)
 }
 
-// setCanonicalHead recomputes the head and re-anchors the finalized checkpoint to
-// the head's chain, mirroring the spec's update_head. Finalization is derived here
-// rather than during block import, matching the live node's head selection.
-func (sess *Session) setCanonicalHead(justifiedRoot [32]byte) {
+// updateHead recomputes the head and re-anchors the finalized checkpoint to the
+// head's chain, mirroring the spec's update_head. Finalization tracks the head's
+// chain unconditionally: a higher-finalized fork that loses head selection must
+// not latch.
+func (sess *Session) updateHead(justifiedRoot [32]byte) {
 	headRoot := sess.fc.UpdateHead(justifiedRoot)
 	sess.store.SetHead(headRoot)
-
-	derived := store.DeriveFinalizedFromHead(sess.store, headRoot)
-	if derived == nil {
-		return
+	if derived := store.DeriveFinalizedFromHead(sess.store, headRoot); derived != nil {
+		sess.store.SetLatestFinalized(derived)
 	}
-	if current := sess.store.LatestFinalized(); current != nil && derived.Slot <= current.Slot {
-		return
-	}
-	sess.store.SetLatestFinalized(derived)
 }
 
+// refreshSafeTarget computes the safe target on demand. It mutates the protoarray
+// scores with the supermajority threshold, so it must run after the head is
+// already recomputed and stored for the step — never before, and only when a
+// safe-target check needs the value.
 func (sess *Session) refreshSafeTarget() {
 	headState := sess.store.GetState(sess.store.Head())
 	if headState == nil {

--- a/internal/specfixtures/types.go
+++ b/internal/specfixtures/types.go
@@ -117,6 +117,9 @@ type ForkChoiceStep struct {
 	Time        *uint64              `json:"time,omitempty"`
 	Interval    *uint64              `json:"interval,omitempty"`
 	HasProposal *bool                `json:"hasProposal,omitempty"`
+	// TickToSlot, when present and false, delivers a block ahead of the store
+	// clock instead of advancing the clock to the block's slot first.
+	TickToSlot *bool `json:"tickToSlot,omitempty"`
 }
 
 type FCGossipAttestation struct {


### PR DESCRIPTION
Follow-up to #385. With the driver's routes reachable and anchors ingesting, gean's hive fork-choice suite went 1/123 → 78/123 — but 45 fixtures still failed on head-slot / head-root / acceptance mismatches. These are **not** engine defects: gean's fork-choice engine passes all the same fixtures locally (246/246 via `internal/spectests`). The hive **test-driver** drove that engine differently from the local spectests harness.

## Divergences fixed (local harness as the reference)

1. **Safe target ran after every step.** `UpdateSafeTarget` mutates the protoarray with the supermajority threshold (`ComputeDeltas(false)`), corrupting the deltas the next step's `UpdateHead` (`ComputeDeltas(true)`) reads. Now computed only when a step checks `safeTarget`, after the head is stored.
2. **Tick jumped straight to the target time.** Now advances one interval at a time, so slot-boundary intervals (4 always, 0 on a signalled proposal) promote the new-vote pool into known and recompute the head — matching `on_tick`.
3. **Block steps didn't seed on-chain attestation weight.** Block votes were weightless, mis-resolving weight-driven reorgs. Now seeded into the known pool with participant bits; finalized tracks the head's chain unconditionally.
4. **Gossip attestations promoted immediately and admitted at slot start.** Now kept in the new pool until a tick promotes them, admitted one gossip-disparity interval earlier, with mocked-proof handling and raw-signature recording.

Adds the `tickToSlot` step field the block path needs.

## Validation (no hive run required)

`TestForkChoiceReplayLocalFixtures` drives every local fork-choice fixture through the HTTP handlers with label resolution — the same checks the local harness makes. Verified non-vacuous: it **fails on the old handler** (reproducing the exact hive failures — `block_beyond_future_horizon`, `block_builder_fixed_point_advances_justification`, …) and **passes 123/123 on the new handler**.

`make test` green; local fork-choice spectests still green (engine untouched); builds plain and `-tags hive_testdriver`.

## Scope

Only the hive test-driver step path (`internal/api/testdriver`) and the `tickToSlot` fixture field. No consensus, fork-choice engine, SSZ, or production code changed.