### PR TITLE
feat(aggregation): start aggregation early on current-slot vote quorum (V=42)

### DIFF
--- a/internal/node/dispatch.go
+++ b/internal/node/dispatch.go
@@ -17,6 +17,9 @@ func (e *Engine) dispatch(ctx context.Context, ticks <-chan time.Time) {
 		case <-ticks:
 			e.onTick()
 
+		case <-e.EarlyAggregateCh:
+			e.maybeEarlyAggregate(uint64(time.Now().UnixMilli()))
+
 		case block := <-e.BlockCh:
 			e.onBlock(block)
 

--- a/internal/node/engine.go
+++ b/internal/node/engine.go
@@ -49,6 +49,12 @@ type Engine struct {
 	FailedRootCh  chan [32]byte
 	FetchRootCh   chan [32]byte
 
+	// EarlyAggregateCh is a coalescing (capacity-1) wake-up: an attestation-verify
+	// goroutine pokes it after inserting a signature, and the dispatch loop reacts
+	// by considering an early aggregation session. It carries no data — the loop
+	// re-reads live store state — so a full channel is simply dropped.
+	EarlyAggregateCh chan struct{}
+
 	AggregationDispatchCh chan aggregation.Dispatch
 	ProposalCh            chan proposalDuty
 	ProposalResultCh      chan *proposalResult
@@ -68,6 +74,18 @@ type Engine struct {
 	// missing parent cannot flood FetchRootCh with duplicate requests. Accessed only
 	// on the dispatch loop (queue on onBlock, clear on receive/exhaustion), so no lock.
 	fetchInFlight map[[32]byte]bool
+
+	// aggregatedSlot is the last slot for which an aggregation session was
+	// dispatched, so the early (attestation-arrival) path and the interval-2
+	// fallback dispatch at most once per slot. Written and read only on the
+	// single dispatch loop, so no lock.
+	aggregatedSlot uint64
+
+	// numValidators caches the validator-set size, fixed at genesis in lean
+	// devnet, used as the denominator for the early-aggregation quorum. Filled
+	// lazily on the dispatch loop to avoid SSZ-decoding the head state on every
+	// attestation arrival; read/written only there, so no lock.
+	numValidators uint64
 }
 
 func New(
@@ -99,6 +117,7 @@ func New(
 		AggregationCh:         make(chan *types.SignedAggregatedAttestation, 64),
 		FailedRootCh:          make(chan [32]byte, 64),
 		FetchRootCh:           make(chan [32]byte, 256),
+		EarlyAggregateCh:      make(chan struct{}, 1),
 		AggregationDispatchCh: make(chan aggregation.Dispatch, 1),
 		ProposalCh:            make(chan proposalDuty, 1),
 		ProposalResultCh:      make(chan *proposalResult, 1),

--- a/internal/node/gossip.go
+++ b/internal/node/gossip.go
@@ -64,6 +64,14 @@ func (e *Engine) onGossipAttestation(att *types.SignedAttestation) {
 	logger.Info(logger.Gossip, "attestation verified: validator=%d slot=%d dataRoot=%x", att.ValidatorID, att.Data.Slot, dataRoot)
 	e.Store.AttestationSignatures.InsertWithHandle(dataRoot, att.Data, att.ValidatorID, att.Signature, sigHandle, parseErr)
 	success = true
+
+	// Nudge the dispatch loop to consider aggregating early now that another vote
+	// is in. The signal is best-effort and coalescing; the loop owns the actual
+	// timing and quorum decision.
+	select {
+	case e.EarlyAggregateCh <- struct{}{}:
+	default:
+	}
 }
 
 func (e *Engine) onGossipAggregatedAttestation(agg *types.SignedAggregatedAttestation) {

--- a/internal/node/tick.go
+++ b/internal/node/tick.go
@@ -66,6 +66,12 @@ func (e *Engine) dispatchAggregationCycle(currentSlot uint64, isAggregator bool)
 		metrics.IncAggregatorSkipped(metrics.AggregatorSkipNotAggregator)
 		return
 	}
+	// Dispatch at most once per slot: the early attestation-arrival path and the
+	// interval-2 fallback both route here, and the recursive proof is far too
+	// expensive to run twice for the same slot.
+	if currentSlot == e.aggregatedSlot {
+		return
+	}
 	// The sync-lag duty gate is spec-defined only for block and attestation; gean
 	// also applies it to aggregation. Aggregating on a stale view only produces
 	// best-effort aggregates that get dropped, so gating when lagging is safe and
@@ -90,11 +96,63 @@ func (e *Engine) dispatchAggregationCycle(currentSlot uint64, isAggregator bool)
 	}
 	select {
 	case e.AggregationDispatchCh <- aggregation.Dispatch{Snapshot: snap, Slot: currentSlot}:
+		e.aggregatedSlot = currentSlot
 		metrics.SetProvingQueueDepth("aggregation", len(e.AggregationDispatchCh))
 	default:
 		metrics.IncAggregationDispatchDropped()
 		metrics.IncAggregatorSkipped(metrics.AggregatorSkipSpawnFailed)
 	}
+}
+
+// maybeEarlyAggregate starts the aggregation session in late interval 1, once this
+// slot's votes have reached quorum — a partial-interval lead ahead of the interval-2
+// fallback — so the slow recursive proof gets a head start toward finishing inside
+// its budget instead of racing the interval boundary and truncating. Gating on the
+// slot's own vote count rather than a wall-clock lead keeps the timing tied to the
+// slot model. It only moves *when the proving starts*: the aggregate still covers
+// same-slot attestations and is gossiped within the slot, so it is spec-neutral.
+// dispatchAggregationCycle enforces the once-per-slot guard shared with the
+// interval-2 fallback.
+func (e *Engine) maybeEarlyAggregate(nowMs uint64) {
+	isAgg := e.AggCtl != nil && e.AggCtl.Get()
+	if !isAgg || e.currentInterval(nowMs) != 1 {
+		return
+	}
+	slot := e.currentSlot(nowMs)
+	if slot == e.aggregatedSlot {
+		return
+	}
+	// Validator set is fixed at genesis in lean devnet, so decode the head state
+	// once and cache the count rather than on every arrival.
+	if e.numValidators == 0 {
+		headState := e.Store.GetState(e.Store.Head())
+		if headState == nil {
+			return
+		}
+		e.numValidators = headState.NumValidators()
+		if e.numValidators == 0 {
+			return
+		}
+	}
+	// Only pull the session forward once a finalizing supermajority of *this slot's*
+	// votes is already collected. The count must be scoped to the current slot: a
+	// cross-slot backlog would satisfy the threshold at the very start of interval 1,
+	// before the slot's own attestations have propagated, and bundling then starves
+	// justification. Scoped to the slot, the threshold is reached only in late
+	// interval 1 once votes are in — a modest proving lead that still carries
+	// decisive weight, with the interval-2 dispatch as the fallback below quorum.
+	if e.Store.AttestationSignatures.SignatureCountForSlot(slot) < earlyAggregationQuorum(e.numValidators) {
+		return
+	}
+	e.dispatchAggregationCycle(slot, isAgg)
+}
+
+// earlyAggregationQuorum is the 3SF supermajority ceil(2n/3) — the same threshold
+// the fork choice uses for justification. At that many collected votes an early
+// aggregate already carries finalizing weight, so proving it ahead of interval 2
+// is worthwhile.
+func earlyAggregationQuorum(numValidators uint64) int {
+	return int((2*numValidators + 2) / 3)
 }
 
 func (e *Engine) runAttestationInterval(currentSlot uint64) {

--- a/internal/node/tick_test.go
+++ b/internal/node/tick_test.go
@@ -1,0 +1,28 @@
+package node
+
+import "testing"
+
+// TestEarlyAggregationQuorum pins the early-dispatch threshold to the 3SF
+// supermajority ceil(2n/3). An off-by-one here would either fire the early
+// session before enough votes are in (poor coverage) or never fire it (no head
+// start), so the boundary is verified against hand-computed ceil(2n/3).
+func TestEarlyAggregationQuorum(t *testing.T) {
+	cases := []struct {
+		n    uint64
+		want int
+	}{
+		{0, 0},
+		{1, 1},
+		{2, 2},
+		{3, 2},
+		{4, 3},
+		{5, 4},
+		{10, 7},
+		{100, 67},
+	}
+	for _, c := range cases {
+		if got := earlyAggregationQuorum(c.n); got != c.want {
+			t.Errorf("earlyAggregationQuorum(%d)=%d, want %d", c.n, got, c.want)
+		}
+	}
+}

--- a/internal/store/gossip.go
+++ b/internal/store/gossip.go
@@ -109,6 +109,21 @@ func (m *AttestationSignatureMap) Len() int {
 	return len(m.data)
 }
 
+// SignatureCountForSlot is the number of collected votes whose attestation data
+// is for the given slot. Early aggregation gauges coverage of the slot being
+// proved, not the cross-slot backlog still awaiting pruning.
+func (m *AttestationSignatureMap) SignatureCountForSlot(slot uint64) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n := 0
+	for _, entry := range m.data {
+		if entry.Data != nil && entry.Data.Slot == slot {
+			n += len(entry.Signatures)
+		}
+	}
+	return n
+}
+
 func (m *AttestationSignatureMap) Snapshot() map[[32]byte]*AttestationDataEntry {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/store/gossip_test.go
+++ b/internal/store/gossip_test.go
@@ -32,6 +32,34 @@ func TestAttestationSignatureInsertAndDelete(t *testing.T) {
 	}
 }
 
+func TestAttestationSignatureCountForSlot(t *testing.T) {
+	gsm := store.NewAttestationSignatureMap()
+	var sig [types.SignatureSize]byte
+
+	if gsm.SignatureCountForSlot(1) != 0 {
+		t.Fatalf("empty map count=%d, want 0", gsm.SignatureCountForSlot(1))
+	}
+
+	// Slot 1: three votes on one root, one on another → 4. Slot 2: one vote.
+	// The count must be scoped to the queried slot, never the cross-slot total.
+	dr1, dr2, dr3 := [32]byte{1}, [32]byte{2}, [32]byte{3}
+	gsm.Insert(dr1, &types.AttestationData{Slot: 1}, 0, sig)
+	gsm.Insert(dr1, &types.AttestationData{Slot: 1}, 1, sig)
+	gsm.Insert(dr1, &types.AttestationData{Slot: 1}, 2, sig)
+	gsm.Insert(dr2, &types.AttestationData{Slot: 1}, 3, sig)
+	gsm.Insert(dr3, &types.AttestationData{Slot: 2}, 4, sig)
+
+	if got := gsm.SignatureCountForSlot(1); got != 4 {
+		t.Fatalf("SignatureCountForSlot(1)=%d, want 4", got)
+	}
+	if got := gsm.SignatureCountForSlot(2); got != 1 {
+		t.Fatalf("SignatureCountForSlot(2)=%d, want 1", got)
+	}
+	if got := gsm.SignatureCountForSlot(3); got != 0 {
+		t.Fatalf("SignatureCountForSlot(3)=%d, want 0", got)
+	}
+}
+
 func TestAttestationSignaturePruneBelow(t *testing.T) {
 	gsm := store.NewAttestationSignatureMap()
 	var sig [types.SignatureSize]byte


### PR DESCRIPTION
Ports the early-aggregation change onto the V=42 / leanVM-internalized-XMSS track.
Same commit as #396 (against `perf/block-import-at-scale`); the two branches share
identical code in every touched file, so it cherry-picks cleanly with no adaptation.

## What

Start the XMSS aggregation session **early** — in late interval 1, once this slot's
collected votes reach the 3SF supermajority `ceil(2n/3)` — instead of only at the
interval-2 boundary, so the recursive proof finishes inside its session budget rather
than racing the boundary and truncating (the finality-ceiling mechanism seen in the
long-run devnet).

## How

- Coalescing (cap-1) wake-up channel poked by the attestation-verify goroutine; the
  single dispatch loop owns the timing and quorum decision.
- Gated on **this slot's** vote count (`SignatureCountForSlot`), not a cross-slot total
  — this scoping is load-bearing (a cross-slot count froze finality at genesis in
  testing; see #396). `ceil(2n/3)` matches the fork choice's `quorumScore`.
- Interval-2 dispatch preserved as the fallback; per-slot guard prevents double-proving.
- Proving stays off the tick loop; validator count cached after one head-state decode.

Spec-neutral: no spec-mirroring package touched; the aggregate stays structurally
identical and peer-admissible, and the change upholds the spec's interval-2
"bundle-after-propagation" rationale via the current-slot quorum gate.

## Validation on this branch (V=42 FFI)

- `make build` (V=42 leanVM FFI + binaries), `go test ./internal/node ./internal/store
  ./internal/aggregation`, `go vet` — all green.
- Design-level validation (all-gean + real multiclient lockstep, zero budget-hit
  truncations, `/lean-review`, `/spec-compliant`) is documented on #396 and applies
  identically here — the code is the same.

See #396 for the full rationale, the regression-caught-in-testing writeup, and reviews.
