### PR TITLE
fix(p2p): bound req/resp reads and writes with an idle deadline

### DIFF
--- a/internal/metrics/counters.go
+++ b/internal/metrics/counters.go
@@ -78,4 +78,8 @@ var (
 	metricProofOperations = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "lean_proof_operations_total", Help: "Recursive proof operations by result",
 	}, []string{"operation", "result"})
+	metricReqRespTimeout = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "lean_p2p_reqresp_timeout_total",
+		Help: "Req/resp stream operations aborted by the idle deadline, by protocol and direction",
+	}, []string{"protocol", "direction"})
 )

--- a/internal/metrics/inc.go
+++ b/internal/metrics/inc.go
@@ -35,3 +35,7 @@ func IncPeerConnection(direction, result string) {
 func IncPeerDisconnection(direction, reason string) {
 	metricPeerDisconnectionEvents.WithLabelValues(labelOrUnknown(direction), labelOrUnknown(reason)).Inc()
 }
+
+func IncReqRespTimeout(protocol, direction string) {
+	metricReqRespTimeout.WithLabelValues(labelOrUnknown(protocol), labelOrUnknown(direction)).Inc()
+}

--- a/internal/p2p/deadline.go
+++ b/internal/p2p/deadline.go
@@ -1,0 +1,53 @@
+package p2p
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/network"
+
+	"github.com/geanlabs/gean/internal/metrics"
+)
+
+// Req/resp streams are bounded by an idle deadline, not a single total one: the
+// deadline is reset before every read and write, so a peer that keeps making
+// progress is never cut, while one that opens the stream and then stalls is
+// aborted within ReqRespTimeout. A total deadline would sever a legitimate but
+// slow large backfill mid-transfer; the context passed to NewStream only covers
+// stream establishment, so without these the response read is unbounded and a
+// single stalled peer can wedge the fetch loop indefinitely.
+
+func armReadDeadline(s network.Stream) {
+	_ = s.SetReadDeadline(time.Now().Add(ReqRespTimeout))
+}
+
+func armWriteDeadline(s network.Stream) {
+	_ = s.SetWriteDeadline(time.Now().Add(ReqRespTimeout))
+}
+
+// isStreamTimeout reports whether err is a read/write deadline expiry, so a stalled
+// peer is attributed distinctly from other transport failures.
+func isStreamTimeout(err error) bool {
+	if errors.Is(err, os.ErrDeadlineExceeded) {
+		return true
+	}
+	var ne net.Error
+	return errors.As(err, &ne) && ne.Timeout()
+}
+
+// readReqRespChunk arms the idle read deadline, decodes one response frame, and on a
+// deadline expiry records the stall and returns a clear error. r reads from the stream
+// (directly or through a size-limiting wrapper); s is armed for the deadline.
+func readReqRespChunk(s network.Stream, r io.Reader, protocol string) (byte, []byte, error) {
+	armReadDeadline(s)
+	code, data, err := DecodeResponse(r)
+	if err != nil && isStreamTimeout(err) {
+		metrics.IncReqRespTimeout(protocol, "read")
+		return code, data, fmt.Errorf("%s: response read stalled beyond %s: %w", protocol, ReqRespTimeout, err)
+	}
+	return code, data, err
+}

