### PR TITLE
fix(checkpoint): retry the anchor fetch with backoff instead of exiting

### DIFF
--- a/internal/checkpoint/anchor.go
+++ b/internal/checkpoint/anchor.go
@@ -2,6 +2,7 @@ package checkpoint
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/geanlabs/gean/internal/types"
 )
@@ -16,12 +17,17 @@ func FetchCheckpointAnchor(
 		return nil, nil, err
 	}
 
-	state, err := fetchState(stateURL)
+	// State and block form one anchor pair; share a single fetch budget so a source
+	// that is briefly unready at boot is retried as a whole rather than each request
+	// racing its own deadline.
+	deadline := time.Now().Add(checkpointFetchBudget)
+
+	state, err := fetchState(stateURL, deadline)
 	if err != nil {
 		return nil, nil, fmt.Errorf("fetch state: %w", err)
 	}
 
-	signedBlock, err := fetchBlock(blockURL)
+	signedBlock, err := fetchBlock(blockURL, deadline)
 	if err != nil {
 		return nil, nil, fmt.Errorf("fetch block: %w", err)
 	}
@@ -36,8 +42,8 @@ func FetchCheckpointAnchor(
 	return state, signedBlock, nil
 }
 
-func fetchState(stateURL string) (*types.State, error) {
-	body, err := fetchSSZ(stateURL)
+func fetchState(stateURL string, deadline time.Time) (*types.State, error) {
+	body, err := fetchSSZ(stateURL, deadline)
 	if err != nil {
 		return nil, err
 	}
@@ -49,8 +55,8 @@ func fetchState(stateURL string) (*types.State, error) {
 	return state, nil
 }
 
-func fetchBlock(blockURL string) (*types.SignedBlock, error) {
-	body, err := fetchSSZ(blockURL)
+func fetchBlock(blockURL string, deadline time.Time) (*types.SignedBlock, error) {
+	body, err := fetchSSZ(blockURL, deadline)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/checkpoint/checkpoint_test.go
+++ b/internal/checkpoint/checkpoint_test.go
@@ -5,7 +5,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/geanlabs/gean/internal/types"
 )
@@ -332,12 +334,56 @@ func TestFetchSSZSendsOctetStreamAccept(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	got, err := fetchSSZ(srv.URL)
+	got, err := fetchSSZ(srv.URL, time.Now().Add(checkpointFetchBudget))
 	if err != nil {
 		t.Fatalf("fetch ssz: %v", err)
 	}
 	if !bytes.Equal(got, wantBody) {
 		t.Fatalf("body=%v, want %v", got, wantBody)
+	}
+}
+
+// A source that is briefly unready — connection errors or non-200s while it warms
+// up — must be retried rather than exiting the node on the first failure.
+func TestFetchSSZRetriesUntilReady(t *testing.T) {
+	wantBody := []byte{0x0a, 0x0b}
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&attempts, 1) < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		writeBody(t, w, wantBody)
+	}))
+	defer srv.Close()
+
+	got, err := fetchSSZ(srv.URL, time.Now().Add(checkpointFetchBudget))
+	if err != nil {
+		t.Fatalf("fetch ssz: %v", err)
+	}
+	if !bytes.Equal(got, wantBody) {
+		t.Fatalf("body=%v, want %v", got, wantBody)
+	}
+	if got := atomic.LoadInt32(&attempts); got < 3 {
+		t.Fatalf("expected the unready responses to be retried, saw %d attempts", got)
+	}
+}
+
+// A source that never comes ready must fail within the shared budget, not hang or
+// retry forever.
+func TestFetchSSZGivesUpAfterBudget(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	start := time.Now()
+	// A short budget keeps the test fast while still exercising at least one retry.
+	if _, err := fetchSSZ(srv.URL, time.Now().Add(1500*time.Millisecond)); err == nil {
+		t.Fatal("expected an error when the source never becomes ready")
+	}
+	if elapsed := time.Since(start); elapsed > checkpointFetchBudget {
+		t.Fatalf("fetch did not respect the budget: ran %s", elapsed)
 	}
 }
 
