### PR TITLE
feat(aggregation): start aggregation early on current-slot vote quorum

### DIFF
--- a/internal/node/dispatch.go
+++ b/internal/node/dispatch.go
@@ -17,6 +17,9 @@ func (e *Engine) dispatch(ctx context.Context, ticks <-chan time.Time) {
 		case <-ticks:
 			e.onTick()
 
+		case <-e.EarlyAggregateCh:
+			e.maybeEarlyAggregate(uint64(time.Now().UnixMilli()))
+
 		case block := <-e.BlockCh:
 			e.onBlock(block)
 

--- a/internal/node/engine.go
+++ b/internal/node/engine.go
@@ -49,6 +49,12 @@ type Engine struct {
 	FailedRootCh  chan [32]byte
 	FetchRootCh   chan [32]byte
 
+	// EarlyAggregateCh is a coalescing (capacity-1) wake-up: an attestation-verify
+	// goroutine pokes it after inserting a signature, and the dispatch loop reacts
+	// by considering an early aggregation session. It carries no data — the loop
+	// re-reads live store state — so a full channel is simply dropped.
+	EarlyAggregateCh chan struct{}
+
 	AggregationDispatchCh chan aggregation.Dispatch
 	ProposalCh            chan proposalDuty
 	ProposalResultCh      chan *proposalResult
@@ -68,6 +74,18 @@ type Engine struct {
 	// missing parent cannot flood FetchRootCh with duplicate requests. Accessed only
 	// on the dispatch loop (queue on onBlock, clear on receive/exhaustion), so no lock.
 	fetchInFlight map[[32]byte]bool
+
+	// aggregatedSlot is the last slot for which an aggregation session was
+	// dispatched, so the early (attestation-arrival) path and the interval-2
+	// fallback dispatch at most once per slot. Written and read only on the
+	// single dispatch loop, so no lock.
+	aggregatedSlot uint64
+
+	// numValidators caches the validator-set size, fixed at genesis in lean
+	// devnet, used as the denominator for the early-aggregation quorum. Filled
+	// lazily on the dispatch loop to avoid SSZ-decoding the head state on every
+	// attestation arrival; read/written only there, so no lock.
+	numValidators uint64
 }
 
 func New(
@@ -99,6 +117,7 @@ func New(
 		AggregationCh:         make(chan *types.SignedAggregatedAttestation, 64),
 		FailedRootCh:          make(chan [32]byte, 64),
 		FetchRootCh:           make(chan [32]byte, 256),
+		EarlyAggregateCh:      make(chan struct{}, 1),
 		AggregationDispatchCh: make(chan aggregation.Dispatch, 1),
 		ProposalCh:            make(chan proposalDuty, 1),
 		ProposalResultCh:      make(chan *proposalResult, 1),

--- a/internal/node/gossip.go
+++ b/internal/node/gossip.go
@@ -64,6 +64,14 @@ func (e *Engine) onGossipAttestation(att *types.SignedAttestation) {
 	logger.Info(logger.Gossip, "attestation verified: validator=%d slot=%d dataRoot=%x", att.ValidatorID, att.Data.Slot, dataRoot)
 	e.Store.AttestationSignatures.InsertWithHandle(dataRoot, att.Data, att.ValidatorID, att.Signature, sigHandle, parseErr)
 	success = true
+
+	// Nudge the dispatch loop to consider aggregating early now that another vote
+	// is in. The signal is best-effort and coalescing; the loop owns the actual
+	// timing and quorum decision.
+	select {
+	case e.EarlyAggregateCh <- struct{}{}:
+	default:
+	}
 }
 
 func (e *Engine) onGossipAggregatedAttestation(agg *types.SignedAggregatedAttestation) {

--- a/internal/node/tick.go
+++ b/internal/node/tick.go
@@ -66,6 +66,12 @@ func (e *Engine) dispatchAggregationCycle(currentSlot uint64, isAggregator bool)
 		metrics.IncAggregatorSkipped(metrics.AggregatorSkipNotAggregator)
 		return
 	}
+	// Dispatch at most once per slot: the early attestation-arrival path and the
+	// interval-2 fallback both route here, and the recursive proof is far too
+	// expensive to run twice for the same slot.
+	if currentSlot == e.aggregatedSlot {
+		return
+	}
 	// The sync-lag duty gate is spec-defined only for block and attestation; gean
 	// also applies it to aggregation. Aggregating on a stale view only produces
 	// best-effort aggregates that get dropped, so gating when lagging is safe and
@@ -90,11 +96,63 @@ func (e *Engine) dispatchAggregationCycle(currentSlot uint64, isAggregator bool)
 	}
 	select {
 	case e.AggregationDispatchCh <- aggregation.Dispatch{Snapshot: snap, Slot: currentSlot}:
+		e.aggregatedSlot = currentSlot
 		metrics.SetProvingQueueDepth("aggregation", len(e.AggregationDispatchCh))
 	default:
 		metrics.IncAggregationDispatchDropped()
 		metrics.IncAggregatorSkipped(metrics.AggregatorSkipSpawnFailed)
 	}
+}
+
+// maybeEarlyAggregate starts the aggregation session in late interval 1, once this
+// slot's votes have reached quorum — a partial-interval lead ahead of the interval-2
+// fallback — so the slow recursive proof gets a head start toward finishing inside
+// its budget instead of racing the interval boundary and truncating. Gating on the
+// slot's own vote count rather than a wall-clock lead keeps the timing tied to the
+// slot model. It only moves *when the proving starts*: the aggregate still covers
+// same-slot attestations and is gossiped within the slot, so it is spec-neutral.
+// dispatchAggregationCycle enforces the once-per-slot guard shared with the
+// interval-2 fallback.
+func (e *Engine) maybeEarlyAggregate(nowMs uint64) {
+	isAgg := e.AggCtl != nil && e.AggCtl.Get()
+	if !isAgg || e.currentInterval(nowMs) != 1 {
+		return
+	}
+	slot := e.currentSlot(nowMs)
+	if slot == e.aggregatedSlot {
+		return
+	}
+	// Validator set is fixed at genesis in lean devnet, so decode the head state
+	// once and cache the count rather than on every arrival.
+	if e.numValidators == 0 {
+		headState := e.Store.GetState(e.Store.Head())
+		if headState == nil {
+			return
+		}
+		e.numValidators = headState.NumValidators()
+		if e.numValidators == 0 {
+			return
+		}
+	}
+	// Only pull the session forward once a finalizing supermajority of *this slot's*
+	// votes is already collected. The count must be scoped to the current slot: a
+	// cross-slot backlog would satisfy the threshold at the very start of interval 1,
+	// before the slot's own attestations have propagated, and bundling then starves
+	// justification. Scoped to the slot, the threshold is reached only in late
+	// interval 1 once votes are in — a modest proving lead that still carries
+	// decisive weight, with the interval-2 dispatch as the fallback below quorum.
+	if e.Store.AttestationSignatures.SignatureCountForSlot(slot) < earlyAggregationQuorum(e.numValidators) {
+		return
+	}
+	e.dispatchAggregationCycle(slot, isAgg)
+}
+
+// earlyAggregationQuorum is the 3SF supermajority ceil(2n/3) — the same threshold
+// the fork choice uses for justification. At that many collected votes an early
+// aggregate already carries finalizing weight, so proving it ahead of interval 2
+// is worthwhile.
+func earlyAggregationQuorum(numValidators uint64) int {
+	return int((2*numValidators + 2) / 3)
 }
 
 func (e *Engine) runAttestationInterval(currentSlot uint64) {

--- a/internal/node/tick_test.go
+++ b/internal/node/tick_test.go
@@ -1,0 +1,28 @@
+package node
+
+import "testing"
+
+// TestEarlyAggregationQuorum pins the early-dispatch threshold to the 3SF
+// supermajority ceil(2n/3). An off-by-one here would either fire the early
+// session before enough votes are in (poor coverage) or never fire it (no head
+// start), so the boundary is verified against hand-computed ceil(2n/3).
+func TestEarlyAggregationQuorum(t *testing.T) {
+	cases := []struct {
+		n    uint64
+		want int
+	}{
+		{0, 0},
+		{1, 1},
+		{2, 2},
+		{3, 2},
+		{4, 3},
+		{5, 4},
+		{10, 7},
+		{100, 67},
+	}
+	for _, c := range cases {
+		if got := earlyAggregationQuorum(c.n); got != c.want {
+			t.Errorf("earlyAggregationQuorum(%d)=%d, want %d", c.n, got, c.want)
+		}
+	}
+}

--- a/internal/store/gossip.go
+++ b/internal/store/gossip.go
@@ -109,6 +109,21 @@ func (m *AttestationSignatureMap) Len() int {
 	return len(m.data)
 }
 
+// SignatureCountForSlot is the number of collected votes whose attestation data
+// is for the given slot. Early aggregation gauges coverage of the slot being
+// proved, not the cross-slot backlog still awaiting pruning.
+func (m *AttestationSignatureMap) SignatureCountForSlot(slot uint64) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n := 0
+	for _, entry := range m.data {
+		if entry.Data != nil && entry.Data.Slot == slot {
+			n += len(entry.Signatures)
+		}
+	}
+	return n
+}
+
 func (m *AttestationSignatureMap) Snapshot() map[[32]byte]*AttestationDataEntry {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/store/gossip_test.go
+++ b/internal/store/gossip_test.go
@@ -32,6 +32,34 @@ func TestAttestationSignatureInsertAndDelete(t *testing.T) {
 	}
 }
 
+func TestAttestationSignatureCountForSlot(t *testing.T) {
+	gsm := store.NewAttestationSignatureMap()
+	var sig [types.SignatureSize]byte
+
+	if gsm.SignatureCountForSlot(1) != 0 {
+		t.Fatalf("empty map count=%d, want 0", gsm.SignatureCountForSlot(1))
+	}
+
+	// Slot 1: three votes on one root, one on another → 4. Slot 2: one vote.
+	// The count must be scoped to the queried slot, never the cross-slot total.
+	dr1, dr2, dr3 := [32]byte{1}, [32]byte{2}, [32]byte{3}
+	gsm.Insert(dr1, &types.AttestationData{Slot: 1}, 0, sig)
+	gsm.Insert(dr1, &types.AttestationData{Slot: 1}, 1, sig)
+	gsm.Insert(dr1, &types.AttestationData{Slot: 1}, 2, sig)
+	gsm.Insert(dr2, &types.AttestationData{Slot: 1}, 3, sig)
+	gsm.Insert(dr3, &types.AttestationData{Slot: 2}, 4, sig)
+
+	if got := gsm.SignatureCountForSlot(1); got != 4 {
+		t.Fatalf("SignatureCountForSlot(1)=%d, want 4", got)
+	}
+	if got := gsm.SignatureCountForSlot(2); got != 1 {
+		t.Fatalf("SignatureCountForSlot(2)=%d, want 1", got)
+	}
+	if got := gsm.SignatureCountForSlot(3); got != 0 {
+		t.Fatalf("SignatureCountForSlot(3)=%d, want 0", got)
+	}
+}
+
 func TestAttestationSignaturePruneBelow(t *testing.T) {
 	gsm := store.NewAttestationSignatureMap()
 	var sig [types.SignatureSize]byte


### PR DESCRIPTION
## What

Start the XMSS aggregation session **early** — in late interval 1, once this slot's
collected votes reach the 3SF supermajority `ceil(2n/3)` — instead of only at the
interval-2 boundary. This gives the slow recursive proof a head start so it finishes
inside its session budget rather than racing the boundary and truncating.

## Why

The aggregator dispatched aggregation only at interval 2. As the chain grows the
~750ms recursive proof overruns its budget and truncates, dropping aggregates and
stalling finality once vote coverage goes incomplete — the ceiling observed in the
long-run devnet (finalization froze at ~slot 22k while heads kept advancing).

## How

- **Trigger:** an attestation-verify goroutine pokes a coalescing (cap-1) wake-up
  channel after inserting a vote; the single dispatch loop owns the timing and quorum
  decision and re-reads live store state. No new shared-state races — `aggregatedSlot`
  and the cached validator count are written only on the dispatch loop.
- **Threshold:** gated on **this slot's** vote count (`SignatureCountForSlot`), not a
  cross-slot total. Scoping to the current slot is load-bearing (see below); it makes
  the gate fire only in late interval 1 once votes have propagated — a modest proving
  lead that still carries decisive weight. `ceil(2n/3)` matches the fork choice's
  `quorumScore`.
- **Fallback preserved:** the unconditional interval-2 dispatch remains for slots that
  never reach early quorum; a per-slot guard prevents proving the same slot twice.
- **Off the tick loop:** proving still runs on the aggregation worker; only *when it
  starts* moves. The validator set is fixed at genesis, so its size is cached after one
  head-state decode rather than re-decoded per arrival.

## Spec compliance

Spec-neutral. No spec-mirroring package touched (`forkchoice` / `statetransition` /
`types` unchanged; `spectests` doesn't import `node`). The aggregate is structurally
identical and remains peer-admissible (current-slot data, within the gossip admission
horizon). It **upholds** the spec's interval-2 rationale ("bundle only after votes
propagate") via the current-slot quorum gate rather than bypassing it. Pin `eca701e`
is current.

## A finality regression caught in testing (and fixed)

An earlier revision gated on a **cross-slot** vote count. On a 3-node devnet that froze
finality at genesis: the stale backlog satisfied the threshold at the *start* of
interval 1, before the slot's own votes arrived, so it bundled a stale set and — via
the once-per-slot guard — suppressed the interval-2 dispatch that carried the fresh
votes. Scoping the count to the current slot fixed it; finality returned on par with
baseline. This branch contains only the corrected design.

## Validation

- `make build`, `go test ./internal/node ./internal/store ./internal/aggregation`,
  `go vet ./...` — green. New unit tests: `earlyAggregationQuorum` boundary vs
  `ceil(2n/3)`, and `SignatureCountForSlot` (slot-scoped, not cross-slot).
- **All-gean devnet:** finalizes on par with baseline (44/38 vs 47/41), early path
  fires correctly at current-slot quorum.
- **Multiclient devnet (gean aggregator + ethlambda + zeam), properly resourced:**
  all three finalize in **lockstep**; ethlambda verifies gean's aggregates with no
  rejection; **zero budget-hit truncations** as the chain advances; no reorgs, no
  disconnects.
- **Still to confirm:** ceiling relief at scale (~22k slots) — under live monitoring.
  Zero budget hits so far is the strongest early indicator.

## Review

- `/lean-review`: clean (applied cosmetic doc/const alignment; the `ceil(2n/3)`
  duplication with `forkchoice.quorumScore` is intentionally report-only — consolidating
  would widen a consensus package's surface).
- `/spec-compliant`: compliant.

## Merge intent

Cut from `perf/block-import-at-scale`; the touched files are byte-identical on
`experimental/leanvm-track-main`, so it cherry-picks cleanly onto both. Intended to
land on both branches.