--- a/internal/p2p/deadline_test.go
+++ b/internal/p2p/deadline_test.go
@@ -1,0 +1,99 @@
+package p2p
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/network"
+)
+
+// deadlineStream records the deadlines set on it and serves a scripted read error,
+// standing in for a peer that opens a req/resp stream and then stalls.
+type deadlineStream struct {
+	network.Stream
+	readDeadline time.Time
+	readErr      error
+}
+
+func (s *deadlineStream) SetReadDeadline(t time.Time) error  { s.readDeadline = t; return nil }
+func (s *deadlineStream) SetWriteDeadline(t time.Time) error { return nil }
+func (s *deadlineStream) Read(p []byte) (int, error) {
+	if s.readErr != nil {
+		return 0, s.readErr
+	}
+	return 0, io.EOF
+}
+
+// A stalled response read must be bounded by an idle deadline — before this fix the
+// read had none and a connected-but-silent peer blocked the fetch loop forever.
+func TestReadReqRespChunkArmsIdleDeadline(t *testing.T) {
+	s := &deadlineStream{readErr: os.ErrDeadlineExceeded}
+	before := time.Now()
+
+	if _, _, err := readReqRespChunk(s, s, "test"); err == nil {
+		t.Fatal("expected an error from a stalled read")
+	}
+
+	if s.readDeadline.Before(before.Add(ReqRespTimeout - time.Second)) {
+		t.Fatalf("read deadline not armed to ~now+%s: got %v", ReqRespTimeout, s.readDeadline)
+	}
+}
+
+// A deadline expiry is reported as a stall with a clear, timeout-classified error so
+// the caller can rotate peers instead of hanging.
+func TestReadReqRespChunkWrapsTimeout(t *testing.T) {
+	s := &deadlineStream{readErr: os.ErrDeadlineExceeded}
+
+	_, _, err := readReqRespChunk(s, s, "blocks_by_root")
+	if !errors.Is(err, os.ErrDeadlineExceeded) {
+		t.Fatalf("timeout not preserved through wrapping: %v", err)
+	}
+	if !strings.Contains(err.Error(), "stalled") || !strings.Contains(err.Error(), "blocks_by_root") {
+		t.Fatalf("error should name the protocol and the stall: %v", err)
+	}
+}
+
+// A non-timeout transport error passes through unchanged, not misattributed as a stall.
+func TestReadReqRespChunkPassesThroughNonTimeout(t *testing.T) {
+	s := &deadlineStream{readErr: io.ErrUnexpectedEOF}
+
+	_, _, err := readReqRespChunk(s, s, "test")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if strings.Contains(err.Error(), "stalled") {
+		t.Fatalf("non-timeout error misreported as a stall: %v", err)
+	}
+}
+
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "i/o timeout" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return true }
+
+func TestIsStreamTimeout(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"deadline exceeded", os.ErrDeadlineExceeded, true},
+		{"wrapped deadline", fmt.Errorf("read: %w", os.ErrDeadlineExceeded), true},
+		{"net timeout", fmt.Errorf("read: %w", timeoutError{}), true},
+		{"eof", io.EOF, false},
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isStreamTimeout(tc.err); got != tc.want {
+				t.Fatalf("isStreamTimeout(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/p2p/p2p_test.go
+++ b/internal/p2p/p2p_test.go
@@ -6,21 +6,36 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"io"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/geanlabs/gean/internal/logger"
 	"github.com/geanlabs/gean/internal/types"
 	"github.com/golang/snappy"
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
-type failingWriter struct{}
-
-func (failingWriter) Write([]byte) (int, error) {
-	return 0, os.ErrClosed
+// stubStream is a minimal network.Stream for exercising writeResponse: it wires
+// Write and SetWriteDeadline (the only methods writeResponse touches) and leaves the
+// rest to the embedded nil interface, which panics if unexpectedly called.
+type stubStream struct {
+	network.Stream
+	w        io.Writer
+	writeErr error
 }
+
+func (s stubStream) Write(p []byte) (int, error) {
+	if s.writeErr != nil {
+		return 0, s.writeErr
+	}
+	return s.w.Write(p)
+}
+
+func (stubStream) SetWriteDeadline(time.Time) error { return nil }
 
 type captureHandler struct {
 	block *types.SignedBlock
@@ -181,14 +196,14 @@ func TestResponseEncoding(t *testing.T) {
 }
 
 func TestWriteResponseReportsWriteFailure(t *testing.T) {
-	if writeResponse(failingWriter{}, "test", RespSuccess, []byte("payload")) {
+	if writeResponse(stubStream{writeErr: os.ErrClosed}, "test", RespSuccess, []byte("payload")) {
 		t.Fatal("expected writeResponse to report failure")
 	}
 }
 
 func TestWriteResponseWritesEncodedResponse(t *testing.T) {
 	var buf bytes.Buffer
-	if !writeResponse(&buf, "test", RespSuccess, []byte("payload")) {
+	if !writeResponse(stubStream{w: &buf}, "test", RespSuccess, []byte("payload")) {
 		t.Fatal("expected writeResponse success")
 	}
 	code, payload, err := DecodeResponse(&buf)

--- a/internal/p2p/protocol.go
+++ b/internal/p2p/protocol.go
@@ -8,4 +8,7 @@ const (
 	BlocksByRangeProtocol = "/leanconsensus/req/blocks_by_range/1/ssz_snappy"
 )
 
+// ReqRespTimeout is the idle deadline applied to each individual req/resp read and
+// write (see deadline.go). It bounds how long a single stalled operation may block,
+// not the whole exchange — a transfer that keeps making progress is never cut.
 const ReqRespTimeout = 15 * time.Second

--- a/internal/p2p/range.go
+++ b/internal/p2p/range.go
@@ -21,6 +21,7 @@ func handleBlocksByRangeRequest(
 	currentSlotFn func() uint64,
 	blocksInRangeFn func(startSlot, count uint64) []*types.SignedBlock,
 ) {
+	armReadDeadline(stream)
 	reqBuf, err := io.ReadAll(io.LimitReader(stream, int64(MaxCompressedPayloadSize)))
 	if err != nil {
 		logger.Warn(logger.Network, "blocks_by_range: read request failed: %v", err)
@@ -101,6 +102,7 @@ func (h *Host) FetchBlocksByRange(
 	if err != nil {
 		return nil, fmt.Errorf("marshal blocks_by_range request: %w", err)
 	}
+	armWriteDeadline(stream)
 	if _, err := stream.Write(EncodeReqRespPayload(reqSSZ)); err != nil {
 		return nil, fmt.Errorf("write blocks_by_range request: %w", err)
 	}
@@ -112,7 +114,7 @@ func (h *Host) FetchBlocksByRange(
 
 	reader := bufio.NewReader(io.LimitReader(stream, int64(MaxCompressedPayloadSize)*int64(count)))
 	for {
-		code, blockData, err := DecodeResponse(reader)
+		code, blockData, err := readReqRespChunk(stream, reader, "blocks_by_range")
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break

--- a/internal/p2p/response.go
+++ b/internal/p2p/response.go
@@ -1,13 +1,20 @@
 package p2p
 
 import (
-	"io"
+	"github.com/libp2p/go-libp2p/core/network"
 
 	"github.com/geanlabs/gean/internal/logger"
+	"github.com/geanlabs/gean/internal/metrics"
 )
 
-func writeResponse(w io.Writer, label string, code byte, data []byte) bool {
-	if _, err := w.Write(EncodeResponse(code, data)); err != nil {
+// writeResponse arms the idle write deadline before every response frame so a peer
+// that stops reading cannot hold an inbound handler open indefinitely.
+func writeResponse(s network.Stream, label string, code byte, data []byte) bool {
+	armWriteDeadline(s)
+	if _, err := s.Write(EncodeResponse(code, data)); err != nil {
+		if isStreamTimeout(err) {
+			metrics.IncReqRespTimeout(label, "write")
+		}
 		logger.Warn(logger.Network, "%s: write response failed: %v", label, err)
 		return false
 	}

--- a/internal/p2p/roots.go
+++ b/internal/p2p/roots.go
@@ -17,6 +17,7 @@ import (
 )
 
 func handleBlocksByRootRequest(stream network.Stream, blockByRootFn func(root [32]byte) *types.SignedBlock) {
+	armReadDeadline(stream)
 	reqBuf, err := io.ReadAll(io.LimitReader(stream, int64(MaxCompressedPayloadSize)))
 	if err != nil {
 		logger.Warn(logger.Network, "blocks_by_root: read request failed: %v", err)
@@ -80,6 +81,7 @@ func (h *Host) FetchBlocksByRoot(ctx context.Context, peerID peer.ID, roots [][3
 	}
 	defer stream.Close()
 
+	armWriteDeadline(stream)
 	if _, err := stream.Write(EncodeReqRespPayload(EncodeBlocksByRootRequest(roots))); err != nil {
 		return nil, fmt.Errorf("write blocks request: %w", err)
 	}
@@ -90,7 +92,7 @@ func (h *Host) FetchBlocksByRoot(ctx context.Context, peerID peer.ID, roots [][3
 	seenRoots := make(map[[32]byte]bool, len(roots))
 	reader := bufio.NewReader(io.LimitReader(stream, int64(MaxCompressedPayloadSize)*int64(len(roots))))
 	for {
-		code, blockData, err := DecodeResponse(reader)
+		code, blockData, err := readReqRespChunk(stream, reader, "blocks_by_root")
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break

--- a/internal/p2p/status.go
+++ b/internal/p2p/status.go
@@ -43,6 +43,7 @@ func (s *StatusMessage) UnmarshalSSZ(buf []byte) error {
 }
 
 func handleStatusRequest(stream network.Stream, statusFn func() *StatusMessage) {
+	armReadDeadline(stream)
 	reqBuf, err := io.ReadAll(io.LimitReader(stream, int64(MaxCompressedPayloadSize)))
 	if err != nil {
 		logger.Warn(logger.Network, "status: read request failed: %v", err)
@@ -91,12 +92,13 @@ func (h *Host) SendStatusRequest(ctx context.Context, peerID peer.ID, ourStatus 
 	}
 	defer stream.Close()
 
+	armWriteDeadline(stream)
 	if _, err := stream.Write(EncodeReqRespPayload(ourStatus.MarshalSSZ())); err != nil {
 		return nil, fmt.Errorf("write status request: %w", err)
 	}
 	stream.CloseWrite()
 
-	code, respData, err := DecodeResponse(stream)
+	code, respData, err := readReqRespChunk(stream, stream, "status")
 	if err != nil {
 		return nil, fmt.Errorf("read status response: %w", err)
 	}


### PR DESCRIPTION
## Problem

`ReqRespTimeout` (15s) was applied via `context.WithTimeout` **only to `NewStream`** (`status.go`, `roots.go`, `range.go`). The context bounds stream establishment; it does **not** propagate to `stream.Write` or the `DecodeResponse` read. There were **zero** `SetDeadline` calls anywhere in `internal/p2p` — so the response read was unbounded in time (the `LimitReader` wrappers bound size, not time).

Consequences:
- Peer crashes / fully idle → QUIC idle timeout (~30s, default transport config) tears the connection down and everything recovers.
- **Peer stays connected but stalls the stream** → the read blocks forever. `FetchBlocksByRootBatchWithRetry` calls `FetchBlocksByRoot` **synchronously inside** its peer-rotation loop (`retry.go`), and `runFetchBatcher` is a **single goroutine** (`workers.go`). So one stalling peer silently kills block gap-recovery until restart, while the node keeps ticking/attesting/proposing — it looks healthy.

Verified against the code on devnet-5; the diagnosis in the originating report holds in full.

## Fix — an idle deadline, not a total one

The deadline is applied to the **stream** and **reset before every read and write**:

- Outbound: `armWriteDeadline` before the request write; `readReqRespChunk` re-arms the read deadline before decoding **each** response frame (status, blocks_by_root, blocks_by_range).
- Inbound: request read bounded before `io.ReadAll`; every response frame written under a write deadline (centralized in `writeResponse`).

**Why idle, not total:** a single total deadline over the whole exchange would sever a legitimately slow but *progressing* large backfill mid-transfer (`MaxRequestBlocks = 1024`). Resetting per operation means a transfer that keeps delivering is never cut, while a genuine stall (no progress within the window) aborts and the retry loop rotates to another peer. Deadline expiries are classified (`isStreamTimeout`: `os.ErrDeadlineExceeded` + `net.Error.Timeout()`), surfaced with a clear "stalled" error, and counted by `lean_p2p_reqresp_timeout_total{protocol,direction}`.

## Testing

`internal/p2p/deadline_test.go`:
- read is armed to ~`now+ReqRespTimeout` before decoding (the core of the fix — previously unbounded);
- a deadline expiry is reported as a timeout-classified "stalled" error, so the caller unblocks and rotates;
- non-timeout errors (incl. EOF) pass through unchanged;
- `isStreamTimeout` table (deadline / wrapped / net-timeout / eof / nil).

`make test`, `go vet ./...`, gofmt all clean.

## Scope

Transport hygiene only — no consensus, SSZ, or protocol-encoding changes. The req/resp wire format and `ReqRespTimeout` value are unchanged.

## Not in this PR

Peer scoring is still absent (no gossipsub `WithPeerScore`, no req/resp misbehaviour penalties). That's the proper defense against a *malicious* slow-loris (a peer that dribbles just enough to keep resetting the idle deadline) and is a substantially larger design piece — deliberately left separate.