@@ -487,6 +533,7 @@ func TestVerifyAnchorPairRejectsHeaderMismatch(t *testing.T) {
 }
 
 func TestFetchCheckpointAnchor_StateNotFound(t *testing.T) {
+	defer shortCheckpointBudget(t)()
 	mux := http.NewServeMux()
 	mux.HandleFunc(StatesFinalizedPath, func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "not found", http.StatusNotFound)
@@ -507,6 +554,7 @@ func TestFetchCheckpointAnchor_StateNotFound(t *testing.T) {
 }
 
 func TestFetchCheckpointAnchor_BlockNotFound(t *testing.T) {
+	defer shortCheckpointBudget(t)()
 	state, signed := makeAnchorPair(t)
 	if signed == nil {
 		t.Fatal("expected signed block fixture")
@@ -530,4 +578,13 @@ func TestFetchCheckpointAnchor_BlockNotFound(t *testing.T) {
 	if gotState != nil || gotBlock != nil {
 		t.Fatalf("expected nil results, got state=%v block=%v", gotState, gotBlock)
 	}
+}
+
+// shortCheckpointBudget shrinks the anchor fetch budget so negative tests that
+// exercise the retry path (a source that never becomes ready) finish quickly.
+func shortCheckpointBudget(t *testing.T) func() {
+	t.Helper()
+	restore := checkpointFetchBudget
+	checkpointFetchBudget = 1500 * time.Millisecond
+	return func() { checkpointFetchBudget = restore }
 }

--- a/internal/checkpoint/fetch.go
+++ b/internal/checkpoint/fetch.go
@@ -1,21 +1,71 @@
 package checkpoint
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/geanlabs/gean/internal/logger"
 )
 
 const (
+	// checkpointRequestTimeout bounds a single HTTP attempt.
 	checkpointRequestTimeout = 30 * time.Second
+	checkpointInitialBackoff = 1 * time.Second
+	checkpointMaxBackoff     = 8 * time.Second
 	checkpointMaxSSZBytes    = 64 << 20
 )
 
-var checkpointHTTPClient = &http.Client{Timeout: checkpointRequestTimeout}
+// checkpointFetchBudget bounds the whole anchor fetch across retries, shared by the
+// state and block requests. A checkpoint source can be briefly unready when this node
+// boots against it; retrying rides that out instead of exiting. Kept well under the
+// hive client-start window so a genuinely-down source still fails the node fast rather
+// than stranding it. A var so tests can shorten it.
+var checkpointFetchBudget = 40 * time.Second
 
-func fetchSSZ(url string) ([]byte, error) {
-	req, err := http.NewRequest("GET", url, nil)
+// checkpointHTTPClient carries no timeout of its own; each attempt is bounded by a
+// per-request context so the shared budget governs the total.
+var checkpointHTTPClient = &http.Client{}
+
+// fetchSSZ retrieves an SSZ body, retrying transient failures with capped exponential
+// backoff until the shared deadline. A finalized checkpoint is immutable, so a failed
+// attempt is safe to repeat: it is either an endpoint still warming up (retry helps) or
+// a misconfigured source (retry exhausts the budget and surfaces the last error).
+func fetchSSZ(url string, deadline time.Time) ([]byte, error) {
+	backoff := checkpointInitialBackoff
+	var lastErr error
+	for attempt := 1; ; attempt++ {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
+		}
+
+		body, err := fetchSSZOnce(url, minDuration(checkpointRequestTimeout, remaining))
+		if err == nil {
+			return body, nil
+		}
+		lastErr = err
+
+		if time.Until(deadline) <= backoff {
+			break
+		}
+		logger.Warn(logger.Sync, "checkpoint fetch attempt %d for %s failed: %v; retrying in %s",
+			attempt, url, err, backoff)
+		time.Sleep(backoff)
+		if backoff < checkpointMaxBackoff {
+			backoff *= 2
+		}
+	}
+	return nil, fmt.Errorf("no successful response within %s: %w", checkpointFetchBudget, lastErr)
+}
+
+func fetchSSZOnce(url string, timeout time.Duration) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
@@ -36,6 +86,13 @@ func fetchSSZ(url string) ([]byte, error) {
 		return nil, fmt.Errorf("read response: %w", err)
 	}
 	return body, nil
+}
+
+func minDuration(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 func readLimitedSSZ(r io.Reader, maxBytes int64) ([]byte, error) {


### PR DESCRIPTION
## Context

Follow-up to ethereum/hive#1579, which made the hive harness wait for the helper's `/lean/v0/blocks/finalized` to be ready before starting the client-under-test. That fixes the flakiness harness-side and gean is already compatible (it serves both finalized endpoints and fetches the state+block anchor pair). gean was **not** failing (sync 6/6), so nothing here is required by the hive PR.

But investigating it surfaced the same fragility the harness works around, on gean's side:

## Problem

`fetchSSZ` did a **single** HTTP GET per endpoint with no retry, and `bootstrapFromCheckpoint` returns an error on any failure → `run()` returns it → **`os.Exit(1)`**. So a checkpoint source that is briefly unready when gean boots against it (still warming up, finalized block not yet served) **kills the node** instead of being waited out. In hive the new harness gate hides this; in production there is no such gate — an operator's checkpoint URL blipping at startup would fail the node.

## Fix

Retry each fetch with capped exponential backoff (1s→8s) until a **shared budget** (40s) is spent. A finalized checkpoint is immutable, so a failed attempt is safe to repeat — either the endpoint is warming up (retry succeeds) or the source is misconfigured (retry exhausts the budget and surfaces the last error).

- **State and block share one budget**, so the anchor pair is bounded as a whole rather than each request racing its own deadline.
- Each attempt is **context-bounded** (`min(30s, remaining)`), so the total stays well under the ~60s hive client-start window — a genuinely-down source still fails fast rather than stranding the node.
- **Anchor verification runs once** on the fetched pair; only the transport fetch retries (a verify failure is a real inconsistency, not transient).
- Happy path unchanged: a ready endpoint succeeds on the first attempt with no added delay.

Public `FetchCheckpointAnchor` signature is unchanged (`bootstrap.go` untouched).

## Testing

`internal/checkpoint`:
- `TestFetchSSZRetriesUntilReady` — two `503`s then `200`; the unready responses are retried and the body is returned.
- `TestFetchSSZGivesUpAfterBudget` — a source that never readies fails within the budget, not forever.
- existing negative tests kept fast via a short-budget override.

`make test`, `go vet ./...`, gofmt all clean.

## Scope

Boot-time robustness only — no consensus, SSZ, or protocol change. `checkpointFetchBudget` is a `var` solely so tests can shorten it.