### PR TITLE
ci: fix invalid YAML in pr-issue-check workflow

### DIFF
--- a/.github/workflows/pr-issue-check.yml
+++ b/.github/workflows/pr-issue-check.yml
@@ -19,12 +19,12 @@ jobs:
   check-issue:
     if: false
     # original condition: >-
-      github.event_name == 'pull_request' ||
-      (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        contains(github.event.comment.body, '/recheck-issue-link')
-      )
+    #   github.event_name == 'pull_request' ||
+    #   (
+    #     github.event_name == 'issue_comment' &&
+    #     github.event.issue.pull_request &&
+    #     contains(github.event.comment.body, '/recheck-issue-link')
+    #   )
     runs-on: ubuntu-latest
     steps:
       - name: Check for linked issue


### PR DESCRIPTION
Same one-line-block fix as #408 (to main), applied to `experimental/leanvm-track-main` so open PRs against this base stop showing "Invalid workflow file … line 19". The disabled `check-issue` job's commented-out original condition had dangling YAML lines; this comments the whole block. Job stays disabled; verified valid with yq.