### PR TITLE
docs(readme): correct the stale leanSpec and leanVM pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,13 @@ prover's headroom; override it via the environment if your budget differs.
 ## Current status
 
 Gean tracks Lean Consensus devnet-5. Consensus fixtures are generated from
-`leanSpec@fd7dfd0e85bd83d43e0a6b1bc2bfafb1ea3049d5` with
-leanVM/leanMultisig `8fcbd77958a58666e828315de2d6ce7c93297117`.
+`leanSpec@eca701efeb5931010fe63925cd203c9ee55b2dbc`, which pins
+`lean-multisig-py` v0.0.9. The XMSS FFI builds against
+leanVM `e2592df4e30fdddbbf8ae26a333116c68cec7026`.
+
+`LEAN_SPEC_COMMIT_HASH` in the [`Makefile`](Makefile) is the source of truth for
+the spec version; the leanVM rev is pinned in
+[`xmss/rust/multisig-glue/Cargo.toml`](xmss/rust/multisig-glue/Cargo.toml).
 
 ## Philosophy
 


### PR DESCRIPTION
The status section named leanSpec@fd7dfd0e, several hundred commits behind the LEAN_SPEC_COMMIT_HASH the Makefile actually pins, and attributed 8fcbd779 to "leanVM/leanMultisig" — that is a leanVM commit, while leanSpec pins leanMultisig-py (v0.0.9 at the current rev, v0.0.6 at fd7dfd0e).

State the spec rev the Makefile pins, the lean-multisig-py version it resolves to, and separately the leanVM rev the XMSS FFI builds against, then point at both files as the sources of truth so the next drift is easier to spot.

Claude-Session: https://claude.ai/code/session_01EyYudfYZJ6tfKYzt1JzWq6

## Description
<!-- Provide a brief summary of your changes -->

## Associated Issue
<!-- PRs targeting main or devnet-N must be linked to an issue. Use Closes #123 / Fixes #123, or link it from the Development sidebar. -->
Closes #

## Test Plan
<!-- Describe how you verified your changes -->

## Checklist
- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
