### PR TITLE
revert(aggregation): remove WS-5 head-relative backlog cap (froze finality + UAF crash)

### DIFF
--- a/docs/aggregator-stability.md
+++ b/docs/aggregator-stability.md
@@ -69,13 +69,31 @@ remaining validation before merge.
 
 No consensus-root change; aggregates produced remain spec-valid.
 
-### WS-5 — Bound the backlog independent of finality (PRIMARY)
-File: `internal/store/gossip.go` (`AttestationSignatureMap`), pruning.
+### WS-5 — Bound the backlog behind head — TRIED AND REVERTED
+A head-relative signature prune (drop roots more than 512 slots behind head) was
+implemented and merged, then reverted after a server run exposed two failures:
 
-Signatures are pruned only below finalized, so a stalled finality lets the
-backlog grow unbounded — the fuel for the loop. Cap the pending window (e.g.
-drop/ignore roots older than a bounded lookback from head, or above a size cap),
-so group count per session is bounded regardless of finality state.
+1. It deleted the finalization-frontier votes. Once finality lag exceeded the
+   window, the votes needed to finalize the next checkpoint sat below head minus
+   the window and were pruned, so finalization froze (12,880 while head ran to
+   14,355). Any head-relative cap has this flaw: everything between finalized and
+   head is potentially finality-critical, so it cannot be safely dropped.
+2. It caused a use-after-free crash. The prune runs on the tick loop and frees
+   XMSS signature handles; the aggregation worker runs async on a snapshot that
+   shares those handle pointers. Pruning the frontier — exactly the votes the
+   frontier-first worker aggregates — freed handles the worker was still using,
+   segfaulting inside the aggregate FFI at ~16h.
+
+Lesson: the backlog is drained by advancing finality (frontier-first + WS-1
+throughput), not by pruning above finalized. A genuine long-stall memory bound
+belongs with WS-3 recovery (checkpoint resync), and the snapshot must not share
+freeable handles with the live map (see WS-6).
+
+### WS-6 — Snapshot handle lifetime (new; correctness)
+The aggregation snapshot copies signature entries but shares the raw XMSS handle
+pointers with the live map, and any prune frees them. Frontier-first widened the
+overlap enough to crash. Make snapshots own their handles (re-parse from bytes in
+the worker, or ref-count) so no prune can free a handle a live session holds.
 
 ### WS-4 — Guardrails & early warning (safe; pair with the above)
 File: `internal/metrics/`, aggregation worker, `internal/node/tick.go` status.

--- a/internal/node/tick.go
+++ b/internal/node/tick.go
@@ -58,10 +58,6 @@ func (e *Engine) onTick() {
 	if currentInterval == 3 {
 		e.updateSafeTarget()
 		store.PeriodicPrune(e.Store, e.FC, currentSlot, e.Store.LatestFinalized().Slot)
-		// Cap the pending-signature backlog to a bounded window behind head.
-		// Finalization pruning alone lets it grow without bound when finality
-		// stalls, inflating each aggregation session and feeding the stall.
-		e.Store.AttestationSignatures.PruneBacklog(e.Store.HeadSlot())
 	}
 }
 

--- a/internal/store/gossip.go
+++ b/internal/store/gossip.go
@@ -109,26 +109,6 @@ func (m *AttestationSignatureMap) Len() int {
 	return len(m.data)
 }
 
-// MaxAttestationBacklogSlots bounds how many slots of pending attestation
-// signatures are kept behind the head. Signatures are otherwise pruned only
-// below finalized, so a stalled finalization lets the backlog grow without
-// bound — inflating each aggregation session and feeding the stall. Beyond this
-// window (relative to head) the votes are too old to justify a still-unfinalized
-// checkpoint, so dropping them bounds memory and session size while leaving
-// normal operation untouched: finality lag is single- to low-double-digit slots,
-// far inside the window.
-const MaxAttestationBacklogSlots = 512
-
-// PruneBacklog drops pending signatures for slots more than
-// MaxAttestationBacklogSlots behind headSlot, bounding the backlog when
-// finalization has stalled. Returns the number of data roots removed.
-func (m *AttestationSignatureMap) PruneBacklog(headSlot uint64) int {
-	if headSlot <= MaxAttestationBacklogSlots {
-		return 0
-	}
-	return m.PruneBelow(headSlot - MaxAttestationBacklogSlots)
-}
-
 // SignatureCountForSlot is the number of collected votes whose attestation data
 // is for the given slot. Early aggregation gauges coverage of the slot being
 // proved, not the cross-slot backlog still awaiting pruning.

