### PR TITLE
ci: fix invalid YAML in pr-issue-check workflow

### DIFF
--- a/.github/workflows/pr-issue-check.yml
+++ b/.github/workflows/pr-issue-check.yml
@@ -19,12 +19,12 @@ jobs:
   check-issue:
     if: false
     # original condition: >-
-      github.event_name == 'pull_request' ||
-      (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        contains(github.event.comment.body, '/recheck-issue-link')
-      )
+    #   github.event_name == 'pull_request' ||
+    #   (
+    #     github.event_name == 'issue_comment' &&
+    #     github.event.issue.pull_request &&
+    #     contains(github.event.comment.body, '/recheck-issue-link')
+    #   )
     runs-on: ubuntu-latest
     steps:
       - name: Check for linked issue


### PR DESCRIPTION
The `check-issue` job was disabled with `if: false` but only the first line of the original condition was commented out; the remaining lines were dangling YAML under the job mapping, so the workflow failed to parse ("Invalid workflow file … line 19"). This comments out the full preserved condition block — job stays disabled, YAML is valid (verified with `yq`).

Note: the identical broken file exists on `experimental/leanvm-track-main` and `perf/block-import-at-scale`, so open PRs against those bases will keep showing the error until the same fix is applied there (their PR runs use the base branch's workflow).