### PR TITLE
fix(store): snapshot owns its XMSS handles — fix aggregate FFI UAF (V=42)

### DIFF
--- a/internal/aggregation/aggregate.go
+++ b/internal/aggregation/aggregate.go
@@ -222,15 +222,15 @@ func aggregateFromSnapshot(snap *Snapshot, cache *xmss.PubKeyCache, deadline tim
 						continue
 					}
 
-					sigHandle := sigEntry.SigHandle
-					if sigHandle == nil {
-						parsed, err := xmss.ParseSignature(sigEntry.Signature[:])
-						if err != nil {
-							continue
-						}
-						defer xmss.FreeSignature(parsed)
-						sigHandle = parsed
+					// Parse a handle the worker owns and frees at the end of this
+					// group. The snapshot carries only bytes, never a handle shared
+					// with the live map, so a concurrent prune cannot free it underneath
+					// the prover.
+					sigHandle, err := xmss.ParseSignature(sigEntry.Signature[:])
+					if err != nil {
+						continue
 					}
+					defer xmss.FreeSignature(sigHandle)
 
 					pk, err := cache.Get(targetState.Validators[sigEntry.ValidatorID].AttestationPubkey)
 					if err != nil {

--- a/internal/node/duties.go
+++ b/internal/node/duties.go
@@ -8,7 +8,6 @@ import (
 	"github.com/geanlabs/gean/internal/logger"
 	"github.com/geanlabs/gean/internal/metrics"
 	"github.com/geanlabs/gean/internal/types"
-	"github.com/geanlabs/gean/xmss"
 )
 
 func (e *Engine) produceAttestations(slot uint64) {
@@ -51,8 +50,7 @@ func (e *Engine) produceAttestations(slot uint64) {
 				logger.Error(logger.Validator, "attestation root failed validator=%d: %v", vid, err)
 				continue
 			}
-			sigHandle, parseErr := xmss.ParseSignature(sig[:])
-			e.Store.AttestationSignatures.InsertWithHandle(dataRoot, attData, vid, sig, sigHandle, parseErr)
+			e.Store.AttestationSignatures.Insert(dataRoot, attData, vid, sig)
 		}
 
 		if e.P2P != nil {

--- a/internal/node/gossip.go
+++ b/internal/node/gossip.go
@@ -8,7 +8,6 @@ import (
 	"github.com/geanlabs/gean/internal/metrics"
 	"github.com/geanlabs/gean/internal/store"
 	"github.com/geanlabs/gean/internal/types"
-	"github.com/geanlabs/gean/xmss"
 )
 
 func (e *Engine) onGossipAttestation(att *types.SignedAttestation) {
@@ -59,10 +58,8 @@ func (e *Engine) onGossipAttestation(att *types.SignedAttestation) {
 	metrics.IncPqSigAttestationSigsValid()
 	metrics.IncAttestationsValid(1)
 
-	sigHandle, parseErr := xmss.ParseSignature(att.Signature[:])
-
 	logger.Info(logger.Gossip, "attestation verified: validator=%d slot=%d dataRoot=%x", att.ValidatorID, att.Data.Slot, dataRoot)
-	e.Store.AttestationSignatures.InsertWithHandle(dataRoot, att.Data, att.ValidatorID, att.Signature, sigHandle, parseErr)
+	e.Store.AttestationSignatures.Insert(dataRoot, att.Data, att.ValidatorID, att.Signature)
 	success = true
 
 	// Nudge the dispatch loop to consider aggregating early now that another vote

--- a/internal/store/gossip.go
+++ b/internal/store/gossip.go
@@ -2,16 +2,18 @@ package store
 
 import (
 	"sync"
-	"unsafe"
 
 	"github.com/geanlabs/gean/internal/types"
-	"github.com/geanlabs/gean/xmss"
 )
 
+// AttestationSignatureEntry holds only the serialized signature, never a parsed
+// XMSS handle. The aggregation worker runs asynchronously on a snapshot of this
+// map, so a handle cached here could be freed by a prune while the worker still
+// held the snapshot's copy of the pointer — a use-after-free that segfaulted the
+// prover. The worker parses its own handle from these bytes and owns its lifetime.
 type AttestationSignatureEntry struct {
 	ValidatorID uint64
 	Signature   [types.SignatureSize]byte
-	SigHandle   unsafe.Pointer
 }
 
 type AttestationDataEntry struct {
@@ -29,10 +31,6 @@ func NewAttestationSignatureMap() AttestationSignatureMap {
 }
 
 func (m *AttestationSignatureMap) Insert(dataRoot [32]byte, data *types.AttestationData, validatorID uint64, sig [types.SignatureSize]byte) {
-	m.InsertWithHandle(dataRoot, data, validatorID, sig, nil, nil)
-}
-
-func (m *AttestationSignatureMap) InsertWithHandle(dataRoot [32]byte, data *types.AttestationData, validatorID uint64, sig [types.SignatureSize]byte, handle unsafe.Pointer, parseErr error) {
 	if data == nil {
 		return
 	}
@@ -47,14 +45,9 @@ func (m *AttestationSignatureMap) InsertWithHandle(dataRoot [32]byte, data *type
 		entry = &AttestationDataEntry{Data: copyAttestationData(data)}
 		m.data[dataRoot] = entry
 	}
-	var h unsafe.Pointer
-	if parseErr == nil {
-		h = handle
-	}
 	entry.Signatures = append(entry.Signatures, AttestationSignatureEntry{
 		ValidatorID: validatorID,
 		Signature:   sig,
-		SigHandle:   h,
 	})
 }
 
@@ -68,11 +61,7 @@ func (m *AttestationSignatureMap) Delete(keys []AttestationDeleteKey) {
 		}
 		filtered := entry.Signatures[:0]
 		for _, sig := range entry.Signatures {
-			if sig.ValidatorID == key.ValidatorID {
-				if sig.SigHandle != nil {
-					xmss.FreeSignature(sig.SigHandle)
-				}
-			} else {
+			if sig.ValidatorID != key.ValidatorID {
 				filtered = append(filtered, sig)
 			}
 		}
@@ -89,13 +78,6 @@ func (m *AttestationSignatureMap) PruneBelow(finalizedSlot uint64) int {
 	pruned := 0
 	for root, entry := range m.data {
 		if entry == nil || entry.Data == nil || entry.Data.Slot <= finalizedSlot {
-			if entry != nil {
-				for _, sig := range entry.Signatures {
-					if sig.SigHandle != nil {
-						xmss.FreeSignature(sig.SigHandle)
-					}
-				}
-			}
 			delete(m.data, root)
 			pruned++
 		}


### PR DESCRIPTION
Draft — V=42 port of the crash-safety fix (WS-6, same commit as #405).

The aggregation worker runs async on a snapshot that copied each entry's cached
XMSS handle pointer; a prune freed those handles, so the worker could dereference
freed memory in the prover — the use-after-free that segfaulted the ~16h run in
xmss_aggregate_type_1. Fix: the map holds only signature bytes; the worker parses
a handle it owns and frees per group, so no prune can free one underneath the
prover. Also drops a receipt-time ParseSignature and a per-prune FreeSignature.

Build-verified on the V=42 leanVM FFI: make build, store/node/aggregation tests +
vet green. Rationale on #405; pairs with #402 (WS-5 revert).