--- a/internal/store/gossip_test.go
+++ b/internal/store/gossip_test.go
@@ -60,46 +60,6 @@ func TestAttestationSignatureCountForSlot(t *testing.T) {
 	}
 }
 
-func TestAttestationSignaturePruneBacklog(t *testing.T) {
-	gsm := store.NewAttestationSignatureMap()
-	var sig [types.SignatureSize]byte
-
-	// Below the window relative to head, nothing is pruned (normal operation:
-	// finality lag is far inside the window).
-	head := uint64(100)
-	gsm.Insert([32]byte{1}, &types.AttestationData{Slot: head - 5}, 0, sig)
-	gsm.Insert([32]byte{2}, &types.AttestationData{Slot: head}, 1, sig)
-	if pruned := gsm.PruneBacklog(head); pruned != 0 {
-		t.Fatalf("in-window prune=%d, want 0", pruned)
-	}
-	if gsm.Len() != 2 {
-		t.Fatalf("in-window Len=%d, want 2", gsm.Len())
-	}
-
-	// With head far ahead, roots older than head-window are dropped, recent kept.
-	head = store.MaxAttestationBacklogSlots + 1000
-	floor := head - store.MaxAttestationBacklogSlots
-	gsm.Insert([32]byte{3}, &types.AttestationData{Slot: floor - 1}, 2, sig) // stale, drop
-	gsm.Insert([32]byte{4}, &types.AttestationData{Slot: floor + 1}, 3, sig) // recent, keep
-	pruned := gsm.PruneBacklog(head)
-	// The two slot-100-era roots and the stale root are all below the new floor.
-	if pruned != 3 {
-		t.Fatalf("backlog prune=%d, want 3", pruned)
-	}
-	snap := gsm.Snapshot()
-	if _, ok := snap[[32]byte{4}]; !ok {
-		t.Fatal("recent root was pruned")
-	}
-	if gsm.Len() != 1 {
-		t.Fatalf("post-prune Len=%d, want 1", gsm.Len())
-	}
-
-	// Head below the window never underflows / prunes.
-	if pruned := gsm.PruneBacklog(store.MaxAttestationBacklogSlots - 1); pruned != 0 {
-		t.Fatalf("head-below-window prune=%d, want 0", pruned)
-	}
-}
-
 func TestAttestationSignaturePruneBelow(t *testing.T) {
 	gsm := store.NewAttestationSignatureMap()
 	var sig [types.SignatureSize]byte


### PR DESCRIPTION
Draft — reverts the WS-5 backlog cap after a server run showed it was net-negative.

## Why
The ~16h server run (gean aggregator, on the merged stability build) exposed two
failures caused by WS-5's head-relative signature prune:

1. **Froze finalization.** Once finality lag exceeded the 512-slot window, the
   frontier votes needed to finalize the next checkpoint fell below head−window and
   were pruned. Finalized stuck at 12,880 while head ran to 14,355 — *lower* than
   the pre-stability run's 14,311. Any head-relative cap has this flaw: everything
   between finalized and head is potentially finality-critical.
2. **Use-after-free crash.** The prune runs on the tick loop and frees XMSS handles;
   the aggregation worker runs async on a snapshot that shares those handle pointers.
   Pruning the frontier freed handles the frontier-first worker was still using →
   SIGSEGV in `xmss_aggregate_type_1` at ~16h / slot ~13.8K.

## What stays
WS-2 (hard session bound) and frontier-first ordering — they held gean **synced
through the whole run** (max Behind 3, no cliff), a real improvement over the
pre-stability cliff (Behind 12,315). This revert removes only the harmful cap.

## Follow-ups (docs/aggregator-stability.md, #398)
- **WS-6** — the aggregation snapshot must own its XMSS handles (re-parse/ref-count)
  so no prune can free a handle a live session holds. Latent fragility WS-5 exposed.
- **WS-1** — cached/incremental state HTR: the real throughput fix so finality keeps
  up past ~11K instead of lagging.
- **WS-3** — aggregator recovery for genuine long stalls.

Build + node/store/aggregation tests + vet green.
