### PR TITLE
feat(aggregation): break the aggregator finality-lag feedback loop (WS-2 + WS-5)

### DIFF
--- a/docs/aggregator-stability.md
+++ b/docs/aggregator-stability.md
@@ -51,10 +51,21 @@ Two parts:
    release the prover) when the estimated session-so-far + next proof would
    exceed the deadline, instead of overrunning. Converts the cliff into graceful
    degradation — gean stays synced.
-2. **Order groups finality-first** so the budget is spent on the aggregates that
-   let finality advance (freshest justifiable target / head-descendant roots),
-   not on stale-view or old backlog roots. This lets finality progress even under
-   backlog, which drains the loop instead of feeding it.
+2. **Order groups finality-first.** Verified against leanSpec eca701e
+   (process_attestations): a source finalizes only when the checkpoint
+   immediately after it is justified — no justifiable slot between source and
+   target — so finalization advances one checkpoint at a time from the frontier.
+   Newest-first spends the budget on the highest target (advancing head /
+   justification) and leaves the frontier-adjacent target unaggregated, so
+   finalization stalls while the head moves — the observed stall shape. Ordering
+   is a local heuristic, not spec-mandated, so reordering is spec-safe.
+
+Status: both parts implemented (hard bound + frontier-first ordering = ascending
+target slot). Group order is the only change; every aggregate produced is
+spec-valid. The head-vs-finality tension and the sparse justifiable-slot
+structure make the exact benefit structure-dependent, so a devnet run (truncating
+aggregator finalizes under frontier-first, stalls under newest-first) is the
+remaining validation before merge.
 
 No consensus-root change; aggregates produced remain spec-valid.
 

