### PR TITLE
docs: add sponsor button and donations section

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# Funding options surfaced by the GitHub "Sponsor" button.
+# https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+custom: ["https://etherscan.io/address/0xB7AD723DDEF4Df973E898D36256E76Ab8489D57E"]

--- a/README.md
+++ b/README.md
@@ -65,3 +65,9 @@ Gean treats reviewability as a consensus-safety property. Consensus-critical beh
 ## License
 
 Gean is open-source software released under the MIT license.
+
+## Donations
+
+We are a small team of African Ethereum core developers building Gean. Gean is an open-source project and a public good. Funding public goods is hard, and our work is supported through grants, community support, and individual donations.
+
+We work full-time to contribute to the Ethereum ecosystem. If you would like to support our work, you can find our ETH address under **"Sponsor this project"** on this repository.


### PR DESCRIPTION
Enables the ♥ Sponsor button on this repository and documents how the project is funded.

## Changes

- **`.github/FUNDING.yml`** (new) — `custom:` entry pointing at the project ETH address on Etherscan. GitHub renders this as the Sponsor button next to Watch/Fork/Star.
- **`README.md`** — new `## Donations` section describing the team and how the work is supported, directing readers to the Sponsor button for the address.

## Notes

- GitHub only reads `FUNDING.yml` from the **default branch**, so the button will not appear until this merges to `main`.
- If the button still does not show after merge, check **Settings → General → Features → Sponsorships** is enabled for the repo.
- Docs only. No Go or Rust code touched, so build and test are unaffected.