### PR TITLE
feat(metrics): reqresp-size, block-proposal, and per-table storage metrics

### DIFF
--- a/internal/blockbuilder/build.go
+++ b/internal/blockbuilder/build.go
@@ -19,6 +19,8 @@ func Build(input Input) (*Result, error) {
 	if err != nil {
 		return nil, err
 	}
+	metrics.ObserveBlockProposalAttestationDataSelected(len(plan.attestations))
+	metrics.ObserveBlockProposalAggregatesSelected(len(plan.proofs))
 
 	finalBlock := newBlock(input.Slot, input.ProposerIndex, input.ParentRoot, plan.attestations)
 	stateRoot, err := plan.postState.HashTreeRoot()

--- a/internal/blockbuilder/plan.go
+++ b/internal/blockbuilder/plan.go
@@ -3,6 +3,7 @@ package blockbuilder
 import (
 	"fmt"
 
+	"github.com/geanlabs/gean/internal/metrics"
 	"github.com/geanlabs/gean/internal/types"
 )
 
@@ -116,6 +117,7 @@ func (p *planner) tryPayload(payload AttestationPayload) bool {
 
 	p.attestations = append(p.attestations, att)
 	p.proofs = append(p.proofs, sig)
+	metrics.IncBlockProposalAttestationBuilds()
 	return true
 }
 

--- a/internal/metrics/counters.go
+++ b/internal/metrics/counters.go
@@ -82,4 +82,8 @@ var (
 		Name: "lean_p2p_reqresp_timeout_total",
 		Help: "Req/resp stream operations aborted by the idle deadline, by protocol and direction",
 	}, []string{"protocol", "direction"})
+	metricBlockProposalAttestationBuilds = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "lean_block_proposal_attestation_builds_total",
+		Help: "Payloads selected into the proposal during greedy attestation planning",
+	})
 )

--- a/internal/metrics/gauges.go
+++ b/internal/metrics/gauges.go
@@ -84,4 +84,7 @@ var (
 	metricProcessRSSBytes = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "lean_node_rss_bytes", Help: "Process resident set size in bytes (includes prover memory outside the Go heap)",
 	})
+	metricTableBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "lean_table_bytes", Help: "Estimated on-disk byte size of a storage table",
+	}, []string{"table"})
 )

--- a/internal/metrics/histograms.go
+++ b/internal/metrics/histograms.go
@@ -135,4 +135,24 @@ var (
 		Name: "lean_proof_merge_components", Help: "Type-1 components merged into a Type-2 proof",
 		Buckets: []float64{1, 2, 3, 4, 5, 6, 7, 8, 9},
 	})
+	metricReqRespRequestSize = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "lean_reqresp_request_size_bytes",
+		Help:    "On-wire bytes of a req/resp request frame",
+		Buckets: []float64{64, 128, 256, 512, 1024, 4096, 16384, 65536},
+	}, []string{"protocol"})
+	metricReqRespResponseChunkSize = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "lean_reqresp_response_chunk_size_bytes",
+		Help:    "On-wire bytes of a single req/resp response frame",
+		Buckets: []float64{128, 1024, 10000, 100000, 500000, 1000000, 5000000, 10000000},
+	}, []string{"protocol"})
+	metricBlockProposalAttestationDataSelected = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "lean_block_proposal_attestation_data_selected",
+		Help:    "Distinct AttestationData entries placed in the proposal block body",
+		Buckets: []float64{0, 1, 2, 4, 8, 16, 32},
+	})
+	metricBlockProposalAggregatesSelected = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "lean_block_proposal_aggregates_selected",
+		Help:    "Aggregated signature proofs selected for the proposal",
+		Buckets: []float64{0, 1, 2, 4, 8, 16, 32, 64, 128},
+	})
 )