--- a/docs/aggregator-stability.md
+++ b/docs/aggregator-stability.md
@@ -1,0 +1,111 @@
+# Aggregator stability at scale — engineering plan
+
+Tracks issue #398. Goal: make gean sustain the aggregator seat indefinitely at
+scale, degrade gracefully if it ever falls behind, and recover on its own —
+matching then bettering ethlambda's stability.
+
+Evidence: a ~31h run (gean aggregator + ethlambda + lantern) had gean's head
+freeze at slot 14,349. Aggregation proof time grew with state (first budget hit
+slot 10,101; 1.6–3.0s per session by 14K; 461 truncations), a single proof
+exceeded the whole 1600ms budget, block import starved on the shared prover, and
+gean fell off the chain irrecoverably — stalling network finality at 14,311.
+ethlambda stayed at ~30–70ms import with state transition 62µs→2.2ms across 14K
+slots (cached hashing), and never bore the every-slot aggregator load.
+
+## Root cause (code-level) — corrected after log re-analysis
+
+The dominant driver is a **finality-lag / aggregation-backlog positive feedback
+loop**, not state-HTR growth. Measured on the stalled run:
+
+- per-proof XMSS cost grew only ~2x over the run (~160ms → ~250–340ms).
+- what blows the 1600ms budget is **group count per session** — the number of
+  distinct attestation data roots the session must prove — which rose from 1–2
+  to 6+ (session totals 350ms → 2055ms). It is noisy: some sessions still fit.
+- finality lag (head − finalized) held ~10 until ~slot 11–12K, then jumped to
+  ~98, and the pending-signature backlog grew in step (2–3 → 19+ roots).
+
+The loop: a session first exceeds budget (modest per-proof creep × a few groups)
+→ `aggregateFromSnapshot` truncates → incomplete vote coverage → finality lags →
+`AttestationSignatureMap` (pruned only below finalized) accumulates roots across
+the now-wider unfinalized window → next session has more groups → exceeds budget
+harder → runaway. Eventually the session runs long enough (2–3s) to starve block
+import on the shared prover, and gean falls off the chain. Stale-view
+attestations from a lagging peer (lantern, behind from ~9,447) plausibly inflate
+the distinct-root count and feed the loop.
+
+State-HTR growth (`State.HashTreeRoot`, fastssz, re-merkleizes the append-only
+`HistoricalBlockHashes` / bitlists every call) is real but **secondary here** —
+it only reduces headroom (the ~2x per-proof creep, block import 34→56ms). It
+becomes dominant only at much larger scale. So caching helps but does **not**
+break the loop.
+
+## Workstreams (corrected priority)
+
+### WS-2 — Break the feedback loop: hard session bound + finality-first ordering (PRIMARY)
+File: `internal/aggregation/aggregate.go`, `worker.go`, `orderedGroups`.
+
+Two parts:
+1. **Hard-bound the session** so it can never run long enough to starve import:
+   `maxUnitsWithin` floors at 2 and models only per-unit cost, so the worker
+   always starts even when it cannot finish. Skip a group (mark truncated,
+   release the prover) when the estimated session-so-far + next proof would
+   exceed the deadline, instead of overrunning. Converts the cliff into graceful
+   degradation — gean stays synced.
+2. **Order groups finality-first** so the budget is spent on the aggregates that
+   let finality advance (freshest justifiable target / head-descendant roots),
+   not on stale-view or old backlog roots. This lets finality progress even under
+   backlog, which drains the loop instead of feeding it.
+
+No consensus-root change; aggregates produced remain spec-valid.
+
+### WS-5 — Bound the backlog independent of finality (PRIMARY)
+File: `internal/store/gossip.go` (`AttestationSignatureMap`), pruning.
+
+Signatures are pruned only below finalized, so a stalled finality lets the
+backlog grow unbounded — the fuel for the loop. Cap the pending window (e.g.
+drop/ignore roots older than a bounded lookback from head, or above a size cap),
+so group count per session is bounded regardless of finality state.
+
+### WS-4 — Guardrails & early warning (safe; pair with the above)
+File: `internal/metrics/`, aggregation worker, `internal/node/tick.go` status.
+
+Emit/observe: session duration vs budget, group count per session, budget-hit
+rate, finality lag (head − finalized), backlog size, behind-slots, prover
+wait/unavailable rate. Warn when finality lag or session duration trends up —
+this run gave ~3K slots (11K→14K) of warning that nothing surfaced.
+
+### WS-1 — Cached / incremental state HTR (headroom; consensus-critical)
+Files: `internal/types/` (State HTR path), new cache type; gated by
+`internal/statetransition/state_scale_bench_test.go` + spec fixtures.
+
+Cache the merkle subtrees of the append-only List/bitlist fields and, on append,
+recompute only the O(log n) path plus the length mixin, instead of re-merkleizing
+the whole list. Reduces per-proof and import cost so the loop starts later and
+gean sustains far higher slots — but it is headroom, not the loop fix. Hard
+requirement: cached root MUST equal the full fastssz root for every state
+(property test over random + fixture states + full spec fixtures). Roll out one
+field at a time (start `HistoricalBlockHashes`) behind an equivalence test.
+
+### WS-3 — Aggregator recovery / catch-up (safety net)
+Files: `internal/syncer/`, `internal/node/`.
+
+Ensure a lagging aggregator can rejoin: batch/parallel XMSS verification during
+backfill so catch-up rate > 1 block / 4s; checkpoint resync when lag exceeds a
+threshold; confirm the duty gate stands the node down while lagging (correct) but
+that recovery is actually reachable (the gap this run exposed).
+
+## Acceptance criteria
+
+- Multi-machine long run, gean as aggregator with real attestation load, sustains
+  past ~30K slots: zero budget-hit truncations, aggregation proof < 1s.
+- State HTR / block-build cost flat (not slot-dependent) on the scale benchmark.
+- An aggregator forced N slots behind recovers to head on its own.
+- If the ceiling is ever hit, finality lags but the node stays synced (graceful),
+  never the cliff.
+
+## Notes
+
+- Early aggregation (#396/#397) delays but does not remove this ceiling, and may
+  worsen the failure mode (front-loads prover contention vs import). Settle with a
+  controlled A/B (early-agg ON vs OFF, identical hardware + client mix + validators).
+- lantern was a straggler this run (fell behind ~9,447); out of scope here.

--- a/internal/aggregation/aggregate.go
+++ b/internal/aggregation/aggregate.go
@@ -15,14 +15,19 @@ import (
 )
 
 type aggregationGroup struct {
-	dataRoot [32]byte
-	slot     uint64
+	dataRoot   [32]byte
+	targetSlot uint64
 }
 
-// orderedGroups lists the snapshot's aggregation work newest-slot-first.
-// Fresh attestations are the only ones that can still influence
-// justification, so they must be proven inside the session budget; older
-// backlog only gets prover time the current slot doesn't need.
+// orderedGroups lists the snapshot's aggregation work frontier-first: by
+// ascending target slot. Finalization advances only when the checkpoint
+// immediately after the current source is justified (leanSpec
+// process_attestations finalizes a source when no justifiable slot sits between
+// it and its justified target). So when a backlog does not all fit the session
+// budget, spending it on the lowest unjustified targets keeps finalization
+// moving; ordering newest-first would advance the head while the finalization
+// frontier starves — the shape of the observed stall (head advancing, finality
+// lagging). Only the group order changes; every aggregate produced is spec-valid.
 func orderedGroups(snap *Snapshot) []aggregationGroup {
 	dataRoots := make(map[[32]byte]bool)
 	for dr := range snap.attSigs {
@@ -38,13 +43,20 @@ func orderedGroups(snap *Snapshot) []aggregationGroup {
 		if attData == nil {
 			continue
 		}
-		groups = append(groups, aggregationGroup{dataRoot: dr, slot: attData.Slot})
+		// The target checkpoint drives finalization; fall back to the attestation
+		// slot only for a malformed entry with no target (validation normally
+		// guarantees one).
+		targetSlot := attData.Slot
+		if attData.Target != nil {
+			targetSlot = attData.Target.Slot
+		}
+		groups = append(groups, aggregationGroup{dataRoot: dr, targetSlot: targetSlot})
 	}
 	sort.Slice(groups, func(i, j int) bool {
-		if groups[i].slot != groups[j].slot {
-			return groups[i].slot > groups[j].slot
+		if groups[i].targetSlot != groups[j].targetSlot {
+			return groups[i].targetSlot < groups[j].targetSlot
 		}
-		return bytes.Compare(groups[i].dataRoot[:], groups[j].dataRoot[:]) > 0
+		return bytes.Compare(groups[i].dataRoot[:], groups[j].dataRoot[:]) < 0
 	})
 	return groups
 }

--- a/internal/aggregation/aggregate.go
+++ b/internal/aggregation/aggregate.go
@@ -56,16 +56,54 @@ func orderedGroups(snap *Snapshot) []aggregationGroup {
 // converges to the real prover cost of whatever hardware runs the node.
 const seedPerUnitSeconds = 0.1
 
-// unitCostEstimator tracks observed per-unit aggregation-proving time so each pass
-// can be sized to the remaining session budget. The single-threaded worker holds
-// one across dispatches. No fixed unit cap would hold across machines and
-// validator-set sizes, so it self-calibrates instead.
+// seedPerGroupSeconds seeds the realized per-group wall-time estimate before any
+// group has been observed. It only governs the first group of the first session;
+// the estimate then tracks real hardware.
+const seedPerGroupSeconds = 0.3
+
+// unitCostEstimator tracks observed aggregation-proving time so each pass can be
+// sized to the remaining session budget. The single-threaded worker holds one
+// across dispatches. No fixed cap would hold across machines and validator-set
+// sizes, so it self-calibrates instead.
 type unitCostEstimator struct {
-	perUnitSeconds float64
+	perUnitSeconds  float64
+	perGroupSeconds float64
 }
 
 func newUnitCostEstimator() *unitCostEstimator {
+	// perGroupSeconds is left zero so the first observed group adopts its real
+	// cost directly (nextGroupDuration falls back to the seed until then). This
+	// makes the bound react within one group when proofs suddenly cost seconds,
+	// rather than easing toward it over many sessions.
 	return &unitCostEstimator{perUnitSeconds: seedPerUnitSeconds}
+}
+
+// nextGroupDuration estimates the wall time the next group will take (prep plus
+// recursive proof). The worker refuses to start a group when less than this
+// remains in the budget, so a session cannot overrun and hold the shared prover
+// past the slot — the overrun that starved block import and dropped the
+// aggregator off the chain at scale.
+func (e *unitCostEstimator) nextGroupDuration() time.Duration {
+	secs := seedPerGroupSeconds
+	if e != nil && e.perGroupSeconds > 0 {
+		secs = e.perGroupSeconds
+	}
+	return time.Duration(secs * float64(time.Second))
+}
+
+// observeGroup folds a completed group's realized wall time into the estimate
+// with an exponential moving average, so the bound tracks the cost growth that
+// comes with a larger state and validator set.
+func (e *unitCostEstimator) observeGroup(duration time.Duration) {
+	if e == nil || duration <= 0 {
+		return
+	}
+	const alpha = 0.3
+	if e.perGroupSeconds <= 0 {
+		e.perGroupSeconds = duration.Seconds()
+		return
+	}
+	e.perGroupSeconds = alpha*duration.Seconds() + (1-alpha)*e.perGroupSeconds
 }
 
 // maxUnitsWithin reports how many units fit in the remaining budget at the current
@@ -109,11 +147,18 @@ func aggregateFromSnapshot(snap *Snapshot, cache *xmss.PubKeyCache, deadline tim
 	truncated := false
 
 	for _, group := range orderedGroups(snap) {
-		if !deadline.IsZero() && time.Now().After(deadline) {
+		// Hard budget bound: never start a proof that cannot finish in the time
+		// left. A session that overruns keeps the shared prover past the slot and
+		// starves block import — the failure that dropped the aggregator off the
+		// chain at scale. Stop cleanly and leave this slot's aggregate partial;
+		// the deferred groups' signatures remain in the store for the next session.
+		if !deadline.IsZero() && time.Until(deadline) < estimator.nextGroupDuration() {
 			truncated = true
 			break
 		}
 		dataRoot := group.dataRoot
+		groupStart := time.Now()
+		provedBefore := len(newAggregates)
 		func() {
 			childProofsBuf := getChildProofsBuf()
 			defer putChildProofsBuf(childProofsBuf)
@@ -262,6 +307,11 @@ func aggregateFromSnapshot(snap *Snapshot, cache *xmss.PubKeyCache, deadline tim
 				}
 			}
 		}()
+		// Only groups that actually proved inform the wall-time estimate; skipped
+		// groups (too few signatures) return fast and would bias it low.
+		if len(newAggregates) > provedBefore {
+			estimator.observeGroup(time.Since(groupStart))
+		}
 	}
 
 	return newAggregates, payloadEntries, keysToDelete, truncated

--- a/internal/aggregation/aggregate_test.go
+++ b/internal/aggregation/aggregate_test.go
@@ -72,23 +72,6 @@ func aggregateTestSnapshot(slots ...uint64) *Snapshot {
 	return snap
 }
 
-func TestOrderedGroupsNewestFirst(t *testing.T) {
-	snap := aggregateTestSnapshot(3, 9, 1, 9)
-
-	groups := orderedGroups(snap)
-	if len(groups) != 4 {
-		t.Fatalf("groups=%d, want 4", len(groups))
-	}
-	for i := 1; i < len(groups); i++ {
-		if groups[i].slot > groups[i-1].slot {
-			t.Fatalf("groups not newest-first at %d: %d after %d", i, groups[i].slot, groups[i-1].slot)
-		}
-	}
-	if groups[0].slot != 9 || groups[len(groups)-1].slot != 1 {
-		t.Fatalf("order=%v", groups)
-	}
-}
-
 func TestAggregateFromSnapshotExpiredDeadlineReportsTruncation(t *testing.T) {
 	snap := aggregateTestSnapshot(5)
 	cache := xmss.NewPubKeyCache()

--- a/internal/aggregation/ordering_test.go
+++ b/internal/aggregation/ordering_test.go
@@ -1,0 +1,94 @@
+package aggregation
+
+import (
+	"testing"
+
+	"github.com/geanlabs/gean/internal/store"
+	"github.com/geanlabs/gean/internal/types"
+)
+
+func rootByte(b byte) [32]byte {
+	var r [32]byte
+	r[0] = b
+	return r
+}
+
+// snapshotWithTargets builds a snapshot whose only content is one attestation
+// group per entry, each voting for the given target slot.
+func snapshotWithTargets(targets map[byte]uint64) *Snapshot {
+	attSigs := make(map[[32]byte]*store.AttestationDataEntry, len(targets))
+	for id, targetSlot := range targets {
+		attSigs[rootByte(id)] = &store.AttestationDataEntry{
+			Data: &types.AttestationData{
+				Slot:   targetSlot,
+				Target: &types.Checkpoint{Slot: targetSlot},
+			},
+		}
+	}
+	return &Snapshot{attSigs: attSigs}
+}
+
+// TestOrderedGroupsFrontierFirst: groups come out by ascending target slot, so
+// the votes nearest the finalized frontier are proven before the head-most ones.
+func TestOrderedGroupsFrontierFirst(t *testing.T) {
+	snap := snapshotWithTargets(map[byte]uint64{1: 104, 2: 100, 3: 102, 4: 101, 5: 103})
+	ordered := orderedGroups(snap)
+
+	want := []uint64{100, 101, 102, 103, 104}
+	if len(ordered) != len(want) {
+		t.Fatalf("group count=%d, want %d", len(ordered), len(want))
+	}
+	for i, g := range ordered {
+		if g.targetSlot != want[i] {
+			t.Fatalf("position %d targetSlot=%d, want %d", i, g.targetSlot, want[i])
+		}
+	}
+}
+
+// TestTruncatingAggregatorKeepsFrontier: with a session budget that covers only
+// the first few groups, frontier-first keeps the finalization-frontier votes and
+// yields the head-most ones. The former newest-first order did the inverse —
+// spending the budget on the head while the frontier starved, which advances the
+// head but stalls finalization (the observed stall shape).
+func TestTruncatingAggregatorKeepsFrontier(t *testing.T) {
+	const frontier = uint64(100)
+	const headMost = uint64(104)
+	snap := snapshotWithTargets(map[byte]uint64{1: frontier, 2: 101, 3: 102, 4: 103, 5: headMost})
+
+	ordered := orderedGroups(snap)
+
+	// A budget that fits only the first two proofs.
+	const budget = 2
+	proven := make(map[uint64]bool)
+	for _, g := range ordered[:budget] {
+		proven[g.targetSlot] = true
+	}
+
+	if !proven[frontier] {
+		t.Fatalf("frontier target %d dropped under truncation", frontier)
+	}
+	if proven[headMost] {
+		t.Fatal("head-most target proven before the frontier under truncation")
+	}
+}
+
+// TestOrderedGroupsDeterministicTiebreak: equal target slots break ties by data
+// root, so the order is stable across snapshots regardless of map iteration.
+func TestOrderedGroupsDeterministicTiebreak(t *testing.T) {
+	snap := snapshotWithTargets(map[byte]uint64{9: 50, 3: 50, 7: 50})
+	first := orderedGroups(snap)
+	for range 5 {
+		again := orderedGroups(snap)
+		for i := range first {
+			if first[i].dataRoot != again[i].dataRoot {
+				t.Fatalf("non-deterministic order at %d", i)
+			}
+		}
+	}
+	// All equal target; must be ascending by data root.
+	for i := 1; i < len(first); i++ {
+		if first[i-1].dataRoot[0] > first[i].dataRoot[0] {
+			t.Fatalf("tiebreak not ascending by data root: %d before %d", first[i-1].dataRoot[0], first[i].dataRoot[0])
+		}
+	}
+}

--- a/internal/aggregation/session_bound_test.go
+++ b/internal/aggregation/session_bound_test.go
@@ -1,0 +1,57 @@
+package aggregation
+
+import (
+	"testing"
+	"time"
+)
+
+// TestEstimatorSeedGroupDuration: before any group is observed the estimator
+// reports the seed, so the very first session still attempts a group.
+func TestEstimatorSeedGroupDuration(t *testing.T) {
+	e := newUnitCostEstimator()
+	want := time.Duration(seedPerGroupSeconds * float64(time.Second))
+	if got := e.nextGroupDuration(); got != want {
+		t.Fatalf("seed nextGroupDuration=%v, want %v", got, want)
+	}
+	// Nil receiver must not panic and must fall back to the seed.
+	var nilEst *unitCostEstimator
+	if got := nilEst.nextGroupDuration(); got != want {
+		t.Fatalf("nil nextGroupDuration=%v, want %v", got, want)
+	}
+}
+
+// TestEstimatorTracksGroupCost: the estimate follows observed per-group wall
+// time via EMA, so the bound rises as proofs get more expensive with scale.
+func TestEstimatorTracksGroupCost(t *testing.T) {
+	e := newUnitCostEstimator()
+	// First observation seeds the running value directly.
+	e.observeGroup(2 * time.Second)
+	if got := e.nextGroupDuration(); got < 1900*time.Millisecond || got > 2100*time.Millisecond {
+		t.Fatalf("after first observe nextGroupDuration=%v, want ~2s", got)
+	}
+	// Repeated 2s observations converge toward 2s.
+	for range 10 {
+		e.observeGroup(2 * time.Second)
+	}
+	if got := e.nextGroupDuration(); got < 1900*time.Millisecond || got > 2100*time.Millisecond {
+		t.Fatalf("converged nextGroupDuration=%v, want ~2s", got)
+	}
+}
+
+// TestSessionBoundRefusesUnfinishableProof: once the estimate exceeds the
+// remaining budget, the worker's gate predicate refuses to start another proof
+// — the check that stops a session overrunning and starving block import.
+func TestSessionBoundRefusesUnfinishableProof(t *testing.T) {
+	e := newUnitCostEstimator()
+	for range 5 {
+		e.observeGroup(2 * time.Second)
+	}
+	// 500ms left, but a group now costs ~2s: must refuse.
+	if 500*time.Millisecond >= e.nextGroupDuration() {
+		t.Fatal("expected 500ms remaining to be below the per-group estimate")
+	}
+	// 3s left: may proceed.
+	if 3*time.Second < e.nextGroupDuration() {
+		t.Fatal("expected 3s remaining to be above the per-group estimate")
+	}
+}

--- a/internal/node/tick.go
+++ b/internal/node/tick.go
@@ -58,6 +58,10 @@ func (e *Engine) onTick() {
 	if currentInterval == 3 {
 		e.updateSafeTarget()
 		store.PeriodicPrune(e.Store, e.FC, currentSlot, e.Store.LatestFinalized().Slot)
+		// Cap the pending-signature backlog to a bounded window behind head.
+		// Finalization pruning alone lets it grow without bound when finality
+		// stalls, inflating each aggregation session and feeding the stall.
+		e.Store.AttestationSignatures.PruneBacklog(e.Store.HeadSlot())
 	}
 }
 

--- a/internal/store/gossip.go
+++ b/internal/store/gossip.go
@@ -109,6 +109,26 @@ func (m *AttestationSignatureMap) Len() int {
 	return len(m.data)
 }
 
+// MaxAttestationBacklogSlots bounds how many slots of pending attestation
+// signatures are kept behind the head. Signatures are otherwise pruned only
+// below finalized, so a stalled finalization lets the backlog grow without
+// bound — inflating each aggregation session and feeding the stall. Beyond this
+// window (relative to head) the votes are too old to justify a still-unfinalized
+// checkpoint, so dropping them bounds memory and session size while leaving
+// normal operation untouched: finality lag is single- to low-double-digit slots,
+// far inside the window.
+const MaxAttestationBacklogSlots = 512
+
+// PruneBacklog drops pending signatures for slots more than
+// MaxAttestationBacklogSlots behind headSlot, bounding the backlog when
+// finalization has stalled. Returns the number of data roots removed.
+func (m *AttestationSignatureMap) PruneBacklog(headSlot uint64) int {
+	if headSlot <= MaxAttestationBacklogSlots {
+		return 0
+	}
+	return m.PruneBelow(headSlot - MaxAttestationBacklogSlots)
+}
+
 // SignatureCountForSlot is the number of collected votes whose attestation data
 // is for the given slot. Early aggregation gauges coverage of the slot being
 // proved, not the cross-slot backlog still awaiting pruning.

--- a/internal/store/gossip_test.go
+++ b/internal/store/gossip_test.go
@@ -60,6 +60,46 @@ func TestAttestationSignatureCountForSlot(t *testing.T) {
 	}
 }
 
+func TestAttestationSignaturePruneBacklog(t *testing.T) {
+	gsm := store.NewAttestationSignatureMap()
+	var sig [types.SignatureSize]byte
+
+	// Below the window relative to head, nothing is pruned (normal operation:
+	// finality lag is far inside the window).
+	head := uint64(100)
+	gsm.Insert([32]byte{1}, &types.AttestationData{Slot: head - 5}, 0, sig)
+	gsm.Insert([32]byte{2}, &types.AttestationData{Slot: head}, 1, sig)
+	if pruned := gsm.PruneBacklog(head); pruned != 0 {
+		t.Fatalf("in-window prune=%d, want 0", pruned)
+	}
+	if gsm.Len() != 2 {
+		t.Fatalf("in-window Len=%d, want 2", gsm.Len())
+	}
+
+	// With head far ahead, roots older than head-window are dropped, recent kept.
+	head = store.MaxAttestationBacklogSlots + 1000
+	floor := head - store.MaxAttestationBacklogSlots
+	gsm.Insert([32]byte{3}, &types.AttestationData{Slot: floor - 1}, 2, sig) // stale, drop
+	gsm.Insert([32]byte{4}, &types.AttestationData{Slot: floor + 1}, 3, sig) // recent, keep
+	pruned := gsm.PruneBacklog(head)
+	// The two slot-100-era roots and the stale root are all below the new floor.
+	if pruned != 3 {
+		t.Fatalf("backlog prune=%d, want 3", pruned)
+	}
+	snap := gsm.Snapshot()
+	if _, ok := snap[[32]byte{4}]; !ok {
+		t.Fatal("recent root was pruned")
+	}
+	if gsm.Len() != 1 {
+		t.Fatalf("post-prune Len=%d, want 1", gsm.Len())
+	}
+
+	// Head below the window never underflows / prunes.
+	if pruned := gsm.PruneBacklog(store.MaxAttestationBacklogSlots - 1); pruned != 0 {
+		t.Fatalf("head-below-window prune=%d, want 0", pruned)
+	}
+}
+
 func TestAttestationSignaturePruneBelow(t *testing.T) {
 	gsm := store.NewAttestationSignatureMap()
 	var sig [types.SignatureSize]byte


### PR DESCRIPTION
Draft — reviewable now; end-to-end devnet validation pending (see below).

Addresses the ~14K-slot aggregator stall (#398). A ~31h multi-client run had gean's
head freeze at slot 14,349 and never recover, dragging network finality; the network
(ethlambda) stayed healthy at ~28K. Root cause after log re-analysis: a **finality-lag
/ aggregation-backlog feedback loop**, not primarily state-HTR growth.

## The loop (why it ran away)
A session first exceeds the 1600ms budget → truncates → incomplete vote coverage →
finality lags → signatures (pruned only below finalized) pile up across the widening
unfinalized window → next session has more groups → exceeds budget harder → the session
eventually runs long enough to starve block import on the shared prover → gean falls off
the chain. Per-proof cost grew only ~2x; group count per session (1–2 → 6+) is what blew
the budget.

## What this branch does (loop-breakers)
- **Hard session bound** (`aggregate.go`): track realized per-group wall time and refuse
  to start a proof that cannot finish in the remaining budget, instead of overrunning.
  Session stays within budget → import isn't starved → node stays synced (graceful
  degradation, not the cliff). The estimate adopts the first observed cost directly, so
  it reacts within one group when proofs suddenly cost seconds.
- **Frontier-first ordering** (`orderedGroups`): order groups by ascending target slot so
  a truncating session covers the finalization frontier first. Verified against leanSpec
  eca701e — `process_attestations` finalizes a source only when the checkpoint
  immediately after it is justified, so finalization advances one checkpoint at a time
  from the frontier; newest-first advanced the head while the frontier starved (the
  observed stall shape). Ordering is a local heuristic, not spec-mandated, so every
  aggregate stays spec-valid.
- **Bounded backlog** (`AttestationSignatureMap.PruneBacklog`, tick interval-3): prune
  signatures more than 512 slots behind head each slot, so a stalled finalization cannot
  grow the pending map without bound. The window is far beyond normal finality lag, so it
  is inert in healthy operation.

## Spec compliance
No spec-mirroring package touched (`statetransition` / `forkchoice` / `types` unchanged).
Aggregation ordering and session bounding are local heuristics; every aggregate produced
is spec-valid. Pin eca701e is current.

## Tests
- Session bound: estimator seed/convergence + the gate predicate.
- Ordering: frontier-first, a truncating aggregator keeping the frontier and yielding the
  head-most group, deterministic tiebreak.
- Backlog: `PruneBacklog` window semantics.
- `make ffi` + `go build`, `go vet ./...`, node/store/aggregation suites green.

## Not done here (follow-ups on #398)
- **WS-1 cached / incremental state HTR** — headroom for very large scale (consensus-
  critical, equivalence-gated).
- **WS-3 aggregator recovery** — so a node that falls far behind can rejoin.
- **Validation**: end-to-end devnet run (finalizes under frontier-first + stays synced
  under load) — the structure-dependent piece the spec flagged. Draft until then.

Plan: `docs/aggregator-stability.md`.
