### PR TITLE
chore(node): log checkpoint-sync configuration at startup

### DIFF
--- a/cmd/gean/bootstrap.go
+++ b/cmd/gean/bootstrap.go
@@ -51,6 +51,15 @@ func loadStartupInputs(cfg config) (*startupInputs, error) {
 }
 
 func bootstrapStore(s *store.ConsensusStore, genesisConfig *genesis.GenesisConfig, checkpointURL string) error {
+	// Surface the checkpoint-sync configuration up front: a node expected to
+	// checkpoint-sync that silently starts from genesis (no url reached the
+	// binary) otherwise looks identical to a normal genesis start in the logs.
+	if checkpointURL != "" {
+		logger.Info(logger.Node, "checkpoint sync configured: url=%s", checkpointURL)
+	} else {
+		logger.Info(logger.Node, "checkpoint sync not configured (no --checkpoint-sync-url)")
+	}
+
 	existingHead := s.Head()
 	existingHeader := s.GetBlockHeader(existingHead)
 	existingState := s.GetState(existingHead)

--- a/internal/api/checkpoint_forkchoice_repro_test.go
+++ b/internal/api/checkpoint_forkchoice_repro_test.go
@@ -1,0 +1,159 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/geanlabs/gean/internal/checkpoint"
+	"github.com/geanlabs/gean/internal/forkchoice"
+	"github.com/geanlabs/gean/internal/storage"
+	"github.com/geanlabs/gean/internal/store"
+	"github.com/geanlabs/gean/internal/types"
+)
+
+// TestCheckpointSyncReachesNonGenesisFinalizedForkChoice reproduces the hive
+// rpc-compat "forkchoice keeps nodes at or beyond finalized slot" test locally:
+// a client given a valid checkpoint source (no peers) must checkpoint-sync and
+// report finalized.slot > 0 on /lean/v0/fork_choice. It exercises the real
+// checkpoint fetch, the store seeding bootstrap performs, and the real handler.
+func TestCheckpointSyncReachesNonGenesisFinalizedForkChoice(t *testing.T) {
+	const genesisTime = 1000
+	const finalizedSlot = 100
+
+	state, signed := makeReproAnchorPair(t, finalizedSlot, genesisTime, 3)
+
+	// Stand up a mock finalized source at the paths the client derives.
+	mux := http.NewServeMux()
+	mux.HandleFunc(checkpoint.StatesFinalizedPath, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(mustSSZ(t, state))
+	})
+	mux.HandleFunc(checkpoint.BlocksFinalizedPath, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(mustSSZ(t, signed))
+	})
+	src := httptest.NewServer(mux)
+	defer src.Close()
+
+	// Real checkpoint sync against the source.
+	anchorState, anchorBlock, err := checkpoint.FetchCheckpointAnchor(src.URL+checkpoint.StatesFinalizedPath, genesisTime, state.Validators)
+	if err != nil {
+		t.Fatalf("checkpoint sync failed against a valid source: %v", err)
+	}
+
+	// Seed the store exactly as bootstrap does, then serve fork_choice.
+	s := store.NewConsensusStore(storage.NewInMemoryBackend())
+	seedStoreFromAnchor(t, s, anchorState, anchorBlock)
+	fc := forkchoice.New(anchorState.Slot, s.Head(), anchorState.LatestBlockHeader.ParentRoot)
+
+	rec := httptest.NewRecorder()
+	ForkChoiceHandler(s, fc)(rec, httptest.NewRequest(http.MethodGet, "/lean/v0/fork_choice", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("fork_choice status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Finalized struct {
+			Slot uint64 `json:"slot"`
+		} `json:"finalized"`
+		Justified struct {
+			Slot uint64 `json:"slot"`
+		} `json:"justified"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode fork_choice: %v", err)
+	}
+	if resp.Finalized.Slot == 0 {
+		t.Fatalf("fork_choice reports finalized.slot=0 after checkpoint sync; the poll would never see a non-genesis boundary")
+	}
+	if resp.Finalized.Slot != finalizedSlot {
+		t.Fatalf("finalized.slot=%d, want %d", resp.Finalized.Slot, finalizedSlot)
+	}
+}
+
+// seedStoreFromAnchor mirrors cmd/gean initStoreFromState + bootstrapFromCheckpoint.
+func seedStoreFromAnchor(t *testing.T, s *store.ConsensusStore, state *types.State, signed *types.SignedBlock) {
+	t.Helper()
+	header := state.LatestBlockHeader
+	stateRoot, err := state.HashTreeRoot()
+	if err != nil {
+		t.Fatalf("state htr: %v", err)
+	}
+	if header.StateRoot == types.ZeroRoot {
+		header.StateRoot = stateRoot
+	}
+	blockRoot, err := header.HashTreeRoot()
+	if err != nil {
+		t.Fatalf("header htr: %v", err)
+	}
+	anchor := &types.Checkpoint{Root: blockRoot, Slot: header.Slot}
+	for _, put := range []func() error{
+		func() error { return s.PutConfig(state.Config) },
+		func() error { return s.PutHead(blockRoot) },
+		func() error { return s.PutSafeTarget(blockRoot) },
+		func() error { return s.PutLatestJustified(anchor) },
+		func() error { return s.PutLatestFinalized(anchor) },
+		func() error { return s.PutBlockHeader(blockRoot, header) },
+		func() error { return s.PutState(blockRoot, state) },
+		func() error { return s.StorePendingBlock(blockRoot, signed) },
+	} {
+		if err := put(); err != nil {
+			t.Fatalf("seed store: %v", err)
+		}
+	}
+}
+
+func makeReproAnchorPair(t *testing.T, slot, genesisTime uint64, numValidators int) (*types.State, *types.SignedBlock) {
+	t.Helper()
+	validators := make([]*types.Validator, numValidators)
+	for i := range validators {
+		validators[i] = &types.Validator{
+			AttestationPubkey: [types.PubkeySize]byte{byte(i + 1)},
+			ProposalPubkey:    [types.PubkeySize]byte{byte(i + 11)},
+			Index:             uint64(i),
+		}
+	}
+	state := &types.State{
+		Config:                   &types.ChainConfig{GenesisTime: genesisTime},
+		Slot:                     slot,
+		LatestBlockHeader:        &types.BlockHeader{Slot: slot},
+		LatestJustified:          &types.Checkpoint{Slot: slot - 2},
+		LatestFinalized:          &types.Checkpoint{Slot: slot - 5},
+		Validators:               validators,
+		JustifiedSlots:           types.NewBitlistSSZ(0),
+		JustificationsValidators: types.NewBitlistSSZ(0),
+	}
+	body := &types.BlockBody{}
+	bodyRoot, err := body.HashTreeRoot()
+	if err != nil {
+		t.Fatalf("body htr: %v", err)
+	}
+	state.LatestBlockHeader.BodyRoot = bodyRoot
+	state.LatestBlockHeader.StateRoot = types.ZeroRoot
+	stateRoot, err := state.HashTreeRoot()
+	if err != nil {
+		t.Fatalf("state htr: %v", err)
+	}
+	signed := &types.SignedBlock{
+		Block: &types.Block{
+			Slot:          state.Slot,
+			ProposerIndex: state.LatestBlockHeader.ProposerIndex,
+			ParentRoot:    state.LatestBlockHeader.ParentRoot,
+			StateRoot:     stateRoot,
+			Body:          body,
+		},
+		Proof: &types.MultiMessageAggregate{},
+	}
+	return state, signed
+}
+
+func mustSSZ(t *testing.T, v interface{ MarshalSSZ() ([]byte, error) }) []byte {
+	t.Helper()
+	b, err := v.MarshalSSZ()
+	if err != nil {
+		t.Fatalf("marshal ssz: %v", err)
+	}
+	return b
+}


### PR DESCRIPTION
## Why

Investigating a hive rpc-compat failure (`forkchoice keeps nodes at or beyond finalized slot`, gean 33/34), the client log showed gean **initializing from genesis** in a test that checkpoint-syncs the client under test — so gean sat at genesis (`finalized.slot = 0`), the test polled fork_choice for `finalized.slot > 0`, and timed out at 180s.

gean's checkpoint→fork_choice path is **correct** (proven by the test below): when given a valid checkpoint url it reaches a non-genesis finalized boundary. So the failure was that gean **didn't checkpoint-sync** — no url reached the binary. But that was hard to confirm, because a genesis start with no url logs identically to any other genesis start.

## Changes

**1. Startup visibility.** `bootstrapStore` now logs whether a checkpoint url was configured:
```
checkpoint sync configured: url=...
```
or
```
checkpoint sync not configured (no --checkpoint-sync-url)
```
so a silent genesis-because-no-url is distinguishable at a glance. (Paired with a matching `gean.sh` echo in ethereum/hive#1578 so it's clear whether the url was lost between the wrapper and the binary.)

**2. End-to-end regression test** (`internal/api`): against a mock finalized source and no peers, a checkpoint-synced node must report a non-genesis finalized boundary on `/lean/v0/fork_choice`. It runs the real `checkpoint.FetchCheckpointAnchor`, the exact store seeding `bootstrap` performs, and the real `ForkChoiceHandler` — guarding the precise path the hive finalized-boundary check depends on. Reproduced locally: `finalized.slot = 100`.

## Scope

Observability + test only — one log line, no behavior change. `make test`, `go vet`, gofmt clean.