--- a/internal/metrics/inc.go
+++ b/internal/metrics/inc.go
@@ -39,3 +39,5 @@ func IncPeerDisconnection(direction, reason string) {
 func IncReqRespTimeout(protocol, direction string) {
 	metricReqRespTimeout.WithLabelValues(labelOrUnknown(protocol), labelOrUnknown(direction)).Inc()
 }
+
+func IncBlockProposalAttestationBuilds() { metricBlockProposalAttestationBuilds.Inc() }

--- a/internal/metrics/observe.go
+++ b/internal/metrics/observe.go
@@ -73,3 +73,19 @@ func ObserveProofSize(proofType string, bytes int) {
 func ObserveProofMergeComponents(n int) {
 	observeNonNegative(metricProofMergeComponents, countValue(n))
 }
+
+func ObserveReqRespRequestSize(protocol string, bytes int) {
+	observeNonNegative(metricReqRespRequestSize.WithLabelValues(labelOrUnknown(protocol)), countValue(bytes))
+}
+
+func ObserveReqRespResponseChunkSize(protocol string, bytes int) {
+	observeNonNegative(metricReqRespResponseChunkSize.WithLabelValues(labelOrUnknown(protocol)), countValue(bytes))
+}
+
+func ObserveBlockProposalAttestationDataSelected(n int) {
+	observeNonNegative(metricBlockProposalAttestationDataSelected, countValue(n))
+}
+
+func ObserveBlockProposalAggregatesSelected(n int) {
+	observeNonNegative(metricBlockProposalAggregatesSelected, countValue(n))
+}

--- a/internal/metrics/set.go
+++ b/internal/metrics/set.go
@@ -52,3 +52,7 @@ func SetAttestationAggregateCoverageDiffValidators(direction string, n int) {
 	metricAttestationAggregateCoverageDiffValidators.
 		WithLabelValues(labelOrUnknown(direction)).Set(countValue(n))
 }
+
+func SetTableBytes(table string, bytes uint64) {
+	metricTableBytes.WithLabelValues(labelOrUnknown(table)).Set(float64(bytes))
+}

--- a/internal/node/import.go
+++ b/internal/node/import.go
@@ -3,6 +3,8 @@ package node
 import (
 	"github.com/geanlabs/gean/internal/blockprocessor"
 	"github.com/geanlabs/gean/internal/logger"
+	"github.com/geanlabs/gean/internal/metrics"
+	"github.com/geanlabs/gean/internal/storage"
 	"github.com/geanlabs/gean/internal/types"
 )
 
@@ -74,9 +76,22 @@ func (e *Engine) importKnownParentBlock(
 	e.dispatchRecovery(signedBlock)
 
 	e.FC.OnBlock(block.Slot, blockRoot, parentRoot)
+	e.recordTableBytes()
 
 	e.updateHead()
 	e.Pending.ClearDepth(blockRoot)
 	e.replayPendingAttestations(blockRoot)
 	e.collectPendingChildren(blockRoot, queue)
+}
+
+// recordTableBytes refreshes the per-table storage-size gauge after a block is
+// persisted. Runs on the single-threaded import path, so the estimate reflects
+// the just-applied write with no locking concerns.
+func (e *Engine) recordTableBytes() {
+	if e.Store == nil || e.Store.Backend == nil {
+		return
+	}
+	for _, table := range storage.AllTables {
+		metrics.SetTableBytes(string(table), e.Store.Backend.EstimateTableBytes(table))
+	}
 }

--- a/internal/p2p/range.go
+++ b/internal/p2p/range.go
@@ -13,6 +13,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/protocol"
 
 	"github.com/geanlabs/gean/internal/logger"
+	"github.com/geanlabs/gean/internal/metrics"
 	"github.com/geanlabs/gean/internal/types"
 )
 
@@ -103,7 +104,9 @@ func (h *Host) FetchBlocksByRange(
 		return nil, fmt.Errorf("marshal blocks_by_range request: %w", err)
 	}
 	armWriteDeadline(stream)
-	if _, err := stream.Write(EncodeReqRespPayload(reqSSZ)); err != nil {
+	reqBytes := EncodeReqRespPayload(reqSSZ)
+	metrics.ObserveReqRespRequestSize("blocks_by_range", len(reqBytes))
+	if _, err := stream.Write(reqBytes); err != nil {
 		return nil, fmt.Errorf("write blocks_by_range request: %w", err)
 	}
 	stream.CloseWrite()

--- a/internal/p2p/response.go
+++ b/internal/p2p/response.go
@@ -11,7 +11,9 @@ import (
 // that stops reading cannot hold an inbound handler open indefinitely.
 func writeResponse(s network.Stream, label string, code byte, data []byte) bool {
 	armWriteDeadline(s)
-	if _, err := s.Write(EncodeResponse(code, data)); err != nil {
+	encoded := EncodeResponse(code, data)
+	metrics.ObserveReqRespResponseChunkSize(label, len(encoded))
+	if _, err := s.Write(encoded); err != nil {
 		if isStreamTimeout(err) {
 			metrics.IncReqRespTimeout(label, "write")
 		}

--- a/internal/p2p/roots.go
+++ b/internal/p2p/roots.go
@@ -13,6 +13,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/protocol"
 
 	"github.com/geanlabs/gean/internal/logger"
+	"github.com/geanlabs/gean/internal/metrics"
 	"github.com/geanlabs/gean/internal/types"
 )
 
@@ -82,7 +83,9 @@ func (h *Host) FetchBlocksByRoot(ctx context.Context, peerID peer.ID, roots [][3
 	defer stream.Close()
 
 	armWriteDeadline(stream)
-	if _, err := stream.Write(EncodeReqRespPayload(EncodeBlocksByRootRequest(roots))); err != nil {
+	reqBytes := EncodeReqRespPayload(EncodeBlocksByRootRequest(roots))
+	metrics.ObserveReqRespRequestSize("blocks_by_root", len(reqBytes))
+	if _, err := stream.Write(reqBytes); err != nil {
 		return nil, fmt.Errorf("write blocks request: %w", err)
 	}
 	stream.CloseWrite()

--- a/internal/p2p/status.go
+++ b/internal/p2p/status.go
@@ -11,6 +11,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/protocol"
 
 	"github.com/geanlabs/gean/internal/logger"
+	"github.com/geanlabs/gean/internal/metrics"
 )
 
 const statusMessageSize = 80
@@ -93,7 +94,9 @@ func (h *Host) SendStatusRequest(ctx context.Context, peerID peer.ID, ourStatus 
 	defer stream.Close()
 
 	armWriteDeadline(stream)
-	if _, err := stream.Write(EncodeReqRespPayload(ourStatus.MarshalSSZ())); err != nil {
+	reqBytes := EncodeReqRespPayload(ourStatus.MarshalSSZ())
+	metrics.ObserveReqRespRequestSize("status", len(reqBytes))
+	if _, err := stream.Write(reqBytes); err != nil {
 		return nil, fmt.Errorf("write status request: %w", err)
 	}
 	stream.CloseWrite()


### PR DESCRIPTION
Closes observability gaps against the wider client set (metric parity), plus two CI/security fixes needed for the workflows to pass.

## Metrics added (6)
- `lean_reqresp_request_size_bytes` / `lean_reqresp_response_chunk_size_bytes` (histograms, `protocol` label) — on-wire frame sizes, observed at the three outbound request sends and the central `writeResponse` path.
- `lean_block_proposal_attestation_data_selected` / `lean_block_proposal_aggregates_selected` (histograms) — distinct AttestationData and aggregate proofs placed in a proposal, observed after `planAttestations`.
- `lean_block_proposal_attestation_builds_total` (counter) — payloads selected during greedy planning.
- `lean_table_bytes` (gauge, `table` label) — per-table storage size via the existing `Backend.EstimateTableBytes`, refreshed after each block import.

Deliberately not added, to avoid dead or duplicate series: gossip arrival metrics (added separately), aggregated proof size (covered by `lean_proof_size_bytes{type=type1}`), proposal child-payloads-consumed (covered by `lean_proof_merge_components`), and aggregation early-start metrics (no such behaviour exists to measure).

## CI/security fixes carried
- **`test-spec`/`test-all` now build the FFI first.** The spec tests link the cgo staticlib but lacked an `ffi` prerequisite; on a cargo-cache miss the link failed with `cannot find -lcgo_glue`.
- **`ruint` bumped to 1.20.0** (RUSTSEC-2026-0220 — incorrect overflow flags / truncated shift amounts in Uint shift ops; pulled transitively via `ethereum_ssz`). Builds clean; extra lockfile entries are platform-gated (windows/wasm) and don't compile on Linux.

## Verification
`make build`, `make test` (25 packages), `make lint` all pass. No consensus-logic changes.