### PR TITLE
chore: flatten a few over-long comments (lean-review pass)

### DIFF
--- a/internal/aggregation/worker.go
+++ b/internal/aggregation/worker.go
@@ -62,9 +62,8 @@ func RunWorker(
 			if gate != nil && !gate.Acquire(acquireCtx, false) {
 				cancelAcquire()
 				metrics.IncProofOperation("aggregation", "canceled")
-				// Losing the prover costs this slot its aggregate, which slows
-				// justification. Log it: without a line here the loss is visible
-				// only in metrics, and an operator reading logs sees a silent gap.
+				// A lost prover costs this slot its aggregate and slows justification;
+				// without this line the loss shows only in metrics, a silent gap in the logs.
 				logger.Warn(logger.Signature, "aggregation skipped: prover unavailable slot=%d", dispatch.Slot)
 				continue
 			}

--- a/internal/checkpoint/fetch.go
+++ b/internal/checkpoint/fetch.go
@@ -22,7 +22,7 @@ const (
 // state and block requests. A checkpoint source can be briefly unready when this node
 // boots against it; retrying rides that out instead of exiting. Kept well under the
 // hive client-start window so a genuinely-down source still fails the node fast rather
-// than stranding it. A var so tests can shorten it.
+// than stranding it.
 var checkpointFetchBudget = 40 * time.Second
 
 // checkpointHTTPClient carries no timeout of its own; each attempt is bounded by a

--- a/internal/p2p/deadline.go
+++ b/internal/p2p/deadline.go
@@ -13,13 +13,12 @@ import (
 	"github.com/geanlabs/gean/internal/metrics"
 )
 
-// Req/resp streams are bounded by an idle deadline, not a single total one: the
-// deadline is reset before every read and write, so a peer that keeps making
-// progress is never cut, while one that opens the stream and then stalls is
-// aborted within ReqRespTimeout. A total deadline would sever a legitimate but
-// slow large backfill mid-transfer; the context passed to NewStream only covers
-// stream establishment, so without these the response read is unbounded and a
-// single stalled peer can wedge the fetch loop indefinitely.
+// Req/resp streams are bounded by an idle deadline, reset before every read and
+// write: a peer making progress is never cut, one that stalls is aborted within
+// ReqRespTimeout. A single total deadline would instead sever a slow-but-valid
+// large backfill mid-transfer. The context passed to NewStream covers only stream
+// establishment, so without these the response read is unbounded and one stalled
+// peer can wedge the fetch loop indefinitely.
 
 func armReadDeadline(s network.Stream) {
 	_ = s.SetReadDeadline(time.Now().Add(ReqRespTimeout))
@@ -40,8 +39,7 @@ func isStreamTimeout(err error) bool {
 }
 
 // readReqRespChunk arms the idle read deadline, decodes one response frame, and on a
-// deadline expiry records the stall and returns a clear error. r reads from the stream
-// (directly or through a size-limiting wrapper); s is armed for the deadline.
+// deadline expiry records the stall and returns a clear error.
 func readReqRespChunk(s network.Stream, r io.Reader, protocol string) (byte, []byte, error) {
 	armReadDeadline(s)
 	code, data, err := DecodeResponse(r)


### PR DESCRIPTION
A `/lean-review` comment-bloat pass over the recent p2p / checkpoint / aggregation work.

**Finding:** the bulk of the recent comments are legitimate protocol reasoning (idle-deadline rationale, checkpoint retry safety, aggregation cost model, recovery-yield logic, the fetch-root in-flight invariant) — the kind of non-obvious "why" gean's comment policy explicitly wants, and not bloat by the skill's definition (restating code / PR-rot / docstrings on obvious functions). Those are left intact.

Only the genuine trims are applied here:
- `p2p/deadline.go` — drop a param-restating sentence on `readReqRespChunk`; condense the file header that repeated its own "total deadline" point.
- `checkpoint/fetch.go` — drop "A var so tests can shorten it" (obvious from the `var`).
- `aggregation/worker.go` — tighten the conversational log rationale.

Comment-only, verified: the non-comment diff is empty. Builds, `go vet`, gofmt clean.